### PR TITLE
feat(versioning): backfill existing mappings with current snapshot (Phase D)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint run docker-build docker-run clean capture-versions
+.PHONY: help install test lint run docker-build docker-run clean capture-versions backfill-versions
 
 help:		## Show this help
 	@echo "Available targets:"
@@ -42,6 +42,9 @@ go-hierarchy:	## Build GO hierarchy data (IC scores, ancestors, depths)
 
 capture-versions:	## Refresh data/source_versions.json from WP / GO / Reactome / AOP-Wiki
 	python scripts/capture_source_versions.py
+
+backfill-versions:	## One-shot: stamp current snapshot's versions onto NULL columns on all existing mappings (idempotent; --dry-run via DRY=1)
+	python scripts/backfill_source_versions.py $(if $(DRY),--dry-run,)
 
 clean:		## Clean up generated files
 	rm -rf __pycache__

--- a/scripts/backfill_source_versions.py
+++ b/scripts/backfill_source_versions.py
@@ -1,0 +1,225 @@
+"""
+Backfill upstream source-version columns on existing mapping rows.
+
+Phase D of source-data versioning (DMP §7). Phase C stamps the deployed
+snapshot's versions onto every new approval, but rows approved before
+Phase C shipped have NULL version columns. This script fills those NULLs
+with the *current* snapshot's values, using `data/source_versions.json`
+as the source of truth.
+
+This is the simplest possible backfill: every legacy row gets the same
+versions, regardless of when it was approved. Downstream consumers can
+treat these stamps as "the snapshot the dataset reached parity with at
+backfill time" rather than per-row historical accuracy. A future
+hand-curated release-calendar backfill could replace this with
+per-row nearest-release lookups if needed.
+
+The script is idempotent — only NULL columns are filled, so re-running
+is a no-op. Use --dry-run to preview the SQL and row counts without
+applying any changes.
+
+Usage:
+    python scripts/backfill_source_versions.py                 # default db
+    python scripts/backfill_source_versions.py --db /tmp/k.db  # explicit
+    python scripts/backfill_source_versions.py --dry-run       # preview
+    python scripts/backfill_source_versions.py --manifest path # alt manifest
+
+Exit codes:
+    0  backfill completed (or dry-run completed)
+    1  config / file error (manifest missing, db missing, malformed)
+    2  manifest has insufficient data for any mapping table
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = _PROJECT_ROOT / "data" / "source_versions.json"
+DEFAULT_DB = _PROJECT_ROOT / "ke_wp_mapping.db"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)s  %(message)s")
+log = logging.getLogger("backfill_source_versions")
+
+
+# ---------- manifest loading ----------
+
+def _load_manifest(path: Path) -> dict:
+    if not path.exists():
+        raise FileNotFoundError(f"manifest not found at {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise ValueError(f"manifest is not valid JSON: {e}") from e
+
+
+def _ok(source: dict) -> bool:
+    return isinstance(source, dict) and source.get("status") == "ok"
+
+
+def _values_for_table(manifest: dict, table: str) -> Optional[dict]:
+    """
+    Resolve the column -> value dict to backfill for a given mapping table.
+
+    Returns None if the manifest doesn't have enough info for this table
+    (e.g. the WikiPathways source is 'unknown' and the AOP-Wiki anchor is
+    missing — there's nothing useful to write).
+    """
+    sources = manifest.get("sources", {}) if manifest else {}
+    aopwiki = sources.get("aopwiki", {})
+    aopwiki_date = aopwiki.get("snapshot_date") if _ok(aopwiki) else None
+
+    if table == "mappings":
+        wp = sources.get("wikipathways", {})
+        wp_date = wp.get("release_date") if _ok(wp) else None
+        if not wp_date and not aopwiki_date:
+            return None
+        return {"wp_release_date": wp_date, "aopwiki_snapshot_date": aopwiki_date}
+
+    if table == "ke_go_mappings":
+        go = sources.get("gene_ontology", {})
+        go_date = go.get("release_date") if _ok(go) else None
+        if not go_date and not aopwiki_date:
+            return None
+        return {"go_release_date": go_date, "aopwiki_snapshot_date": aopwiki_date}
+
+    if table == "ke_reactome_mappings":
+        rx = sources.get("reactome", {})
+        rx_version = rx.get("release_version") if _ok(rx) else None
+        rx_date = rx.get("release_date") if _ok(rx) else None
+        if not rx_version and not rx_date and not aopwiki_date:
+            return None
+        return {
+            "reactome_release_version": rx_version,
+            "reactome_release_date": rx_date,
+            "aopwiki_snapshot_date": aopwiki_date,
+        }
+
+    raise ValueError(f"Unknown table {table!r}")
+
+
+# ---------- backfill ----------
+
+def _count_null_rows(conn: sqlite3.Connection, table: str, columns: list[str]) -> int:
+    """Count rows where ANY of the named columns is currently NULL."""
+    where = " OR ".join(f"{col} IS NULL" for col in columns)
+    return conn.execute(f"SELECT COUNT(*) FROM {table} WHERE {where}").fetchone()[0]
+
+
+def _backfill_table(conn: sqlite3.Connection, table: str, fields: dict, dry_run: bool) -> tuple[int, int]:
+    """
+    Backfill NULLs on `table` with the given column -> value dict.
+
+    Uses COALESCE so each column is updated only if it's currently NULL —
+    rows with some columns already populated keep those values. The WHERE
+    clause restricts the update to rows where at least one of the relevant
+    columns is NULL, so re-running on a fully-stamped table is a no-op.
+
+    Returns (rows_targeted, rows_affected). In a dry run rows_affected is 0.
+    """
+    # Drop any fields where the manifest had no value — we can only fill
+    # columns we actually have data for.
+    fields = {k: v for k, v in fields.items() if v is not None}
+    if not fields:
+        log.info("%s: no fields to fill (manifest has no values for this table)", table)
+        return 0, 0
+
+    cols = list(fields.keys())
+    targeted = _count_null_rows(conn, table, cols)
+    if targeted == 0:
+        log.info("%s: 0 rows need backfill (already fully stamped)", table)
+        return 0, 0
+
+    set_clauses = [f"{col} = COALESCE({col}, ?)" for col in cols]
+    where_clauses = [f"{col} IS NULL" for col in cols]
+    set_values = [fields[col] for col in cols]
+
+    sql = (
+        f"UPDATE {table} SET {', '.join(set_clauses)} "
+        f"WHERE {' OR '.join(where_clauses)}"
+    )
+
+    log.info(
+        "%s: %d rows targeted (any-of %s NULL) -> %s",
+        table, targeted, cols, ", ".join(f"{c}={fields[c]!r}" for c in cols),
+    )
+    log.debug("SQL: %s ; params=%s", sql, set_values)
+
+    if dry_run:
+        log.info("  [dry-run] no changes written")
+        return targeted, 0
+
+    cursor = conn.execute(sql, set_values)
+    affected = cursor.rowcount
+    log.info("  -> %d rows updated", affected)
+    return targeted, affected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--manifest", type=Path, default=DEFAULT_MANIFEST,
+        help=f"Path to source-versions manifest (default: {DEFAULT_MANIFEST.relative_to(_PROJECT_ROOT)})",
+    )
+    parser.add_argument(
+        "--db", type=Path, default=DEFAULT_DB,
+        help=f"Path to the SQLite database (default: {DEFAULT_DB.relative_to(_PROJECT_ROOT) if str(DEFAULT_DB).startswith(str(_PROJECT_ROOT)) else DEFAULT_DB})",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without writing")
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = _load_manifest(args.manifest)
+    except (FileNotFoundError, ValueError) as e:
+        log.error(str(e))
+        return 1
+
+    if not args.db.exists():
+        log.error("database not found at %s", args.db)
+        return 1
+
+    log.info("Backfilling %s from %s%s",
+             args.db, args.manifest, " (dry-run)" if args.dry_run else "")
+
+    conn = sqlite3.connect(str(args.db), timeout=30)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute("PRAGMA busy_timeout=5000;")
+
+    total_targeted = 0
+    total_affected = 0
+    no_data_tables = []
+    try:
+        for table in ("mappings", "ke_go_mappings", "ke_reactome_mappings"):
+            fields = _values_for_table(manifest, table)
+            if fields is None:
+                log.warning("%s: manifest has no data to backfill this table — skipping", table)
+                no_data_tables.append(table)
+                continue
+            t, a = _backfill_table(conn, table, fields, args.dry_run)
+            total_targeted += t
+            total_affected += a
+        if not args.dry_run:
+            conn.commit()
+    finally:
+        conn.close()
+
+    log.info(
+        "Done: %d rows %s%s",
+        total_targeted if args.dry_run else total_affected,
+        "would be updated" if args.dry_run else "updated",
+        f" (across {3 - len(no_data_tables)} tables)" if no_data_tables else "",
+    )
+
+    if len(no_data_tables) == 3:
+        log.error("Manifest has no usable data for any mapping table")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backfill_source_versions.py
+++ b/tests/test_backfill_source_versions.py
@@ -1,0 +1,224 @@
+"""Tests for scripts/backfill_source_versions.py (Phase D).
+
+Each test spins up a fresh `Database(tmp_path)` (which runs the Phase B
+migrations so the version columns exist), inserts a couple of legacy
+rows with NULL version columns via raw sqlite3, then invokes the
+backfill script's `main()` and asserts row counts + persisted values.
+"""
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts import backfill_source_versions as bf
+from src.core.models import Database
+
+_OK_MANIFEST = {
+    "captured_at": "2026-05-15T00:00:00Z",
+    "sources": {
+        "wikipathways": {"status": "ok", "release_date": "2026-05-10"},
+        "gene_ontology": {"status": "ok", "release_date": "2026-01-23"},
+        "reactome": {
+            "status": "ok",
+            "release_version": "96",
+            "release_date": "2026-03-25",
+        },
+        "aopwiki": {"status": "ok", "snapshot_date": "2026-05-06"},
+    },
+}
+
+
+# ---------- fixtures ----------
+
+@pytest.fixture
+def manifest_path(tmp_path: Path, request) -> Path:
+    """Write the requested manifest to a tmp file. Defaults to _OK_MANIFEST."""
+    manifest = getattr(request, "param", _OK_MANIFEST)
+    p = tmp_path / "source_versions.json"
+    p.write_text(json.dumps(manifest), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    """Fresh DB with Phase B migrations applied."""
+    return Database(str(tmp_path / "k.db"))
+
+
+def _seed_legacy_rows(db_path: str) -> None:
+    """Insert one row per mapping table with NULL version columns."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO mappings (ke_id, ke_title, wp_id, wp_title, "
+            "connection_type, confidence_level, created_by) "
+            "VALUES ('KE 1', 't', 'WP1', 't', 'causative', 'high', 'u')"
+        )
+        conn.execute(
+            "INSERT INTO ke_go_mappings (ke_id, ke_title, go_id, go_name, "
+            "connection_type, confidence_level, created_by) "
+            "VALUES ('KE 2', 't', 'GO:0000001', 't', 'causative', 'high', 'u')"
+        )
+        conn.execute(
+            "INSERT INTO ke_reactome_mappings (ke_id, ke_title, reactome_id, "
+            "pathway_name, confidence_level, created_by) "
+            "VALUES ('KE 3', 't', 'R-HSA-1', 't', 'high', 'u')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_version_cols(db_path: str) -> dict:
+    """Pull the version columns from each mapping table's first row."""
+    conn = sqlite3.connect(db_path)
+    try:
+        wp = conn.execute(
+            "SELECT wp_release_date, aopwiki_snapshot_date FROM mappings LIMIT 1"
+        ).fetchone()
+        go = conn.execute(
+            "SELECT go_release_date, aopwiki_snapshot_date FROM ke_go_mappings LIMIT 1"
+        ).fetchone()
+        rx = conn.execute(
+            "SELECT reactome_release_version, reactome_release_date, "
+            "aopwiki_snapshot_date FROM ke_reactome_mappings LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    return {"mappings": wp, "ke_go_mappings": go, "ke_reactome_mappings": rx}
+
+
+# ---------- happy path ----------
+
+def test_backfill_fills_all_three_tables(db: Database, manifest_path: Path) -> None:
+    _seed_legacy_rows(db.db_path)
+    rc = bf.main(["--manifest", str(manifest_path), "--db", db.db_path])
+    assert rc == 0
+    vals = _read_version_cols(db.db_path)
+    assert vals["mappings"] == ("2026-05-10", "2026-05-06")
+    assert vals["ke_go_mappings"] == ("2026-01-23", "2026-05-06")
+    assert vals["ke_reactome_mappings"] == ("96", "2026-03-25", "2026-05-06")
+
+
+def test_dry_run_does_not_write(db: Database, manifest_path: Path) -> None:
+    _seed_legacy_rows(db.db_path)
+    rc = bf.main(["--manifest", str(manifest_path), "--db", db.db_path, "--dry-run"])
+    assert rc == 0
+    vals = _read_version_cols(db.db_path)
+    # All columns still NULL after dry-run.
+    assert vals["mappings"] == (None, None)
+    assert vals["ke_go_mappings"] == (None, None)
+    assert vals["ke_reactome_mappings"] == (None, None, None)
+
+
+def test_backfill_is_idempotent(db: Database, manifest_path: Path) -> None:
+    _seed_legacy_rows(db.db_path)
+    # First pass — updates 30 rows
+    rc1 = bf.main(["--manifest", str(manifest_path), "--db", db.db_path])
+    assert rc1 == 0
+    # Second pass — 0 changes
+    rc2 = bf.main(["--manifest", str(manifest_path), "--db", db.db_path])
+    assert rc2 == 0
+    # Values unchanged.
+    vals = _read_version_cols(db.db_path)
+    assert vals["mappings"] == ("2026-05-10", "2026-05-06")
+
+
+def test_backfill_preserves_already_stamped_rows(db: Database, manifest_path: Path) -> None:
+    """Rows that already have non-NULL version columns must not be overwritten."""
+    conn = sqlite3.connect(db.db_path)
+    try:
+        # Row already has wp_release_date populated.
+        conn.execute(
+            "INSERT INTO mappings (ke_id, ke_title, wp_id, wp_title, "
+            "connection_type, confidence_level, created_by, "
+            "wp_release_date) "
+            "VALUES ('KE 99', 't', 'WP99', 't', 'causative', 'high', 'u', "
+            "'2025-12-15')"
+        )
+        # Another row fully populated.
+        conn.execute(
+            "INSERT INTO mappings (ke_id, ke_title, wp_id, wp_title, "
+            "connection_type, confidence_level, created_by, "
+            "wp_release_date, aopwiki_snapshot_date) "
+            "VALUES ('KE 100', 't', 'WP100', 't', 'causative', 'high', 'u', "
+            "'2025-12-15', '2025-12-20')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    bf.main(["--manifest", str(manifest_path), "--db", db.db_path])
+
+    conn = sqlite3.connect(db.db_path)
+    try:
+        rows = conn.execute(
+            "SELECT ke_id, wp_release_date, aopwiki_snapshot_date "
+            "FROM mappings ORDER BY ke_id"
+        ).fetchall()
+    finally:
+        conn.close()
+    # KE 99 keeps its existing wp_release_date but gains the AOP-Wiki date
+    # (which was previously NULL).
+    assert ("KE 99", "2025-12-15", "2026-05-06") in rows
+    # KE 100 untouched on both columns.
+    assert ("KE 100", "2025-12-15", "2025-12-20") in rows
+
+
+# ---------- manifest variants ----------
+
+@pytest.mark.parametrize(
+    "manifest_path",
+    [
+        {  # WP unknown — should backfill only the AOP-Wiki anchor on `mappings`.
+            "sources": {
+                "wikipathways": {"status": "unknown", "reason": "down"},
+                "gene_ontology": {"status": "ok", "release_date": "2026-01-23"},
+                "reactome": {"status": "ok", "release_version": "96"},
+                "aopwiki": {"status": "ok", "snapshot_date": "2026-05-06"},
+            }
+        },
+    ],
+    indirect=True,
+)
+def test_unknown_source_still_backfills_aopwiki_anchor(db: Database, manifest_path: Path) -> None:
+    _seed_legacy_rows(db.db_path)
+    rc = bf.main(["--manifest", str(manifest_path), "--db", db.db_path])
+    assert rc == 0
+    vals = _read_version_cols(db.db_path)
+    # WP column stays NULL because the manifest entry was 'unknown', but the
+    # AOP-Wiki anchor is filled in.
+    assert vals["mappings"] == (None, "2026-05-06")
+
+
+@pytest.mark.parametrize(
+    "manifest_path",
+    [
+        {  # All sources unknown — script reports failure (exit 2).
+            "sources": {
+                "wikipathways": {"status": "unknown"},
+                "gene_ontology": {"status": "unknown"},
+                "reactome": {"status": "unknown"},
+                "aopwiki": {"status": "unknown"},
+            }
+        },
+    ],
+    indirect=True,
+)
+def test_all_unknown_manifest_returns_2(db: Database, manifest_path: Path) -> None:
+    _seed_legacy_rows(db.db_path)
+    rc = bf.main(["--manifest", str(manifest_path), "--db", db.db_path])
+    assert rc == 2
+
+
+def test_missing_manifest_returns_1(db: Database, tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.json"
+    rc = bf.main(["--manifest", str(missing), "--db", db.db_path])
+    assert rc == 1
+
+
+def test_missing_db_returns_1(manifest_path: Path, tmp_path: Path) -> None:
+    missing_db = tmp_path / "does-not-exist.db"
+    rc = bf.main(["--manifest", str(manifest_path), "--db", str(missing_db)])
+    assert rc == 1


### PR DESCRIPTION
## Summary

Fourth slice of **source-data versioning** (DMP §7). Adds `scripts/backfill_source_versions.py` — a one-shot script that fills NULL upstream-version columns on every existing mapping row with the **current snapshot's** values from `data/source_versions.json`.

Per the user's "for now, just add the same versions for backfill" decision: this is the simplest possible backfill — every legacy row gets the same versions, regardless of when it was approved. Downstream consumers can treat these stamps as *"the snapshot the dataset reached parity with at backfill time"* rather than per-row historical accuracy. A future hand-curated release-calendar backfill could refine this with per-row nearest-release lookups when needed.

## Behaviour

- Reads `data/source_versions.json` and groups its `ok` sources by mapping table (WP → `mappings`, GO → `ke_go_mappings`, Reactome → `ke_reactome_mappings`; AOP-Wiki anchor stamps all three).
- Per table: `UPDATE ... SET col = COALESCE(col, ?) WHERE col IS NULL OR ...` — already-populated rows are preserved, only NULLs get filled.
- **Idempotent** — re-running on a fully-stamped table is a no-op.
- Sources flagged `unknown` in the manifest are skipped; their column stays NULL.
- `--dry-run` prints targeted row counts and SQL without writing.
- `--db` / `--manifest` overrides for non-default locations.

## CLI

```bash
make backfill-versions               # standard run
make backfill-versions DRY=1         # dry-run preview
python scripts/backfill_source_versions.py --dry-run
python scripts/backfill_source_versions.py --db /path/to/k.db --manifest /path/to/manifest.json
```

**Exit codes:** `0` ok · `1` config / file error · `2` manifest has no usable data for any table.

## Live verification

Backfilled a tmp copy of the prod-shape local DB twice:

```
--- pass 1 (real) ---
mappings: 27 rows targeted -> wp_release_date='2026-05-10', aopwiki_snapshot_date='2026-05-06'
  -> 27 rows updated
ke_go_mappings: 3 rows targeted -> go_release_date='2026-01-23', aopwiki_snapshot_date='2026-05-06'
  -> 3 rows updated
ke_reactome_mappings: 0 rows need backfill (already fully stamped)
Done: 30 rows updated

--- pass 2 (idempotent re-run) ---
mappings: 0 rows need backfill (already fully stamped)
ke_go_mappings: 0 rows need backfill (already fully stamped)
ke_reactome_mappings: 0 rows need backfill (already fully stamped)
Done: 0 rows updated
```

## Tests

`tests/test_backfill_source_versions.py` — 8 cases:

- Happy path across all three tables (values land in the right columns)
- `--dry-run` does not write
- Idempotency (second run targets 0 rows)
- Preservation of already-stamped rows (values not overwritten; NULLs in *other* columns still filled)
- Partial manifest — `unknown` WP still fills AOP-Wiki anchor
- All-unknown manifest → exit `2`
- Missing manifest → exit `1`
- Missing DB → exit `1`

Full suite: **364 passed** (was 356 after Phase C), coverage **51.58%**.

## Deployment

After merge, run **once** against the production DB:

```bash
ssh tgx1 'docker exec $(docker ps -qf name=molaop-builder) python /app/scripts/backfill_source_versions.py --dry-run'
# Review the row counts, then:
ssh tgx1 'docker exec $(docker ps -qf name=molaop-builder) python /app/scripts/backfill_source_versions.py'
```

Subsequent re-runs are safe (idempotent) — they'll only touch rows that still have NULL version columns (e.g. mappings approved before Phase C was running, or rows imported through some other path).

## Test plan

- [x] All three tables backfilled correctly against a tmp prod-shape DB.
- [x] Already-stamped rows preserved.
- [x] Idempotency verified (second pass targets 0 rows).
- [x] Full suite 364 passing.
- [ ] After merge: dry-run against production, then real run.

## What this PR deliberately does *not* do

- **Surface** the versions in the UI / exporters / Zenodo metadata (Phase E).
- **Wire into init_db()** as an auto-migration — the backfill is operator-triggered intentionally, so production changes happen on a controlled rollout.