### PR TITLE
feat(versioning): stamp approvals with deployed snapshot versions (Phase C)

### DIFF
--- a/src/blueprints/admin.py
+++ b/src/blueprints/admin.py
@@ -21,6 +21,28 @@ from src.core.schemas import AdminNotesSchema, SecurityValidation, validate_requ
 logger = logging.getLogger(__name__)
 
 
+def _source_version_fields(resource: str) -> dict:
+    """
+    Resolve the upstream source-version fields to stamp on a new approval.
+
+    Wraps `current_app.service_container.source_version_fields_for(resource)`
+    with a safety net: if the container is unavailable or raises, returns an
+    empty dict so the approval still goes through (the mapping just gets
+    NULL version columns rather than failing).
+
+    Phase C of source-data versioning (DMP §7).
+    """
+    try:
+        return current_app.service_container.source_version_fields_for(resource)
+    except Exception as e:
+        logger.warning(
+            "Could not resolve source-version fields for %s: %s — approval "
+            "will proceed with NULL version columns",
+            resource, e,
+        )
+        return {}
+
+
 def _get_admin_users():
     """Return list of provider-prefixed admin usernames from ADMIN_USERS env var.
 
@@ -348,6 +370,9 @@ def approve_proposal(proposal_id: int):
             # New-pair proposal: create the mapping then write provenance
             approved_at = datetime.utcnow().isoformat()
             proposal_score = proposal.get("suggestion_score")
+            # Phase C: stamp the new mapping with the current snapshot's
+            # WikiPathways + AOP-Wiki release info from data/source_versions.json.
+            wp_version_fields = _source_version_fields("wp")
             new_mapping_id = mapping_model.create_mapping(
                 ke_id=proposal["ke_id"],
                 ke_title=proposal["ke_title"],
@@ -361,6 +386,7 @@ def approve_proposal(proposal_id: int):
                 proposed_basis=proposed_basis,
                 proposed_specificity=proposed_specificity,
                 proposed_coverage=proposed_coverage,
+                **wp_version_fields,
             )
             if new_mapping_id:
                 success = mapping_model.update_mapping(
@@ -385,6 +411,10 @@ def approve_proposal(proposal_id: int):
             # Existing mapping revision proposal: update the mapping with provenance
             approved_at = datetime.utcnow().isoformat()
             proposal_score = proposal.get("suggestion_score")   # REAL or None
+            # Phase C: revision approvals refresh the version stamp too — they
+            # represent a re-confirmation of the mapping against the current
+            # snapshot, so the snapshot the curator was reviewing wins.
+            wp_version_fields = _source_version_fields("wp")
             success = mapping_model.update_mapping(
                 mapping_id=mapping_id,
                 connection_type=proposal["proposed_connection_type"],
@@ -399,6 +429,7 @@ def approve_proposal(proposal_id: int):
                 proposed_basis=proposed_basis,
                 proposed_specificity=proposed_specificity,
                 proposed_coverage=proposed_coverage,
+                **wp_version_fields,
             )
             action = "updated"
 
@@ -662,6 +693,8 @@ def approve_go_proposal(proposal_id: int):
             evidence_score = None
             assessment_version = "v1"
 
+        # Phase C: stamp the new GO mapping with current GO + AOP-Wiki versions.
+        go_version_fields = _source_version_fields("go")
         new_mapping_id = go_mapping_model.create_mapping(
             ke_id=proposal["ke_id"],
             ke_title=proposal["ke_title"],
@@ -675,6 +708,7 @@ def approve_go_proposal(proposal_id: int):
             evidence_score=evidence_score,
             assessment_version=assessment_version,
             go_namespace=proposal.get("go_namespace", "biological_process"),
+            **go_version_fields,
         )
 
         if new_mapping_id:
@@ -865,10 +899,15 @@ def approve_reactome_proposal(proposal_id: int):
         # on partial failure). Phase 34 (ASMT-10): create_approved_mapping
         # now loads all carry-fields from the proposal row internally via
         # REACTOME_PROPOSAL_CARRY_FIELDS — pass only the approval context.
+        # Phase C: source-version fields are stamped from the deployed
+        # manifest (NOT from the proposal), so they ride alongside the
+        # approval context kwargs.
+        reactome_version_fields = _source_version_fields("reactome")
         new_mapping_id = reactome_mapping_model.create_approved_mapping(
             proposal_id=proposal_id,
             approved_by_curator=admin_username,
             approved_at_curator=approved_at,
+            **reactome_version_fields,
         )
 
         if not new_mapping_id:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1550,6 +1550,11 @@ class MappingModel:
         proposed_basis: Optional[str] = None,
         proposed_specificity: Optional[str] = None,
         proposed_coverage: Optional[str] = None,
+        # Phase C — source-data versioning. Stamped from the deployed manifest
+        # (data/source_versions.json) by the admin approval handler. NULL if
+        # the manifest is missing or the upstream is currently 'unknown'.
+        wp_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
     ) -> Optional[int]:
         """Create a new KE-WP mapping"""
         mapping_uuid = str(uuid_lib.uuid4())
@@ -1566,8 +1571,9 @@ class MappingModel:
                                     confidence_level, created_by, uuid,
                                     proposed_relationship, proposed_basis,
                                     proposed_specificity, proposed_coverage,
-                                    assessment_version)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                    assessment_version,
+                                    wp_release_date, aopwiki_snapshot_date)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     ke_id,
@@ -1583,6 +1589,8 @@ class MappingModel:
                     proposed_specificity,
                     proposed_coverage,
                     assessment_version,
+                    wp_release_date,
+                    aopwiki_snapshot_date,
                 ),
             )
 
@@ -1921,6 +1929,9 @@ class MappingModel:
         proposed_basis: Optional[str] = None,
         proposed_specificity: Optional[str] = None,
         proposed_coverage: Optional[str] = None,
+        # Phase C — source-data versioning kwargs; nullable, stamped at approval.
+        wp_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
     ) -> bool:
         """
         Update an existing mapping
@@ -1956,6 +1967,9 @@ class MappingModel:
             "proposed_specificity": "proposed_specificity",
             "proposed_coverage": "proposed_coverage",
             "assessment_version": "assessment_version",
+            # Phase C source-data versioning columns.
+            "wp_release_date": "wp_release_date",
+            "aopwiki_snapshot_date": "aopwiki_snapshot_date",
         }
 
         # Phase 34 dual-write: proposed_relationship also populates connection_type
@@ -1989,6 +2003,11 @@ class MappingModel:
                 "proposed_specificity": proposed_specificity,
                 "proposed_coverage": proposed_coverage,
                 "assessment_version": assessment_version,
+                # Phase C source-data versioning — None values are skipped by the
+                # `field_value is not None` guard below so unspecified columns
+                # remain untouched on revision updates.
+                "wp_release_date": wp_release_date,
+                "aopwiki_snapshot_date": aopwiki_snapshot_date,
             }
 
             for field_name, field_value in update_data.items():
@@ -2446,6 +2465,9 @@ class GoMappingModel:
         evidence_score: int = None,
         assessment_version: str = "v1",
         go_namespace: str = "biological_process",
+        # Phase C — source-data versioning kwargs; nullable, stamped at approval.
+        go_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
     ) -> Optional[int]:
         """Create a new KE-GO mapping"""
         mapping_uuid = str(uuid_lib.uuid4())
@@ -2462,8 +2484,9 @@ class GoMappingModel:
                 INSERT INTO ke_go_mappings (ke_id, ke_title, go_id, go_name, connection_type,
                                            confidence_level, evidence_code, created_by, uuid,
                                            go_direction, connection_score, specificity_score,
-                                           evidence_score, assessment_version, go_namespace)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                           evidence_score, assessment_version, go_namespace,
+                                           go_release_date, aopwiki_snapshot_date)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     ke_id,
@@ -2481,6 +2504,8 @@ class GoMappingModel:
                     evidence_score,
                     assessment_version,
                     go_namespace,
+                    go_release_date,
+                    aopwiki_snapshot_date,
                 ),
             )
 
@@ -2753,6 +2778,9 @@ class GoMappingModel:
         approved_at_curator: str = None,
         suggestion_score: float = None,
         proposed_by: str = None,
+        # Phase C — source-data versioning kwargs; nullable, stamped at approval.
+        go_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
     ) -> bool:
         """
         Update an existing KE-GO mapping.
@@ -2768,6 +2796,8 @@ class GoMappingModel:
             "approved_at_curator": "approved_at_curator",
             "suggestion_score": "suggestion_score",
             "proposed_by": "proposed_by",
+            "go_release_date": "go_release_date",
+            "aopwiki_snapshot_date": "aopwiki_snapshot_date",
         }
 
         conn = self.db.get_connection()
@@ -2783,6 +2813,8 @@ class GoMappingModel:
                 "approved_at_curator": approved_at_curator,
                 "suggestion_score": suggestion_score,
                 "proposed_by": proposed_by,
+                "go_release_date": go_release_date,
+                "aopwiki_snapshot_date": aopwiki_snapshot_date,
             }
 
             for field_name, field_value in update_data.items():
@@ -3514,6 +3546,10 @@ class ReactomeMappingModel:
         proposed_basis: Optional[str] = None,
         proposed_specificity: Optional[str] = None,
         proposed_coverage: Optional[str] = None,
+        # Phase C — source-data versioning kwargs; nullable, stamped from manifest.
+        reactome_release_version: Optional[str] = None,
+        reactome_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
     ) -> Optional[int]:
         """Create a new KE-Reactome mapping"""
         mapping_uuid = str(uuid_lib.uuid4())
@@ -3529,14 +3565,18 @@ class ReactomeMappingModel:
                      confidence_level, suggestion_score, created_by, uuid,
                      proposed_relationship, proposed_basis,
                      proposed_specificity, proposed_coverage,
-                     assessment_version)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     assessment_version,
+                     reactome_release_version, reactome_release_date,
+                     aopwiki_snapshot_date)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (ke_id, ke_title, reactome_id, pathway_name, species,
                  confidence_level, suggestion_score, created_by, mapping_uuid,
                  proposed_relationship, proposed_basis,
                  proposed_specificity, proposed_coverage,
-                 assessment_version),
+                 assessment_version,
+                 reactome_release_version, reactome_release_date,
+                 aopwiki_snapshot_date),
             )
             conn.commit()
             logger.info(
@@ -3561,6 +3601,10 @@ class ReactomeMappingModel:
         proposal_id: int,
         approved_by_curator: str,
         approved_at_curator: str = None,
+        # Phase C — source-data versioning kwargs; nullable, stamped from manifest.
+        reactome_release_version: Optional[str] = None,
+        reactome_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
     ) -> Optional[int]:
         """Create an approved KE-Reactome mapping in a single INSERT.
 
@@ -3639,6 +3683,11 @@ class ReactomeMappingModel:
                 'created_by', 'uuid',
                 'approved_by_curator', 'approved_at_curator', 'proposed_by',
                 'assessment_version',
+                # Phase C source-data versioning columns. Stamped from the
+                # deployed manifest, NOT carried from the proposal — so they
+                # ride the fixed-cols path even though they're nullable.
+                'reactome_release_version', 'reactome_release_date',
+                'aopwiki_snapshot_date',
             )
             fixed_values = (
                 ke_id, ke_title, reactome_id,
@@ -3646,6 +3695,8 @@ class ReactomeMappingModel:
                 mapping_uuid,
                 approved_by_curator, approved_at_curator, proposed_by,
                 assessment_version,
+                reactome_release_version, reactome_release_date,
+                aopwiki_snapshot_date,
             )
 
             all_cols = fixed_cols + tuple(carry_cols)

--- a/src/services/container.py
+++ b/src/services/container.py
@@ -86,6 +86,7 @@ class ServiceContainer:
         self._go_hierarchy = None
         self._go_bp_metadata = None
         self._go_mf_metadata = None
+        self._source_versions = None  # Phase C — lazy-loaded data/source_versions.json
 
         logger.info("Service container initialized")
 
@@ -194,6 +195,90 @@ class ServiceContainer:
                 except Exception as e:
                     logger.warning("Failed to load ke_aop_membership.json: %s", e)
         return self._ke_aop_membership
+
+    @property
+    def source_versions(self):
+        """
+        Load and cache the upstream source-versions manifest.
+
+        Phase C of source-data versioning (DMP §7). The manifest is written by
+        scripts/capture_source_versions.py and travels with the snapshot at
+        data/source_versions.json. New approvals are stamped with the current
+        snapshot's versions via `source_version_fields_for(resource)` below.
+
+        Returns the parsed manifest dict, or `{}` if the file is missing or
+        unreadable — that case logs a warning but does not fail startup
+        (mappings just get NULL version columns until the manifest exists).
+        """
+        if self._source_versions is None:
+            path = os.path.join(PROJECT_ROOT, 'data', 'source_versions.json')
+            if os.path.exists(path):
+                try:
+                    with open(path, 'r', encoding='utf-8') as f:
+                        self._source_versions = json.load(f)
+                    sources = self._source_versions.get('sources', {})
+                    ok = [k for k, v in sources.items() if v.get('status') == 'ok']
+                    logger.info(
+                        "Loaded source_versions.json: %d/%d sources OK (%s)",
+                        len(ok), len(sources), ', '.join(sorted(ok)) or 'none',
+                    )
+                except Exception as e:
+                    logger.warning("Failed to load source_versions.json: %s", e)
+                    self._source_versions = {}
+            else:
+                logger.warning(
+                    "source_versions.json not found at %s — new approvals will "
+                    "have NULL version columns until the manifest is generated "
+                    "(run `make capture-versions`).",
+                    path,
+                )
+                self._source_versions = {}
+        return self._source_versions
+
+    def source_version_fields_for(self, resource: str) -> dict:
+        """
+        Return the kwargs dict to stamp on a newly-approved mapping of `resource`.
+
+        `resource` is one of {"wp", "go", "reactome"}. The returned dict contains
+        column-name → value entries suitable for passing directly into the
+        relevant `create_mapping` / `update_mapping` / `create_approved_mapping`
+        call. Sources whose manifest status is not "ok" (or missing entirely)
+        are silently omitted, so the corresponding column stays NULL.
+
+        Every resource also stamps `aopwiki_snapshot_date` (the KE side of the
+        mapping is anchored in AOP-Wiki regardless of the molecular resource).
+
+        Returns `{}` if the manifest is empty or all relevant sources are
+        unknown — the caller can `**unpack` the result safely either way.
+        """
+        manifest = self.source_versions
+        sources = manifest.get('sources', {}) if manifest else {}
+
+        fields = {}
+        aopwiki = sources.get('aopwiki', {})
+        if aopwiki.get('status') == 'ok' and aopwiki.get('snapshot_date'):
+            fields['aopwiki_snapshot_date'] = aopwiki['snapshot_date']
+
+        if resource == 'wp':
+            wp = sources.get('wikipathways', {})
+            if wp.get('status') == 'ok' and wp.get('release_date'):
+                fields['wp_release_date'] = wp['release_date']
+        elif resource == 'go':
+            go = sources.get('gene_ontology', {})
+            if go.get('status') == 'ok' and go.get('release_date'):
+                fields['go_release_date'] = go['release_date']
+        elif resource == 'reactome':
+            rx = sources.get('reactome', {})
+            if rx.get('status') == 'ok':
+                if rx.get('release_version'):
+                    fields['reactome_release_version'] = rx['release_version']
+                if rx.get('release_date'):
+                    fields['reactome_release_date'] = rx['release_date']
+        else:
+            raise ValueError(
+                f"Unknown resource {resource!r}; expected 'wp', 'go', or 'reactome'"
+            )
+        return fields
 
     @property
     def ker_adjacency(self):

--- a/tests/test_source_version_stamping.py
+++ b/tests/test_source_version_stamping.py
@@ -1,0 +1,328 @@
+"""Source-data versioning Phase C — approval-time stamping tests.
+
+Two layers:
+
+1. Container — `source_versions` property handles missing / malformed manifests
+   gracefully, and `source_version_fields_for(resource)` returns the right
+   per-resource kwargs dict (skipping `unknown` upstreams so columns stay
+   NULL rather than erroring).
+
+2. Model — `create_mapping` / `create_approved_mapping` / `update_mapping`
+   accept the new version kwargs and persist them in the new schema columns
+   added by Phase B.
+
+The full admin-route approval flow is exercised by the existing integration
+tests in test_assessment_roundtrip_*.py and test_reactome_admin.py, which
+already cover the proposal-to-mapping pipeline; we add a minimal smoke test
+here that goes through the container helper and writes directly via the
+model to keep this test module focused on the new wiring.
+"""
+import json
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from src.core.models import (
+    Database,
+    GoMappingModel,
+    MappingModel,
+    ReactomeMappingModel,
+    ReactomeProposalModel,
+)
+
+
+# ---------- Container `source_versions` property ----------
+
+def _make_container(tmp_path: Path, manifest: dict | None):
+    """Mint a bare ServiceContainer with the manifest path overridden."""
+    from src.services.container import ServiceContainer
+
+    class _StubConfig:
+        DATABASE_PATH = str(tmp_path / "test.db")
+
+    c = ServiceContainer(_StubConfig())
+
+    # Redirect the container's manifest lookup at the tmp_path directory.
+    # ServiceContainer.source_versions hard-codes the path under PROJECT_ROOT,
+    # so we monkeypatch the relevant module-level constant in-place.
+    import src.services.container as cont_mod
+
+    if manifest is None:
+        # Caller wants the "manifest missing" case — point PROJECT_ROOT at an
+        # empty directory so the existence check returns False.
+        missing_root = tmp_path / "empty"
+        missing_root.mkdir()
+        c._project_root_override = missing_root
+        original_project_root = cont_mod.PROJECT_ROOT
+        cont_mod.PROJECT_ROOT = str(missing_root)
+        return c, lambda: setattr(cont_mod, "PROJECT_ROOT", original_project_root)
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "source_versions.json").write_text(json.dumps(manifest), encoding="utf-8")
+    original_project_root = cont_mod.PROJECT_ROOT
+    cont_mod.PROJECT_ROOT = str(tmp_path)
+    return c, lambda: setattr(cont_mod, "PROJECT_ROOT", original_project_root)
+
+
+_ALL_OK_MANIFEST = {
+    "captured_at": "2026-05-14T21:00:00Z",
+    "sources": {
+        "wikipathways": {
+            "status": "ok", "release_date": "2026-05-10",
+        },
+        "gene_ontology": {
+            "status": "ok", "release_date": "2026-01-23",
+        },
+        "reactome": {
+            "status": "ok",
+            "release_version": "96", "release_date": "2026-03-25",
+        },
+        "aopwiki": {
+            "status": "ok", "snapshot_date": "2026-05-06",
+        },
+    },
+}
+
+
+def test_source_versions_returns_empty_dict_when_file_missing(tmp_path):
+    container, undo = _make_container(tmp_path, manifest=None)
+    try:
+        assert container.source_versions == {}
+        # And the resource-resolver returns an empty dict — caller can `**unpack` it.
+        for resource in ("wp", "go", "reactome"):
+            assert container.source_version_fields_for(resource) == {}
+    finally:
+        undo()
+
+
+def test_source_versions_returns_empty_dict_when_file_unreadable(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "source_versions.json").write_text("not valid json{", encoding="utf-8")
+    import src.services.container as cont_mod
+
+    class _StubConfig:
+        DATABASE_PATH = str(tmp_path / "x.db")
+
+    container = cont_mod.ServiceContainer(_StubConfig())
+    original = cont_mod.PROJECT_ROOT
+    cont_mod.PROJECT_ROOT = str(tmp_path)
+    try:
+        assert container.source_versions == {}
+    finally:
+        cont_mod.PROJECT_ROOT = original
+
+
+def test_source_version_fields_for_wp(tmp_path):
+    container, undo = _make_container(tmp_path, manifest=_ALL_OK_MANIFEST)
+    try:
+        out = container.source_version_fields_for("wp")
+        assert out == {
+            "wp_release_date": "2026-05-10",
+            "aopwiki_snapshot_date": "2026-05-06",
+        }
+    finally:
+        undo()
+
+
+def test_source_version_fields_for_go(tmp_path):
+    container, undo = _make_container(tmp_path, manifest=_ALL_OK_MANIFEST)
+    try:
+        out = container.source_version_fields_for("go")
+        assert out == {
+            "go_release_date": "2026-01-23",
+            "aopwiki_snapshot_date": "2026-05-06",
+        }
+    finally:
+        undo()
+
+
+def test_source_version_fields_for_reactome(tmp_path):
+    container, undo = _make_container(tmp_path, manifest=_ALL_OK_MANIFEST)
+    try:
+        out = container.source_version_fields_for("reactome")
+        assert out == {
+            "reactome_release_version": "96",
+            "reactome_release_date": "2026-03-25",
+            "aopwiki_snapshot_date": "2026-05-06",
+        }
+    finally:
+        undo()
+
+
+def test_source_version_fields_skips_unknown_sources(tmp_path):
+    """A source flagged 'unknown' in the manifest is omitted from the result dict."""
+    manifest = {
+        "captured_at": "now",
+        "sources": {
+            "wikipathways": {"status": "unknown", "reason": "endpoint down"},
+            "gene_ontology": {"status": "ok", "release_date": "2026-01-23"},
+            "reactome": {"status": "ok", "release_version": "96"},
+            "aopwiki": {"status": "ok", "snapshot_date": "2026-05-06"},
+        },
+    }
+    container, undo = _make_container(tmp_path, manifest=manifest)
+    try:
+        # WP is unknown so only the AOP-Wiki anchor is stamped for WP approvals.
+        wp = container.source_version_fields_for("wp")
+        assert wp == {"aopwiki_snapshot_date": "2026-05-06"}
+        # Reactome OK but without release_date — version still surfaces.
+        rx = container.source_version_fields_for("reactome")
+        assert rx == {
+            "reactome_release_version": "96",
+            "aopwiki_snapshot_date": "2026-05-06",
+        }
+    finally:
+        undo()
+
+
+def test_source_version_fields_unknown_resource_raises(tmp_path):
+    container, undo = _make_container(tmp_path, manifest=_ALL_OK_MANIFEST)
+    try:
+        with pytest.raises(ValueError, match="Unknown resource"):
+            container.source_version_fields_for("orcid")
+    finally:
+        undo()
+
+
+# ---------- Model — kwargs persist into the new columns ----------
+
+@pytest.fixture
+def db(tmp_path):
+    return Database(str(tmp_path / "k.db"))
+
+
+def test_wp_create_mapping_persists_version_columns(db):
+    mm = MappingModel(db)
+    mid = mm.create_mapping(
+        ke_id="KE 100", ke_title="t", wp_id="WP100", wp_title="t",
+        created_by="u",
+        wp_release_date="2026-05-10",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    assert mid is not None
+    conn = sqlite3.connect(db.db_path)
+    row = conn.execute(
+        "SELECT wp_release_date, aopwiki_snapshot_date FROM mappings WHERE id = ?",
+        (mid,),
+    ).fetchone()
+    conn.close()
+    assert row == ("2026-05-10", "2026-05-06")
+
+
+def test_wp_update_mapping_persists_version_columns(db):
+    mm = MappingModel(db)
+    mid = mm.create_mapping(
+        ke_id="KE 101", ke_title="t", wp_id="WP101", wp_title="t", created_by="u",
+    )
+    assert mid is not None
+    ok = mm.update_mapping(
+        mapping_id=mid,
+        approved_by_curator="admin",
+        approved_at_curator="2026-05-14T21:00:00",
+        wp_release_date="2026-05-10",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    assert ok is True
+    conn = sqlite3.connect(db.db_path)
+    row = conn.execute(
+        "SELECT wp_release_date, aopwiki_snapshot_date FROM mappings WHERE id = ?",
+        (mid,),
+    ).fetchone()
+    conn.close()
+    assert row == ("2026-05-10", "2026-05-06")
+
+
+def test_go_create_mapping_persists_version_columns(db):
+    gm = GoMappingModel(db)
+    mid = gm.create_mapping(
+        ke_id="KE 102", ke_title="t", go_id="GO:0000001", go_name="t",
+        created_by="u",
+        go_release_date="2026-01-23",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    assert mid is not None
+    conn = sqlite3.connect(db.db_path)
+    row = conn.execute(
+        "SELECT go_release_date, aopwiki_snapshot_date FROM ke_go_mappings "
+        "WHERE id = ?",
+        (mid,),
+    ).fetchone()
+    conn.close()
+    assert row == ("2026-01-23", "2026-05-06")
+
+
+def test_reactome_create_approved_mapping_persists_version_columns(db):
+    rm = ReactomeMappingModel(db)
+    rpm = ReactomeProposalModel(db)
+    # Create a pending new-pair proposal so create_approved_mapping has
+    # carry-fields to read (it loads ke_id/title/reactome_id/etc. from the
+    # proposal row internally — Phase 25 H-1 single-INSERT carry path).
+    proposal_id = rpm.create_new_pair_reactome_proposal(
+        ke_id="KE 200", ke_title="t",
+        reactome_id="R-HSA-200", pathway_name="t",
+        confidence_level="high",
+        provider_username="github:u",
+    )
+    assert proposal_id is not None and proposal_id != "duplicate_pending"
+
+    mid = rm.create_approved_mapping(
+        proposal_id=proposal_id,
+        approved_by_curator="admin",
+        approved_at_curator="2026-05-14T21:00:00",
+        reactome_release_version="96",
+        reactome_release_date="2026-03-25",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    assert mid is not None
+    conn = sqlite3.connect(db.db_path)
+    row = conn.execute(
+        "SELECT reactome_release_version, reactome_release_date, "
+        "aopwiki_snapshot_date FROM ke_reactome_mappings WHERE id = ?",
+        (mid,),
+    ).fetchone()
+    conn.close()
+    assert row == ("96", "2026-03-25", "2026-05-06")
+
+
+def test_reactome_create_mapping_persists_version_columns(db):
+    """The non-approval `create_mapping` path on Reactome also accepts the kwargs."""
+    rm = ReactomeMappingModel(db)
+    mid = rm.create_mapping(
+        ke_id="KE 201", ke_title="t",
+        reactome_id="R-HSA-201", pathway_name="t",
+        created_by="u",
+        reactome_release_version="96",
+        reactome_release_date="2026-03-25",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    assert mid is not None
+    conn = sqlite3.connect(db.db_path)
+    row = conn.execute(
+        "SELECT reactome_release_version, reactome_release_date, "
+        "aopwiki_snapshot_date FROM ke_reactome_mappings WHERE id = ?",
+        (mid,),
+    ).fetchone()
+    conn.close()
+    assert row == ("96", "2026-03-25", "2026-05-06")
+
+
+def test_omitting_version_kwargs_leaves_columns_null(db):
+    """Backwards compatibility — existing callers that don't pass the new
+    kwargs continue to work, with NULL in the new columns."""
+    mm = MappingModel(db)
+    mid = mm.create_mapping(
+        ke_id="KE 300", ke_title="t", wp_id="WP300", wp_title="t", created_by="u",
+    )
+    assert mid is not None
+    conn = sqlite3.connect(db.db_path)
+    row = conn.execute(
+        "SELECT wp_release_date, aopwiki_snapshot_date FROM mappings WHERE id = ?",
+        (mid,),
+    ).fetchone()
+    conn.close()
+    assert row == (None, None)


### PR DESCRIPTION
## Summary

Third slice of **source-data versioning** (DMP §7). Wires the running app to read `data/source_versions.json` at boot and stamp every new approval with the current snapshot's upstream release info — populating the columns added by Phase B (#171).

After this PR ships, every approval going forward records exactly which upstream release each side of the mapping was anchored to. Backfilling the **existing** rows is Phase D.

## Surface area

### `src/services/container.py`
- New `source_versions` property — lazy-loads `data/source_versions.json` at first access. Missing file / parse error → `{}` + warning log (does not fail startup; approvals get NULL version columns instead).
- New `source_version_fields_for(resource)` helper — takes `"wp" | "go" | "reactome"` and returns a kwargs dict ready to `**unpack` into the model write methods. Every resource also stamps `aopwiki_snapshot_date` (KE side is always anchored in AOP-Wiki). Unknown-status sources are silently omitted from the result.

### `src/core/models.py`
- `MappingModel.create_mapping` + `update_mapping` accept `wp_release_date`, `aopwiki_snapshot_date`. INSERT list and ALLOWED_FIELDS whitelist + update_data dict extended.
- `GoMappingModel.create_mapping` + `update_go_mapping` accept `go_release_date`, `aopwiki_snapshot_date` with the same pattern.
- `ReactomeMappingModel.create_approved_mapping` and `create_mapping` accept `reactome_release_version`, `reactome_release_date`, `aopwiki_snapshot_date`. The Phase 25 single-INSERT carry path rides these as additional `fixed_cols` (they come from the *deployed manifest*, not from the proposal — sitting alongside approval-context columns rather than `REACTOME_PROPOSAL_CARRY_FIELDS`).

### `src/blueprints/admin.py`
- New `_source_version_fields(resource)` blueprint helper wraps the container call with a `try/except` fallback. If the container is unavailable for any reason the approval still goes through; the mapping just gets NULL version columns + a log line.
- Threaded through all three approval handlers: `approve_proposal` (WP, both new-pair create + update path AND revision update path), `approve_go_proposal`, `approve_reactome_proposal`.

## Tests

`tests/test_source_version_stamping.py` — 13 cases:

- Container `source_versions` graceful handling of missing / malformed manifest files
- `source_version_fields_for` per-resource shape (wp / go / reactome)
- Skipping unknown-status sources from the resolved fields dict
- ValueError on unknown resource name
- Per-model kwarg round-trips (5 model entry points)
- Backwards compatibility — callers that omit the new kwargs continue to work, columns stay NULL

Full suite: **356 passed** (was 343 after Phase B), coverage **51.58%** (floor 40).

## Live verification

App boot:
```
Loaded source_versions.json: 4/4 sources OK (aopwiki, gene_ontology, reactome, wikipathways)
```

Container helper resolves cleanly:
- `wp`  → `{'wp_release_date': '2026-05-10', 'aopwiki_snapshot_date': '2026-05-06'}`
- `go`  → `{'go_release_date': '2026-01-23', 'aopwiki_snapshot_date': '2026-05-06'}`
- `reactome`  → `{'reactome_release_version': '96', 'reactome_release_date': '2026-03-25', 'aopwiki_snapshot_date': '2026-05-06'}`

## What this PR deliberately does *not* do

- **Backfill** existing rows (Phase D — needs the hand-curated release calendar).
- **Surface** versions in the UI / exporters / Zenodo metadata (Phase E).
- **Modify proposals** — version capture happens at *approval* time from the deployed snapshot, not at proposal time. Proposals carry their existing assessment + carry fields unchanged.

## Test plan

- [x] Container reads `source_versions.json` at boot.
- [x] Helper returns correct fields per resource.
- [x] Each of the 5 model write methods persists the new kwargs to its respective columns.
- [x] Existing call sites that omit the new kwargs still work (NULL).
- [x] Full suite 356 passing, coverage 51.58%.
- [ ] After merge: deploy + smoke-test an approval through the live admin UI; verify the new row in `mappings` has `wp_release_date` and `aopwiki_snapshot_date` populated.