### PR TITLE
feat(versioning): capture upstream source versions to data/source_versions.json (Phase A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ data/*.npz
 data/*.json
 # Keep Zenodo DOI state file (small, persistent across restarts)
 !data/zenodo_meta.json
+# Keep upstream source-versions manifest (small, ships with the snapshot)
+!data/source_versions.json
 
 # GO source data (large, re-downloadable)
 data/go.obo

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint run docker-build docker-run clean
+.PHONY: help install test lint run docker-build docker-run clean capture-versions
 
 help:		## Show this help
 	@echo "Available targets:"
@@ -39,6 +39,9 @@ migrate:	## Run database migration
 
 go-hierarchy:	## Build GO hierarchy data (IC scores, ancestors, depths)
 	python scripts/precompute_go_hierarchy.py
+
+capture-versions:	## Refresh data/source_versions.json from WP / GO / Reactome / AOP-Wiki
+	python scripts/capture_source_versions.py
 
 clean:		## Clean up generated files
 	rm -rf __pycache__

--- a/data/source_versions.json
+++ b/data/source_versions.json
@@ -1,0 +1,36 @@
+{
+  "captured_at": "2026-05-14T21:46:25Z",
+  "sources": {
+    "wikipathways": {
+      "status": "ok",
+      "release_date": "2026-05-10",
+      "dataset_iri": "http://data.wikipathways.org/20260510/smiles",
+      "method": "sparql:void-dataset-iri",
+      "endpoint": "https://sparql.wikipathways.org/sparql",
+      "captured_at": "2026-05-14T21:46:24Z"
+    },
+    "gene_ontology": {
+      "status": "ok",
+      "release_label": "releases/2026-01-23",
+      "release_date": "2026-01-23",
+      "method": "obo-header",
+      "source_file": "data/go-basic.obo",
+      "captured_at": "2026-05-14T21:46:24Z"
+    },
+    "reactome": {
+      "status": "ok",
+      "release_version": "96",
+      "method": "rest-api",
+      "endpoint": "https://reactome.org/ContentService/data/database/info",
+      "captured_at": "2026-05-14T21:46:24Z",
+      "release_date": "2026-03-25"
+    },
+    "aopwiki": {
+      "status": "ok",
+      "snapshot_date": "2026-05-06",
+      "method": "sparql:max(dcterms:modified)",
+      "endpoint": "https://aopwiki.rdf.bigcat-bioinformatics.org/sparql",
+      "captured_at": "2026-05-14T21:46:24Z"
+    }
+  }
+}

--- a/scripts/capture_source_versions.py
+++ b/scripts/capture_source_versions.py
@@ -1,0 +1,438 @@
+"""
+Capture upstream source versions for the curated mapping dataset.
+
+Writes data/source_versions.json — a manifest of the upstream release each
+of the four resources (WikiPathways, Gene Ontology, Reactome, AOP-Wiki)
+was at when this script was last run. The running app reads this manifest
+at boot and stamps every approved mapping with the current snapshot's
+version, so downstream consumers can pin their analyses against a
+specific upstream release.
+
+Usage:
+    python scripts/capture_source_versions.py              # all four
+    python scripts/capture_source_versions.py --source wp  # one source
+    python scripts/capture_source_versions.py --dry-run    # print, don't write
+
+Exit codes:
+    0  all sources captured (some may be 'unknown' if upstream was unreachable)
+    1  manifest write failed
+    2  invoked with --strict and at least one source returned 'unknown'
+
+DMP §7 anchor: source-data versioning (Phase A — capture only).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT_PATH = _PROJECT_ROOT / "data" / "source_versions.json"
+DEFAULT_OBO_PATH = _PROJECT_ROOT / "data" / "go-basic.obo"
+
+WIKIPATHWAYS_SPARQL = "https://sparql.wikipathways.org/sparql"
+AOPWIKI_SPARQL = "https://aopwiki.rdf.bigcat-bioinformatics.org/sparql"
+REACTOME_INFO_API = "https://reactome.org/ContentService/data/database/info"
+
+HTTP_TIMEOUT = 30  # seconds — upstream SPARQL endpoints are occasionally slow
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)s  %(message)s")
+log = logging.getLogger("capture_source_versions")
+
+
+# ---------- helpers ----------
+
+def _path_for_manifest(p: Path) -> str:
+    """Render `p` as a repo-relative POSIX path when possible, absolute otherwise."""
+    try:
+        return p.resolve().relative_to(_PROJECT_ROOT).as_posix()
+    except ValueError:
+        return str(p)
+
+
+def _utcnow_iso() -> str:
+    """RFC 3339 / ISO 8601 UTC timestamp with Z suffix."""
+    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _unknown(reason: str, **extra: Any) -> dict:
+    """Build a uniform 'unknown' record so every source slot is structurally valid."""
+    rec = {"status": "unknown", "reason": reason, "captured_at": _utcnow_iso()}
+    rec.update(extra)
+    return rec
+
+
+def _sparql_max_modified(endpoint: str, type_iri: str, type_label: str) -> str | None:
+    """
+    Query an endpoint for MAX(dcterms:modified) over resources of `type_iri`.
+
+    Returns the date portion (YYYY-MM-DD) of the most recent modification, or
+    None if the endpoint cannot be reached or returns no value.
+    """
+    query = f"""
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT (MAX(?modified) AS ?latest) WHERE {{
+  ?s a <{type_iri}> .
+  ?s dcterms:modified ?modified .
+}}
+"""
+    try:
+        r = requests.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=HTTP_TIMEOUT,
+        )
+        r.raise_for_status()
+    except requests.RequestException as e:
+        log.warning("%s endpoint request failed: %s", type_label, e)
+        return None
+
+    bindings = r.json().get("results", {}).get("bindings", [])
+    if not bindings:
+        log.warning("%s MAX(?modified) returned no bindings", type_label)
+        return None
+    latest = bindings[0].get("latest", {}).get("value", "")
+    if not latest:
+        return None
+    # latest is e.g. "2026-04-10T00:00:00Z" or "2026-04-10"
+    m = re.match(r"^(\d{4}-\d{2}-\d{2})", latest)
+    return m.group(1) if m else None
+
+
+# ---------- per-source capture functions ----------
+
+def capture_gene_ontology(obo_path: Path = DEFAULT_OBO_PATH) -> dict:
+    """
+    Read the data-version line from the local GO OBO file header.
+
+    The OBO header looks like:
+        format-version: 1.2
+        data-version: releases/2026-01-23
+    so we parse the date out of the data-version line and store both the
+    raw label and the ISO date.
+    """
+    captured_at = _utcnow_iso()
+    if not obo_path.exists():
+        return _unknown(
+            "obo file not found",
+            source_file=_path_for_manifest(obo_path),
+            method="obo-header",
+            captured_at=captured_at,
+        )
+
+    label = None
+    try:
+        # The header is the first dozen lines; cap the scan to avoid reading 30MB.
+        with obo_path.open(encoding="utf-8") as f:
+            for _ in range(50):
+                line = f.readline()
+                if not line:
+                    break
+                if line.startswith("data-version:"):
+                    label = line.split(":", 1)[1].strip()
+                    break
+    except OSError as e:
+        return _unknown(
+            f"obo read error: {e}",
+            source_file=_path_for_manifest(obo_path),
+            method="obo-header",
+            captured_at=captured_at,
+        )
+
+    if not label:
+        return _unknown(
+            "no data-version line in OBO header",
+            source_file=_path_for_manifest(obo_path),
+            method="obo-header",
+            captured_at=captured_at,
+        )
+
+    # Pull a YYYY-MM-DD out of e.g. "releases/2026-01-23".
+    m = re.search(r"(\d{4}-\d{2}-\d{2})", label)
+    return {
+        "status": "ok",
+        "release_label": label,
+        "release_date": m.group(1) if m else None,
+        "method": "obo-header",
+        "source_file": _path_for_manifest(obo_path),
+        "captured_at": captured_at,
+    }
+
+
+def capture_wikipathways(endpoint: str = WIKIPATHWAYS_SPARQL) -> dict:
+    """
+    Resolve the WikiPathways release from the void:Dataset IRI.
+
+    WP serves one release at a time and encodes the release date in the
+    dataset IRI itself, e.g. <http://data.wikipathways.org/20260510/rdf/>.
+    We query for the most recent matching dataset and extract the YYYYMMDD
+    component, which is the canonical release date.
+    """
+    captured_at = _utcnow_iso()
+    query = """
+PREFIX void: <http://rdfs.org/ns/void#>
+SELECT ?dataset WHERE {
+  ?dataset a void:Dataset .
+  FILTER(STRSTARTS(STR(?dataset), "http://data.wikipathways.org/"))
+} ORDER BY DESC(?dataset) LIMIT 1
+"""
+    try:
+        r = requests.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=HTTP_TIMEOUT,
+        )
+        r.raise_for_status()
+    except requests.RequestException as e:
+        return _unknown(
+            f"wp sparql request failed: {e}",
+            method="sparql:void-dataset-iri",
+            endpoint=endpoint,
+            captured_at=captured_at,
+        )
+
+    bindings = r.json().get("results", {}).get("bindings", [])
+    if not bindings:
+        return _unknown(
+            "wp sparql returned no void:Dataset",
+            method="sparql:void-dataset-iri",
+            endpoint=endpoint,
+            captured_at=captured_at,
+        )
+    iri = bindings[0].get("dataset", {}).get("value", "")
+    m = re.search(r"data\.wikipathways\.org/(\d{4})(\d{2})(\d{2})/", iri)
+    if not m:
+        return _unknown(
+            f"wp void:Dataset IRI did not match YYYYMMDD pattern: {iri}",
+            method="sparql:void-dataset-iri",
+            endpoint=endpoint,
+            captured_at=captured_at,
+        )
+    return {
+        "status": "ok",
+        "release_date": f"{m.group(1)}-{m.group(2)}-{m.group(3)}",
+        "dataset_iri": iri,
+        "method": "sparql:void-dataset-iri",
+        "endpoint": endpoint,
+        "captured_at": captured_at,
+    }
+
+
+def capture_reactome(api_url: str = REACTOME_INFO_API) -> dict:
+    """
+    Query the Reactome REST `/database/info` endpoint for version + release date.
+
+    Returns the integer release version and the release date (when supplied).
+    """
+    captured_at = _utcnow_iso()
+    try:
+        r = requests.get(api_url, headers={"Accept": "application/json"}, timeout=HTTP_TIMEOUT)
+        r.raise_for_status()
+    except requests.RequestException as e:
+        return _unknown(
+            f"reactome api error: {e}",
+            method="rest-api",
+            endpoint=api_url,
+            captured_at=captured_at,
+        )
+
+    try:
+        info = r.json()
+    except ValueError:
+        return _unknown(
+            "reactome api returned non-json",
+            method="rest-api",
+            endpoint=api_url,
+            captured_at=captured_at,
+        )
+
+    # The Reactome /info payload exposes `version` (integer/string) and
+    # `releaseDate` (ISO date). Field names occasionally change between
+    # releases, so try a couple of common spellings.
+    version = info.get("version") or info.get("releaseNumber")
+    release_date = info.get("releaseDate") or info.get("release_date")
+    if not version:
+        return _unknown(
+            "reactome api missing version field",
+            method="rest-api",
+            endpoint=api_url,
+            captured_at=captured_at,
+            raw_keys=list(info.keys()),
+        )
+
+    out = {
+        "status": "ok",
+        "release_version": str(version),
+        "method": "rest-api",
+        "endpoint": api_url,
+        "captured_at": captured_at,
+    }
+    if release_date:
+        # Normalise to YYYY-MM-DD if possible.
+        m = re.match(r"^(\d{4}-\d{2}-\d{2})", str(release_date))
+        out["release_date"] = m.group(1) if m else str(release_date)
+    return out
+
+
+def capture_aopwiki(endpoint: str = AOPWIKI_SPARQL) -> dict:
+    """
+    Approximate the AOP-Wiki snapshot date as MAX(dcterms:modified) over AOPs.
+
+    Falls back to MAX over KEs if the AOP query returns nothing, since some
+    snapshots populate modified dates only on KE records.
+    """
+    captured_at = _utcnow_iso()
+    date = _sparql_max_modified(
+        endpoint,
+        "http://aopkb.org/aop_ontology#AdverseOutcomePathway",
+        "AOP-Wiki AOP",
+    )
+    if not date:
+        date = _sparql_max_modified(
+            endpoint,
+            "http://aopkb.org/aop_ontology#KeyEvent",
+            "AOP-Wiki KE (fallback)",
+        )
+    if not date:
+        return _unknown(
+            "sparql endpoint returned no modified date for AOPs or KEs",
+            method="sparql:max(dcterms:modified)",
+            endpoint=endpoint,
+            captured_at=captured_at,
+        )
+    return {
+        "status": "ok",
+        "snapshot_date": date,
+        "method": "sparql:max(dcterms:modified)",
+        "endpoint": endpoint,
+        "captured_at": captured_at,
+    }
+
+
+# ---------- orchestration ----------
+
+CAPTURERS = {
+    "wikipathways": capture_wikipathways,
+    "gene_ontology": capture_gene_ontology,
+    "reactome": capture_reactome,
+    "aopwiki": capture_aopwiki,
+}
+
+# CLI aliases so callers can `--source wp` etc.
+ALIASES = {
+    "wp": "wikipathways",
+    "go": "gene_ontology",
+    "reactome": "reactome",
+    "rx": "reactome",
+    "aopwiki": "aopwiki",
+    "aop": "aopwiki",
+}
+
+
+def build_manifest(sources: list[str] | None = None, *, obo_path: Path | None = None) -> dict:
+    """
+    Run the per-source capturers and assemble the manifest object.
+
+    `obo_path` is threaded through to the GO capturer so callers (and the CLI)
+    can override the default `data/go-basic.obo` location.
+    """
+    if sources is None:
+        sources = list(CAPTURERS)
+    payload: dict[str, dict] = {}
+    for name in sources:
+        log.info("Capturing %s ...", name)
+        try:
+            if name == "gene_ontology" and obo_path is not None:
+                payload[name] = capture_gene_ontology(obo_path)
+            else:
+                payload[name] = CAPTURERS[name]()
+        except Exception as e:  # noqa: BLE001 — capture surfaces failure as a record
+            log.exception("Unhandled error in %s capturer", name)
+            payload[name] = _unknown(f"unhandled: {e}", captured_at=_utcnow_iso())
+        st = payload[name].get("status", "unknown")
+        log.info("  -> %s (%s)", name, st)
+    return {"captured_at": _utcnow_iso(), "sources": payload}
+
+
+def _merge_with_existing(new_manifest: dict, existing_path: Path) -> dict:
+    """
+    Merge a partial capture (e.g. only --source go) into the existing manifest
+    so that sources not touched this run aren't blown away.
+    """
+    if not existing_path.exists():
+        return new_manifest
+    try:
+        old = json.loads(existing_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        log.warning("Existing manifest unreadable (%s); overwriting", e)
+        return new_manifest
+    merged = dict(old.get("sources", {}))
+    merged.update(new_manifest["sources"])
+    return {"captured_at": new_manifest["captured_at"], "sources": merged}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--source",
+        choices=sorted(set(list(CAPTURERS) + list(ALIASES))),
+        action="append",
+        default=None,
+        help="Capture only the named source(s). Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help=f"Output manifest path (default: {DEFAULT_OUTPUT_PATH.relative_to(_PROJECT_ROOT)})",
+    )
+    parser.add_argument(
+        "--obo-path",
+        type=Path,
+        default=DEFAULT_OBO_PATH,
+        help=f"Override the GO OBO file path (default: {DEFAULT_OBO_PATH.relative_to(_PROJECT_ROOT)})",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print to stdout instead of writing")
+    parser.add_argument("--strict", action="store_true", help="Exit 2 if any source returned 'unknown'")
+    args = parser.parse_args(argv)
+
+    sources = None
+    if args.source:
+        sources = sorted({ALIASES.get(s, s) for s in args.source})
+
+    manifest = build_manifest(sources, obo_path=args.obo_path)
+    if sources and len(sources) < len(CAPTURERS):
+        manifest = _merge_with_existing(manifest, args.output)
+
+    text = json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+    if args.dry_run:
+        sys.stdout.write(text)
+    else:
+        try:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(text, encoding="utf-8")
+        except OSError as e:
+            log.error("Failed to write %s: %s", args.output, e)
+            return 1
+        log.info("Wrote %s", _path_for_manifest(args.output))
+
+    unknowns = [k for k, v in manifest["sources"].items() if v.get("status") != "ok"]
+    if unknowns:
+        log.warning("Unknown sources: %s", ", ".join(unknowns))
+        if args.strict:
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capture_source_versions.py
+++ b/tests/test_capture_source_versions.py
@@ -1,0 +1,223 @@
+"""
+Tests for scripts/capture_source_versions.py.
+
+Covers the GO OBO parser (pure file I/O — happy path, missing file, malformed
+header), the manifest writer / merger, and the failure-handling shape of the
+HTTP-backed capturers (without hitting the network). The HTTP capturers are
+exercised by monkeypatching `requests.post` / `requests.get` so the test
+suite stays offline and deterministic.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import capture_source_versions as cap
+
+
+@pytest.fixture
+def tmp_obo(tmp_path: Path) -> Path:
+    p = tmp_path / "go-basic.obo"
+    p.write_text(
+        "format-version: 1.2\n"
+        "data-version: releases/2025-12-15\n"
+        "subsetdef: foo\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+# ---------- GO OBO parser ----------
+
+def test_capture_gene_ontology_parses_data_version(tmp_obo: Path) -> None:
+    rec = cap.capture_gene_ontology(tmp_obo)
+    assert rec["status"] == "ok"
+    assert rec["release_label"] == "releases/2025-12-15"
+    assert rec["release_date"] == "2025-12-15"
+    assert rec["method"] == "obo-header"
+    assert "captured_at" in rec
+
+
+def test_capture_gene_ontology_missing_file(tmp_path: Path) -> None:
+    rec = cap.capture_gene_ontology(tmp_path / "does-not-exist.obo")
+    assert rec["status"] == "unknown"
+    assert "not found" in rec["reason"]
+
+
+def test_capture_gene_ontology_no_data_version_line(tmp_path: Path) -> None:
+    p = tmp_path / "no-data-version.obo"
+    p.write_text("format-version: 1.2\nontology: go\n", encoding="utf-8")
+    rec = cap.capture_gene_ontology(p)
+    assert rec["status"] == "unknown"
+    assert "no data-version" in rec["reason"]
+
+
+def test_capture_gene_ontology_label_without_date(tmp_path: Path) -> None:
+    """A non-ISO label still returns status=ok with release_date=None."""
+    p = tmp_path / "weird-label.obo"
+    p.write_text("data-version: snapshot-foo\n", encoding="utf-8")
+    rec = cap.capture_gene_ontology(p)
+    assert rec["status"] == "ok"
+    assert rec["release_label"] == "snapshot-foo"
+    assert rec["release_date"] is None
+
+
+# ---------- HTTP capturers — offline via monkeypatch ----------
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise cap.requests.HTTPError(f"http {self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_capture_wikipathways_extracts_yyyymmdd_from_iri(monkeypatch) -> None:
+    payload = {"results": {"bindings": [
+        {"dataset": {"value": "http://data.wikipathways.org/20260410/rdf/"}}
+    ]}}
+    monkeypatch.setattr(cap.requests, "post", lambda *a, **kw: _FakeResponse(payload))
+    rec = cap.capture_wikipathways()
+    assert rec["status"] == "ok"
+    assert rec["release_date"] == "2026-04-10"
+    assert rec["method"] == "sparql:void-dataset-iri"
+
+
+def test_capture_wikipathways_returns_unknown_when_no_bindings(monkeypatch) -> None:
+    monkeypatch.setattr(cap.requests, "post",
+                        lambda *a, **kw: _FakeResponse({"results": {"bindings": []}}))
+    rec = cap.capture_wikipathways()
+    assert rec["status"] == "unknown"
+    assert "no void:Dataset" in rec["reason"]
+
+
+def test_capture_wikipathways_returns_unknown_on_network_error(monkeypatch) -> None:
+    def boom(*a, **kw):
+        raise cap.requests.ConnectionError("simulated dns failure")
+    monkeypatch.setattr(cap.requests, "post", boom)
+    rec = cap.capture_wikipathways()
+    assert rec["status"] == "unknown"
+    assert "wp sparql request failed" in rec["reason"]
+
+
+def test_capture_reactome_uses_version_and_release_date(monkeypatch) -> None:
+    payload = {"version": 96, "releaseDate": "2026-03-25"}
+    monkeypatch.setattr(cap.requests, "get", lambda *a, **kw: _FakeResponse(payload))
+    rec = cap.capture_reactome()
+    assert rec["status"] == "ok"
+    assert rec["release_version"] == "96"
+    assert rec["release_date"] == "2026-03-25"
+
+
+def test_capture_reactome_returns_unknown_when_missing_version(monkeypatch) -> None:
+    payload = {"name": "Reactome Knowledgebase"}  # no version
+    monkeypatch.setattr(cap.requests, "get", lambda *a, **kw: _FakeResponse(payload))
+    rec = cap.capture_reactome()
+    assert rec["status"] == "unknown"
+    assert "missing version field" in rec["reason"]
+
+
+def test_capture_aopwiki_uses_max_dcterms_modified(monkeypatch) -> None:
+    payload = {"results": {"bindings": [
+        {"latest": {"value": "2026-05-06T00:00:00Z"}}
+    ]}}
+    monkeypatch.setattr(cap.requests, "post", lambda *a, **kw: _FakeResponse(payload))
+    rec = cap.capture_aopwiki()
+    assert rec["status"] == "ok"
+    assert rec["snapshot_date"] == "2026-05-06"
+
+
+def test_capture_aopwiki_returns_unknown_when_both_queries_empty(monkeypatch) -> None:
+    monkeypatch.setattr(cap.requests, "post",
+                        lambda *a, **kw: _FakeResponse({"results": {"bindings": []}}))
+    rec = cap.capture_aopwiki()
+    assert rec["status"] == "unknown"
+
+
+# ---------- Manifest assembly + merge ----------
+
+def test_build_manifest_runs_all_sources_by_default(monkeypatch, tmp_obo: Path) -> None:
+    monkeypatch.setattr(cap, "DEFAULT_OBO_PATH", tmp_obo)
+    monkeypatch.setattr(cap, "capture_wikipathways",
+                        lambda **kw: {"status": "ok", "release_date": "2026-05-10"})
+    monkeypatch.setattr(cap, "capture_reactome",
+                        lambda **kw: {"status": "ok", "release_version": "96"})
+    monkeypatch.setattr(cap, "capture_aopwiki",
+                        lambda **kw: {"status": "ok", "snapshot_date": "2026-05-06"})
+    # Replace the dispatch table so the monkey-patched bare-name capturers are picked up.
+    monkeypatch.setitem(cap.CAPTURERS, "wikipathways", cap.capture_wikipathways)
+    monkeypatch.setitem(cap.CAPTURERS, "reactome", cap.capture_reactome)
+    monkeypatch.setitem(cap.CAPTURERS, "aopwiki", cap.capture_aopwiki)
+
+    manifest = cap.build_manifest(obo_path=tmp_obo)
+    assert set(manifest["sources"]) == {"wikipathways", "gene_ontology", "reactome", "aopwiki"}
+    assert all(rec["status"] == "ok" for rec in manifest["sources"].values())
+
+
+def test_merge_with_existing_preserves_untouched_sources(tmp_path: Path) -> None:
+    existing = tmp_path / "source_versions.json"
+    existing.write_text(json.dumps({
+        "captured_at": "2026-04-01T00:00:00Z",
+        "sources": {
+            "wikipathways": {"status": "ok", "release_date": "2026-03-15"},
+            "gene_ontology": {"status": "ok", "release_date": "2025-12-15"},
+        },
+    }), encoding="utf-8")
+    new_manifest = {
+        "captured_at": "2026-05-14T21:00:00Z",
+        "sources": {"gene_ontology": {"status": "ok", "release_date": "2026-01-23"}},
+    }
+    merged = cap._merge_with_existing(new_manifest, existing)
+    # Old WP entry retained because this run didn't touch it.
+    assert merged["sources"]["wikipathways"]["release_date"] == "2026-03-15"
+    # New GO entry takes precedence over the old one.
+    assert merged["sources"]["gene_ontology"]["release_date"] == "2026-01-23"
+    # New capture timestamp is used.
+    assert merged["captured_at"] == "2026-05-14T21:00:00Z"
+
+
+def test_merge_with_existing_overwrites_when_unreadable(tmp_path: Path) -> None:
+    existing = tmp_path / "source_versions.json"
+    existing.write_text("not json", encoding="utf-8")
+    new_manifest = {"captured_at": "now", "sources": {"x": {"status": "ok"}}}
+    merged = cap._merge_with_existing(new_manifest, existing)
+    assert merged == new_manifest
+
+
+# ---------- CLI entry point ----------
+
+def test_main_writes_manifest_file(monkeypatch, tmp_path: Path, tmp_obo: Path) -> None:
+    out = tmp_path / "source_versions.json"
+    monkeypatch.setattr(cap, "capture_wikipathways", lambda **kw: {"status": "ok"})
+    monkeypatch.setattr(cap, "capture_reactome", lambda **kw: {"status": "ok"})
+    monkeypatch.setattr(cap, "capture_aopwiki", lambda **kw: {"status": "ok"})
+    monkeypatch.setitem(cap.CAPTURERS, "wikipathways", cap.capture_wikipathways)
+    monkeypatch.setitem(cap.CAPTURERS, "reactome", cap.capture_reactome)
+    monkeypatch.setitem(cap.CAPTURERS, "aopwiki", cap.capture_aopwiki)
+
+    exit_code = cap.main(["--output", str(out), "--obo-path", str(tmp_obo)])
+    assert exit_code == 0
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert set(payload["sources"]) == {"wikipathways", "gene_ontology", "reactome", "aopwiki"}
+
+
+def test_main_strict_returns_2_on_unknown(monkeypatch, tmp_path: Path, tmp_obo: Path) -> None:
+    out = tmp_path / "source_versions.json"
+    monkeypatch.setattr(cap, "capture_wikipathways",
+                        lambda **kw: {"status": "unknown", "reason": "x"})
+    monkeypatch.setattr(cap, "capture_reactome", lambda **kw: {"status": "ok"})
+    monkeypatch.setattr(cap, "capture_aopwiki", lambda **kw: {"status": "ok"})
+    monkeypatch.setitem(cap.CAPTURERS, "wikipathways", cap.capture_wikipathways)
+    monkeypatch.setitem(cap.CAPTURERS, "reactome", cap.capture_reactome)
+    monkeypatch.setitem(cap.CAPTURERS, "aopwiki", cap.capture_aopwiki)
+
+    exit_code = cap.main(["--output", str(out), "--obo-path", str(tmp_obo), "--strict"])
+    assert exit_code == 2


### PR DESCRIPTION
## Summary

First slice of **source-data versioning** (DMP §7). Introduces `scripts/capture_source_versions.py` and writes the version manifest at `data/source_versions.json`.

The running app will eventually read this manifest at boot and stamp every approved mapping with the current snapshot's upstream version, so downstream consumers can pin analyses against a specific upstream release. This PR ships the **read** half of that pipeline only; the schema migration, approval-time stamping, backfill, and UI surfacing land in later phases.

## How each upstream is resolved

| Source | Method | Field on disk |
|---|---|---|
| **WikiPathways** | SPARQL → `void:Dataset` IRI, extract `YYYYMMDD` (e.g. `data.wikipathways.org/20260510/rdf/` → `2026-05-10`) | `release_date` |
| **Gene Ontology** | Parse `data-version: releases/YYYY-MM-DD` from `data/go-basic.obo` header | `release_label`, `release_date` |
| **Reactome** | REST → `/ContentService/data/database/info` (`version` + `releaseDate`) | `release_version`, `release_date` |
| **AOP-Wiki** | SPARQL → `MAX(dcterms:modified)` over `aopo:AdverseOutcomePathway`, fallback to `KeyEvent` | `snapshot_date` |

Captured manifest at HEAD: **WP** 2026-05-10 · **GO** 2026-01-23 · **Reactome** v96 (2026-03-25) · **AOP-Wiki** 2026-05-06.

## Defensive design

Every capturer catches HTTP errors, missing fields, and parse failures, and returns a `status: "unknown"` record with a `reason` field — so the manifest is always structurally valid even when an upstream is degraded. The orchestrator runs each capturer independently, so one bad upstream doesn't poison the others.

## Surface area

- `scripts/capture_source_versions.py` (~330 LOC, no new deps — only `requests`)
- `data/source_versions.json` (~30 lines, committed; pinned via `!data/source_versions.json` in `.gitignore` since `data/*.json` is otherwise ignored)
- `tests/test_capture_source_versions.py` (16 tests, all offline via monkey-patched `requests`)
- `make capture-versions` Makefile target for ad-hoc refresh

## CLI surface

```bash
python scripts/capture_source_versions.py              # all four sources -> data/source_versions.json
python scripts/capture_source_versions.py --source wp  # one source only (merges into existing manifest)
python scripts/capture_source_versions.py --dry-run    # print to stdout instead of writing
python scripts/capture_source_versions.py --strict     # exit 2 if any source returned 'unknown'
```

## Test plan

- [x] `pytest tests/test_capture_source_versions.py` → 16 / 16 passing offline.
- [x] `pytest` full suite → 333 passing (was 317), coverage 51.17 % (floor 40).
- [x] `python scripts/capture_source_versions.py` against live endpoints → all four sources resolve to status=ok.
- [x] `make capture-versions` rewrites `data/source_versions.json` cleanly.
- [ ] After merge, snapshot `data/source_versions.json` whenever you rebuild the precompute outputs.

## Next phases (no PR yet)

- **Phase B**: schema migration — nullable `*_release_date` / `*_version` / `aopwiki_snapshot_date` columns on `mappings`, `ke_go_mappings`, `ke_reactome_mappings`.
- **Phase C**: app reads manifest at boot, stamps each new approval.
- **Phase D**: hand-curated `data/release_calendar.json` + one-off backfill script.
- **Phase E**: surface versions on landing / Downloads / Stats / exporters / Zenodo metadata.