### PR TITLE
feat(versioning): schema migration for per-mapping upstream versions (Phase B)

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -362,6 +362,13 @@ class Database:
             # cleanup pass.
             self._migrate_go_proposals_pending_unique_index(conn)
 
+            # Source-data versioning (DMP §7, Phase B):
+            # add nullable upstream-release columns to each mapping table so
+            # Phase C can stamp every new approval with the snapshot version.
+            self._migrate_mappings_source_versions(conn)
+            self._migrate_go_mappings_source_versions(conn)
+            self._migrate_reactome_mappings_source_versions(conn)
+
             conn.commit()
             logger.info("Database initialized successfully")
         except Exception as e:
@@ -1212,6 +1219,92 @@ class Database:
             logger.error(
                 "Error migrating ke_reactome_mappings assessment fields: %s", e
             )
+            raise
+
+    def _migrate_mappings_source_versions(self, conn):
+        """
+        Add upstream source-version columns to the WP `mappings` table.
+
+        Phase B of source-data versioning (DMP §7). Phase C will populate
+        these at approval time from `data/source_versions.json`; Phase D
+        will backfill historical rows from a hand-curated release calendar.
+        Until then the columns are NULL on every row.
+
+        Columns added:
+            wp_release_date         TEXT (nullable, ISO YYYY-MM-DD) —
+                WikiPathways snapshot the curator was working against.
+            aopwiki_snapshot_date   TEXT (nullable, ISO YYYY-MM-DD) —
+                AOP-Wiki snapshot the KE was sourced from.
+        """
+        self._add_columns_if_missing(
+            conn,
+            table="mappings",
+            fields=[
+                ("wp_release_date", "TEXT"),
+                ("aopwiki_snapshot_date", "TEXT"),
+            ],
+            log_label="WP mappings source-version fields",
+        )
+
+    def _migrate_go_mappings_source_versions(self, conn):
+        """
+        Add upstream source-version columns to the `ke_go_mappings` table.
+
+        Sibling of _migrate_mappings_source_versions. The `go_release_date`
+        column stores the GO release date parsed from the OBO header
+        (the manifest's `gene_ontology.release_date` field).
+        """
+        self._add_columns_if_missing(
+            conn,
+            table="ke_go_mappings",
+            fields=[
+                ("go_release_date", "TEXT"),
+                ("aopwiki_snapshot_date", "TEXT"),
+            ],
+            log_label="GO mappings source-version fields",
+        )
+
+    def _migrate_reactome_mappings_source_versions(self, conn):
+        """
+        Add upstream source-version columns to the `ke_reactome_mappings` table.
+
+        Reactome uses an integer release number (e.g. v96) in addition to a
+        release date, so both are persisted: the version is the canonical
+        upstream identifier and the date enables nearest-release lookups
+        during backfill (Phase D).
+        """
+        self._add_columns_if_missing(
+            conn,
+            table="ke_reactome_mappings",
+            fields=[
+                ("reactome_release_version", "TEXT"),
+                ("reactome_release_date", "TEXT"),
+                ("aopwiki_snapshot_date", "TEXT"),
+            ],
+            log_label="Reactome mappings source-version fields",
+        )
+
+    def _add_columns_if_missing(self, conn, *, table, fields, log_label):
+        """
+        Idempotent helper: ADD COLUMN for any of `fields` not already present.
+
+        `fields` is a list of (name, sqlite_type) tuples — all nullable. Used by
+        the Phase B source-version migrations to keep the three sibling
+        methods short and verifiable. Errors are logged and re-raised so the
+        outer init_database() rollback fires.
+        """
+        try:
+            cursor = conn.execute(f"PRAGMA table_info({table})")
+            existing = {row[1] for row in cursor.fetchall()}
+            added = []
+            for name, sql_type in fields:
+                if name not in existing:
+                    conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {sql_type}")
+                    added.append(name)
+            if added:
+                logger.info("Migrated %s: added %s", log_label, added)
+        except Exception as e:
+            logger.error("Error migrating %s: %s", log_label, e)
             raise
 
     def _migrate_reactome_proposals_pending_unique_index(self, conn):

--- a/tests/test_source_version_migrations.py
+++ b/tests/test_source_version_migrations.py
@@ -1,0 +1,174 @@
+"""Source-data versioning Phase B — schema-migration tests.
+
+Mirrors the Phase 34 assessment-migration test pattern: each test spins up a
+fresh Database() against a tmp_path SQLite file and inspects PRAGMA
+table_info to assert presence of the new upstream source-version columns
+on mappings / ke_go_mappings / ke_reactome_mappings. Idempotency is
+verified by reinitialising the Database() against the same file and
+re-checking the column set.
+"""
+import sqlite3
+
+import pytest
+
+from src.core.models import Database
+
+
+def _columns(db_path, table):
+    conn = sqlite3.connect(db_path)
+    try:
+        return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+    finally:
+        conn.close()
+
+
+def _row_count(db_path, table):
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    path = tmp_path / "ke_wp_mapping.db"
+    Database(str(path))  # init triggers all migrations
+    return str(path)
+
+
+# ---------- Column presence ----------
+
+def test_mappings_gains_wp_release_and_aopwiki_snapshot(fresh_db):
+    cols = _columns(fresh_db, "mappings")
+    assert "wp_release_date" in cols
+    assert "aopwiki_snapshot_date" in cols
+
+
+def test_ke_go_mappings_gains_go_release_and_aopwiki_snapshot(fresh_db):
+    cols = _columns(fresh_db, "ke_go_mappings")
+    assert "go_release_date" in cols
+    assert "aopwiki_snapshot_date" in cols
+
+
+def test_ke_reactome_mappings_gains_version_release_and_snapshot(fresh_db):
+    cols = _columns(fresh_db, "ke_reactome_mappings")
+    assert "reactome_release_version" in cols
+    assert "reactome_release_date" in cols
+    assert "aopwiki_snapshot_date" in cols
+
+
+# ---------- Nullability — new rows can omit the columns ----------
+
+@pytest.mark.parametrize(
+    "table,insert_sql,values",
+    [
+        (
+            "mappings",
+            "INSERT INTO mappings (ke_id, ke_title, wp_id, wp_title, "
+            "connection_type, confidence_level, created_by) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("KE 1", "Test KE", "WP1", "Test pathway", "causative", "high", "test"),
+        ),
+        (
+            "ke_go_mappings",
+            "INSERT INTO ke_go_mappings (ke_id, ke_title, go_id, go_name, "
+            "connection_type, confidence_level, created_by) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("KE 2", "Test KE 2", "GO:0001234", "test GO term", "causative", "high", "test"),
+        ),
+        (
+            "ke_reactome_mappings",
+            "INSERT INTO ke_reactome_mappings (ke_id, ke_title, reactome_id, "
+            "pathway_name, confidence_level, created_by) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("KE 3", "Test KE 3", "R-HSA-1234", "Test reactome", "high", "test"),
+        ),
+    ],
+)
+def test_new_columns_are_nullable(fresh_db, table, insert_sql, values):
+    """A fresh row that doesn't supply any of the new columns must still insert."""
+    conn = sqlite3.connect(fresh_db)
+    try:
+        conn.execute(insert_sql, values)
+        conn.commit()
+        row = conn.execute(
+            f"SELECT wp_release_date, aopwiki_snapshot_date FROM {table} LIMIT 1"
+        ).fetchone() if table == "mappings" else conn.execute(
+            f"SELECT * FROM {table} LIMIT 1"
+        ).fetchone()
+        assert row is not None
+    finally:
+        conn.close()
+
+
+# ---------- Idempotency ----------
+
+def test_reinitialising_database_does_not_duplicate_columns(fresh_db):
+    cols_first = _columns(fresh_db, "mappings")
+    Database(fresh_db)  # second init must be a no-op for our migrations
+    cols_second = _columns(fresh_db, "mappings")
+    assert cols_first == cols_second
+
+
+def test_reinitialising_database_preserves_row_count(fresh_db):
+    conn = sqlite3.connect(fresh_db)
+    try:
+        conn.execute(
+            "INSERT INTO mappings (ke_id, ke_title, wp_id, wp_title, "
+            "connection_type, confidence_level, created_by) "
+            "VALUES ('KE 99', 'persist test', 'WP99', 'persist', 'causative', 'low', 'test')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    before = _row_count(fresh_db, "mappings")
+    Database(fresh_db)
+    after = _row_count(fresh_db, "mappings")
+    assert before == after == 1
+
+
+# ---------- Round-trip — values written into the new columns are readable ----------
+
+def test_round_trip_wp_release_date(fresh_db):
+    conn = sqlite3.connect(fresh_db)
+    try:
+        conn.execute(
+            "INSERT INTO mappings (ke_id, ke_title, wp_id, wp_title, "
+            "connection_type, confidence_level, created_by, "
+            "wp_release_date, aopwiki_snapshot_date) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("KE 4", "rt", "WP4", "rt", "causative", "high", "test",
+             "2026-05-10", "2026-05-06"),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT wp_release_date, aopwiki_snapshot_date FROM mappings "
+            "WHERE ke_id = 'KE 4'"
+        ).fetchone()
+        assert row == ("2026-05-10", "2026-05-06")
+    finally:
+        conn.close()
+
+
+def test_round_trip_reactome_version_and_release(fresh_db):
+    conn = sqlite3.connect(fresh_db)
+    try:
+        conn.execute(
+            "INSERT INTO ke_reactome_mappings (ke_id, ke_title, reactome_id, "
+            "pathway_name, confidence_level, created_by, "
+            "reactome_release_version, reactome_release_date, "
+            "aopwiki_snapshot_date) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("KE 5", "rt", "R-HSA-5", "rt", "high", "test",
+             "96", "2026-03-25", "2026-05-06"),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT reactome_release_version, reactome_release_date, "
+            "aopwiki_snapshot_date FROM ke_reactome_mappings "
+            "WHERE ke_id = 'KE 5'"
+        ).fetchone()
+        assert row == ("96", "2026-03-25", "2026-05-06")
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Second slice of **source-data versioning** (DMP §7). Adds the seven nullable upstream source-version columns to the three mapping tables via the existing auto-migration pattern in `src/core/models.py`. Columns stay NULL on every row for now — this PR is schema-only.

Builds on Phase A (#170, merged): the manifest at `data/source_versions.json` is the source the Phase C stamping logic will read at boot.

## Columns added

| Table | New columns |
|---|---|
| `mappings` | `wp_release_date`, `aopwiki_snapshot_date` |
| `ke_go_mappings` | `go_release_date`, `aopwiki_snapshot_date` |
| `ke_reactome_mappings` | `reactome_release_version`, `reactome_release_date`, `aopwiki_snapshot_date` |

All TEXT, nullable. Dates are ISO `YYYY-MM-DD`; the Reactome version is the integer-as-string from the ContentService payload (e.g. `"96"`).

## Implementation

- Three new `_migrate_*_source_versions` methods on `Database`, sharing a small `_add_columns_if_missing` helper to keep the diff readable.
- Each uses `PRAGMA table_info` to guard against re-adding columns, so init is idempotent. Verified against the prod-shaped local DB (27 + 3 + 0 rows preserved across two consecutive `Database()` inits).
- Wired into `init_database()` after the existing partial-unique-index migrations, before the final commit, so any failure rolls back the whole init.

## Tests

`tests/test_source_version_migrations.py` (10 cases) covers:

- Column presence on all three tables
- Nullability — a row that omits the new columns still inserts
- Idempotency on reinit (column set is unchanged)
- Row preservation on reinit
- Round-trip read/write for both WP and Reactome variants

Full suite: **343 passed** (was 333 after Phase A), coverage **51.29%** (floor 40).

## What this PR deliberately does *not* do

- Populate the columns (Phase C — wire the running app to read the manifest at boot and stamp each new approval)
- Backfill historical rows (Phase D — needs a hand-curated release calendar)
- Surface versions anywhere user-visible (Phase E — landing, Downloads, Stats, exporters, Zenodo metadata)

## Test plan

- [x] Migration applies cleanly to a fresh DB.
- [x] Migration applies idempotently to a prod-shaped DB (run twice; no double-ALTER, no row corruption, no column duplication).
- [x] Rows can omit the new columns (nullable) and still insert.
- [x] Values round-trip through write/read.
- [ ] After merge: deploy + spot-check `PRAGMA table_info(mappings)` on the live container.