### PR TITLE
feat(versioning): surface source versions in JSON + Turtle exports (Phase E.1)

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1626,7 +1626,10 @@ class MappingModel:
                        -- positional consumers append at end (Pitfall 5)
                        proposed_relationship, proposed_basis,
                        proposed_specificity, proposed_coverage,
-                       assessment_version
+                       assessment_version,
+                       -- Phase E.1 source-data versioning columns. Same
+                       -- positional-append rule as the Phase 34 fields.
+                       wp_release_date, aopwiki_snapshot_date
                 FROM mappings
                 ORDER BY created_at DESC
             """
@@ -2538,7 +2541,9 @@ class GoMappingModel:
                        connection_type, confidence_level, evidence_code, created_by, created_at, updated_at,
                        uuid, approved_by_curator, approved_at_curator, proposed_by,
                        connection_score, specificity_score, evidence_score, assessment_version,
-                       suggestion_score
+                       suggestion_score,
+                       -- Phase E.1 source-data versioning columns.
+                       go_release_date, aopwiki_snapshot_date
                 FROM ke_go_mappings
                 ORDER BY created_at DESC
             """
@@ -3763,7 +3768,10 @@ class ReactomeMappingModel:
                        -- positional consumers append at end (Pitfall 5)
                        proposed_relationship, proposed_basis,
                        proposed_specificity, proposed_coverage,
-                       assessment_version
+                       assessment_version,
+                       -- Phase E.1 source-data versioning columns.
+                       reactome_release_version, reactome_release_date,
+                       aopwiki_snapshot_date
                 FROM ke_reactome_mappings
                 ORDER BY created_at DESC
                 """

--- a/src/exporters/json_exporter.py
+++ b/src/exporters/json_exporter.py
@@ -22,13 +22,14 @@ class JSONExporter:
         try:
             # Get all mappings
             cursor = conn.execute("""
-                SELECT id, ke_id, ke_title, wp_id, wp_title, connection_type, 
-                       confidence_level, created_by, created_at, updated_at
-                FROM mappings 
+                SELECT id, ke_id, ke_title, wp_id, wp_title, connection_type,
+                       confidence_level, created_by, created_at, updated_at,
+                       wp_release_date, aopwiki_snapshot_date
+                FROM mappings
                 ORDER BY created_at DESC
             """)
             mappings = [dict(row) for row in cursor.fetchall()]
-            
+
             # Build comprehensive JSON structure
             export_data = {
                 "dataset_info": {
@@ -102,9 +103,19 @@ class JSONExporter:
                             "description": "Timestamp when mapping was created (ISO 8601 format)"
                         },
                         {
-                            "name": "updated_at", 
+                            "name": "updated_at",
                             "type": "datetime",
                             "description": "Timestamp when mapping was last updated (ISO 8601 format)"
+                        },
+                        {
+                            "name": "wp_release_date",
+                            "type": "date",
+                            "description": "WikiPathways release the mapping was approved against (ISO YYYY-MM-DD). NULL on rows approved before source-data versioning was rolled out. See data/source_versions.json for the current snapshot."
+                        },
+                        {
+                            "name": "aopwiki_snapshot_date",
+                            "type": "date",
+                            "description": "AOP-Wiki snapshot the KE side of the mapping was anchored to at approval time (ISO YYYY-MM-DD). NULL on legacy rows."
                         }
                     ]
                 },
@@ -133,13 +144,14 @@ class JSONExporter:
         try:
             # Get all mappings
             cursor = conn.execute("""
-                SELECT id, ke_id, ke_title, wp_id, wp_title, connection_type, 
-                       confidence_level, created_by, created_at, updated_at
-                FROM mappings 
+                SELECT id, ke_id, ke_title, wp_id, wp_title, connection_type,
+                       confidence_level, created_by, created_at, updated_at,
+                       wp_release_date, aopwiki_snapshot_date
+                FROM mappings
                 ORDER BY created_at DESC
             """)
             mappings = [dict(row) for row in cursor.fetchall()]
-            
+
             # Build JSON-LD structure with schema.org and custom vocabularies
             json_ld = {
                 "@context": {

--- a/src/exporters/rdf_exporter.py
+++ b/src/exporters/rdf_exporter.py
@@ -76,6 +76,24 @@ def generate_ke_wp_turtle(mappings, min_confidence=None) -> str:
                 Literal(float(row["suggestion_score"]), datatype=XSD.decimal),
             ))
 
+        # Phase E.1: upstream snapshot provenance per mapping.
+        # `wpReleaseDate` is the WikiPathways release the curator was reviewing
+        # at approval time; `aopWikiSnapshotDate` is the AOP-Wiki snapshot the
+        # KE side was anchored to. Both are nullable (legacy rows that pre-date
+        # the backfill have NULL — emit nothing for those).
+        if row.get("wp_release_date"):
+            g.add((
+                uri,
+                VOCAB.wpReleaseDate,
+                Literal(row["wp_release_date"], datatype=XSD.date),
+            ))
+        if row.get("aopwiki_snapshot_date"):
+            g.add((
+                uri,
+                VOCAB.aopWikiSnapshotDate,
+                Literal(row["aopwiki_snapshot_date"], datatype=XSD.date),
+            ))
+
     return g.serialize(format="turtle")
 
 
@@ -143,6 +161,21 @@ def generate_ke_go_turtle(mappings, min_confidence=None) -> str:
 
         if row.get("go_namespace"):
             g.add((uri, VOCAB.goNamespace, Literal(row["go_namespace"])))
+
+        # Phase E.1: upstream snapshot provenance per mapping. See the
+        # corresponding block in generate_ke_wp_turtle for shape rationale.
+        if row.get("go_release_date"):
+            g.add((
+                uri,
+                VOCAB.goReleaseDate,
+                Literal(row["go_release_date"], datatype=XSD.date),
+            ))
+        if row.get("aopwiki_snapshot_date"):
+            g.add((
+                uri,
+                VOCAB.aopWikiSnapshotDate,
+                Literal(row["aopwiki_snapshot_date"], datatype=XSD.date),
+            ))
 
     return g.serialize(format="turtle")
 
@@ -221,5 +254,26 @@ def generate_ke_reactome_turtle(mappings, min_confidence=None, reactome_metadata
             meta = reactome_metadata.get(row["reactome_id"])
             if meta and meta.get("description"):
                 g.add((uri, VOCAB.pathwayDescription, Literal(meta["description"])))
+
+        # Phase E.1: upstream snapshot provenance per mapping. Reactome
+        # carries both an integer release version and a release date.
+        if row.get("reactome_release_version"):
+            g.add((
+                uri,
+                VOCAB.reactomeReleaseVersion,
+                Literal(row["reactome_release_version"]),
+            ))
+        if row.get("reactome_release_date"):
+            g.add((
+                uri,
+                VOCAB.reactomeReleaseDate,
+                Literal(row["reactome_release_date"], datatype=XSD.date),
+            ))
+        if row.get("aopwiki_snapshot_date"):
+            g.add((
+                uri,
+                VOCAB.aopWikiSnapshotDate,
+                Literal(row["aopwiki_snapshot_date"], datatype=XSD.date),
+            ))
 
     return g.serialize(format="turtle")

--- a/tests/test_source_version_exports.py
+++ b/tests/test_source_version_exports.py
@@ -1,0 +1,231 @@
+"""Source-data versioning Phase E.1 — exporter surface tests.
+
+Verifies that the upstream source-version columns added in Phase B and
+stamped by Phase C / D actually flow through to:
+
+- MappingModel / GoMappingModel / ReactomeMappingModel.get_all_mappings()
+- The Turtle exporters (per-row vocab triples)
+- The JSON exporter (schema fields + per-row values)
+"""
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.core.models import (
+    Database,
+    GoMappingModel,
+    MappingModel,
+    ReactomeMappingModel,
+    ReactomeProposalModel,
+)
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    return Database(str(tmp_path / "k.db"))
+
+
+# ---------- get_all_mappings returns the new columns ----------
+
+def test_wp_get_all_mappings_returns_version_columns(db):
+    mm = MappingModel(db)
+    mm.create_mapping(
+        ke_id="KE 1", ke_title="t", wp_id="WP1", wp_title="t", created_by="u",
+        wp_release_date="2026-05-10",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    rows = mm.get_all_mappings()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["wp_release_date"] == "2026-05-10"
+    assert row["aopwiki_snapshot_date"] == "2026-05-06"
+
+
+def test_go_get_all_mappings_returns_version_columns(db):
+    gm = GoMappingModel(db)
+    gm.create_mapping(
+        ke_id="KE 2", ke_title="t", go_id="GO:0001", go_name="t",
+        created_by="u",
+        go_release_date="2026-01-23",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    rows = gm.get_all_mappings()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["go_release_date"] == "2026-01-23"
+    assert row["aopwiki_snapshot_date"] == "2026-05-06"
+
+
+def test_reactome_get_all_mappings_returns_version_columns(db):
+    rpm = ReactomeProposalModel(db)
+    rm = ReactomeMappingModel(db)
+    pid = rpm.create_new_pair_reactome_proposal(
+        ke_id="KE 3", ke_title="t", reactome_id="R-HSA-3", pathway_name="t",
+        confidence_level="high", provider_username="github:u",
+    )
+    rm.create_approved_mapping(
+        proposal_id=pid, approved_by_curator="admin",
+        approved_at_curator="2026-05-14T21:00:00",
+        reactome_release_version="96",
+        reactome_release_date="2026-03-25",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    rows = rm.get_all_mappings()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["reactome_release_version"] == "96"
+    assert row["reactome_release_date"] == "2026-03-25"
+    assert row["aopwiki_snapshot_date"] == "2026-05-06"
+
+
+def test_legacy_rows_have_null_version_columns(db):
+    """Rows created without the new kwargs surface NULL in the new fields."""
+    mm = MappingModel(db)
+    mm.create_mapping(
+        ke_id="KE 10", ke_title="t", wp_id="WP10", wp_title="t", created_by="u",
+    )
+    rows = mm.get_all_mappings()
+    assert rows[0]["wp_release_date"] is None
+    assert rows[0]["aopwiki_snapshot_date"] is None
+
+
+# ---------- Turtle exporters emit version triples ----------
+
+def test_ke_wp_turtle_emits_version_triples(db):
+    from src.exporters.rdf_exporter import generate_ke_wp_turtle
+
+    mm = MappingModel(db)
+    mm.create_mapping(
+        ke_id="KE 1", ke_title="oxidative stress", wp_id="WP1", wp_title="apoptosis",
+        confidence_level="high", created_by="u",
+        wp_release_date="2026-05-10",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    ttl = generate_ke_wp_turtle(mm.get_all_mappings())
+    assert "wpReleaseDate" in ttl
+    assert "2026-05-10" in ttl
+    assert "aopWikiSnapshotDate" in ttl
+    assert "2026-05-06" in ttl
+
+
+def test_ke_wp_turtle_skips_null_version_triples(db):
+    """A mapping without version data must not emit empty/Null triples."""
+    from src.exporters.rdf_exporter import generate_ke_wp_turtle
+
+    mm = MappingModel(db)
+    mm.create_mapping(
+        ke_id="KE 2", ke_title="t", wp_id="WP2", wp_title="t",
+        confidence_level="high", created_by="u",
+    )
+    ttl = generate_ke_wp_turtle(mm.get_all_mappings())
+    assert "wpReleaseDate" not in ttl
+    assert "aopWikiSnapshotDate" not in ttl
+
+
+def test_ke_go_turtle_emits_version_triples(db):
+    from src.exporters.rdf_exporter import generate_ke_go_turtle
+
+    gm = GoMappingModel(db)
+    gm.create_mapping(
+        ke_id="KE 5", ke_title="t", go_id="GO:0006915", go_name="apoptotic process",
+        confidence_level="high", created_by="u",
+        go_release_date="2026-01-23",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    ttl = generate_ke_go_turtle(gm.get_all_mappings())
+    assert "goReleaseDate" in ttl
+    assert "2026-01-23" in ttl
+    assert "aopWikiSnapshotDate" in ttl
+    assert "2026-05-06" in ttl
+
+
+def test_ke_reactome_turtle_emits_version_triples(db):
+    from src.exporters.rdf_exporter import generate_ke_reactome_turtle
+
+    rpm = ReactomeProposalModel(db)
+    rm = ReactomeMappingModel(db)
+    pid = rpm.create_new_pair_reactome_proposal(
+        ke_id="KE 7", ke_title="t", reactome_id="R-HSA-7", pathway_name="t",
+        confidence_level="high", provider_username="github:u",
+    )
+    rm.create_approved_mapping(
+        proposal_id=pid, approved_by_curator="admin",
+        approved_at_curator="2026-05-14T21:00:00",
+        reactome_release_version="96",
+        reactome_release_date="2026-03-25",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+    ttl = generate_ke_reactome_turtle(rm.get_all_mappings())
+    assert "reactomeReleaseVersion" in ttl
+    assert "96" in ttl
+    assert "reactomeReleaseDate" in ttl
+    assert "2026-03-25" in ttl
+    assert "aopWikiSnapshotDate" in ttl
+    assert "2026-05-06" in ttl
+
+
+def test_turtle_round_trip_with_rdflib(db):
+    """Generated Turtle parses cleanly with rdflib (no malformed output)."""
+    from rdflib import Graph
+    from src.exporters.rdf_exporter import generate_ke_wp_turtle
+
+    mm = MappingModel(db)
+    mm.create_mapping(
+        ke_id="KE 1", ke_title="t", wp_id="WP1", wp_title="t",
+        confidence_level="high", created_by="u",
+        wp_release_date="2026-05-10", aopwiki_snapshot_date="2026-05-06",
+    )
+    ttl = generate_ke_wp_turtle(mm.get_all_mappings())
+    g = Graph().parse(data=ttl, format="turtle")
+    # Look for the two new predicates by IRI.
+    from rdflib import URIRef
+    wp_release = URIRef("https://ke-wp-mapping.org/vocab#wpReleaseDate")
+    aop_snap = URIRef("https://ke-wp-mapping.org/vocab#aopWikiSnapshotDate")
+    assert any(p == wp_release for _, p, _ in g)
+    assert any(p == aop_snap for _, p, _ in g)
+
+
+# ---------- JSON exporter includes the new fields ----------
+
+def test_json_export_includes_version_fields_in_data_schema(db, monkeypatch):
+    """The data_schema.fields block advertises the new columns to downstream
+    consumers (so they can pick them up by name from the JSON envelope)."""
+    from src.exporters.json_exporter import JSONExporter
+
+    # JSONExporter needs a metadata manager — patch with a minimal stub.
+    class _StubMeta:
+        metadata = {"version": "test"}
+
+        def get_current_metadata(self):
+            return {}
+
+    mm = MappingModel(db)
+    mm.create_mapping(
+        ke_id="KE 1", ke_title="t", wp_id="WP1", wp_title="t", created_by="u",
+        wp_release_date="2026-05-10",
+        aopwiki_snapshot_date="2026-05-06",
+    )
+
+    # JSONExporter signature varies; instantiate via attribute injection to
+    # avoid coupling the test to its constructor surface.
+    exporter = JSONExporter.__new__(JSONExporter)
+    exporter.db = db
+    exporter.metadata = _StubMeta()
+    # Stub the helper methods this test doesn't exercise.
+    exporter._get_provenance_info = lambda: {}
+    exporter._generate_statistics = lambda mappings: {"count": len(mappings)}
+
+    raw = exporter.export(include_metadata=False, include_provenance=False)
+    payload = json.loads(raw)
+
+    field_names = {f["name"] for f in payload["data_schema"]["fields"]}
+    assert "wp_release_date" in field_names
+    assert "aopwiki_snapshot_date" in field_names
+
+    # And the actual row values are present.
+    assert len(payload["mappings"]) == 1
+    row = payload["mappings"][0]
+    assert row["wp_release_date"] == "2026-05-10"
+    assert row["aopwiki_snapshot_date"] == "2026-05-06"


### PR DESCRIPTION
## Summary

Fifth slice of **source-data versioning** (DMP §7). Threads the upstream-release columns (added in Phase B, populated by Phase C and D) through the model SELECTs and the **load-bearing exporters** — JSON envelope + Turtle — so downstream consumers can pin their analyses against a specific upstream release.

E.1 deliberately keeps scope to the formats where per-row version provenance is *load-bearing* for downstream analysis. The user-visible surfaces (landing badge, Downloads cards, Stats, Zenodo metadata) land in E.2.

## What's wired through

### Model `get_all_mappings` SELECTs

| Model | Added columns |
|---|---|
| `MappingModel` | `wp_release_date`, `aopwiki_snapshot_date` |
| `GoMappingModel` | `go_release_date`, `aopwiki_snapshot_date` |
| `ReactomeMappingModel` | `reactome_release_version`, `reactome_release_date`, `aopwiki_snapshot_date` |

All appended at end per the Phase 34 ASMT-08 positional-consumer rule (existing index-based consumers don't shift).

### Turtle (`rdf_exporter.py`)

New per-mapping predicates:

- KE-WP: `vocab#wpReleaseDate` (`xsd:date`), `vocab#aopWikiSnapshotDate` (`xsd:date`)
- KE-GO: `vocab#goReleaseDate`, `vocab#aopWikiSnapshotDate`
- KE-Reactome: `vocab#reactomeReleaseVersion` (plain literal — integer release number), `vocab#reactomeReleaseDate`, `vocab#aopWikiSnapshotDate`

Legacy rows with NULL columns emit **no** triple (rather than an empty literal) — preserves backward compat for SPARQL consumers that filter on presence.

### JSON (`json_exporter.py`)

- Both `export()` and `export_json_ld()` SELECTs include the WP-side version columns.
- `data_schema.fields` block adds two new entries (`type: "date"`) so consumers can pick the fields up by name from the envelope without reading source.

## Out of scope (deferred to E.2)

- **GMT exporters** — GMT spec has no comment-line convention; header decoration would break strict fgsea / clusterProfiler parsers. Version provenance for GMT consumers lives in the Zenodo deposit README.
- **Excel / Parquet exporters** — auto-pick up the columns via dict iteration but are informational; verifying + documenting their shape is E.2.
- **Landing page / Downloads / Stats / Zenodo metadata** — all UI-surface work for E.2.
- **KE-GO and KE-Reactome JSON exporter paths** — only WP path is currently wired through `json_exporter.py`; siblings will follow when needed.

## Tests

`tests/test_source_version_exports.py` — 10 cases:

- Each `get_all_mappings` returns the new columns
- Legacy rows surface NULL in the new fields (backward compat)
- Each Turtle generator emits the expected predicates + values
- Turtle output round-trips through `rdflib` cleanly
- NULL-column rows don't emit empty triples
- JSON `data_schema.fields` advertises the new fields
- JSON `mappings` per-row entries carry the values

Full suite: **366 passed** (was 356 after Phase D), coverage **52.43%** (up from 51.58%).

## Test plan

- [x] All three `get_all_mappings` return the new columns.
- [x] Turtle emits the right predicates with `xsd:date` datatypes.
- [x] Turtle round-trips through `rdflib` without error.
- [x] JSON envelope includes the new fields in both `data_schema.fields` and per-row mappings.
- [x] Legacy NULL rows don't emit empty triples / produce empty values.
- [ ] After merge: smoke test a Turtle download via `/exports/rdf/ke-wp` and confirm `wpReleaseDate` triples on backfilled rows.