### PR TITLE
feat(versioning): surface source versions in UI + Zenodo deposits (Phase E.2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -264,6 +264,28 @@ def create_app(config_name: str = None):
             pass
         return {"zenodo_meta": {}}
 
+    @app.context_processor
+    def inject_source_versions():
+        """
+        Inject the upstream source-versions manifest globally so templates
+        can display the snapshot the running container is serving.
+
+        Surfaced as `source_versions` in every template. Built from the
+        same data/source_versions.json file that approval-time stamping
+        reads (Phase C); reading it directly here instead of through the
+        service container so the context processor stays a pure read with
+        no service-graph dependency.
+        """
+        import json as _json
+        from pathlib import Path as _Path
+        try:
+            path = _Path("data/source_versions.json")
+            if path.exists():
+                return {"source_versions": _json.loads(path.read_text())}
+        except Exception:
+            pass
+        return {"source_versions": {}}
+
     # Register blueprints
     app.register_blueprint(main_bp)
     app.register_blueprint(auth_bp)

--- a/scripts/publish_zenodo.py
+++ b/scripts/publish_zenodo.py
@@ -93,7 +93,8 @@ def _changes_significant(current: dict, last: Optional[dict], min_delta: int) ->
 
 # ---------- deposit assembly ----------
 
-def _build_resource_zip(prefix: str, gmt_fn, ttl_fn, mappings: list, today: str, gmt_kwargs=None) -> bytes:
+def _build_resource_zip(prefix: str, gmt_fn, ttl_fn, mappings: list, today: str,
+                         gmt_kwargs=None, source_versions_slice: dict | None = None) -> bytes:
     buf = io.BytesIO()
     gmt_kwargs = gmt_kwargs or {}
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
@@ -104,10 +105,62 @@ def _build_resource_zip(prefix: str, gmt_fn, ttl_fn, mappings: list, today: str,
         ttl_content = ttl_fn(mappings)
         if ttl_content:
             zf.writestr(f"{prefix}/{prefix.lower()}-mappings.ttl", ttl_content)
+        # Phase E.2: emit a source_versions.json sidecar inside each per-resource
+        # ZIP so GMT-only consumers (clusterProfiler / fgsea users) can still
+        # pin against an upstream release without reading the Turtle export.
+        if source_versions_slice:
+            zf.writestr(
+                f"{prefix}/source_versions.json",
+                json.dumps(source_versions_slice, indent=2, ensure_ascii=False) + "\n",
+            )
     return buf.getvalue()
 
 
-def _build_readme(today: str, wp_n: dict, go_n: dict, rx_n: dict) -> bytes:
+def _slice_source_versions(manifest: dict, *resources: str) -> dict:
+    """Return a manifest slice containing only the named upstream resources.
+
+    `manifest` is the parsed data/source_versions.json. Resources are the
+    keys in `manifest["sources"]` (e.g. "wikipathways", "aopwiki"). Used
+    by `_build_resource_zip` to attach a per-resource sidecar without
+    leaking unrelated sources into each ZIP.
+    """
+    if not manifest:
+        return {}
+    sources = manifest.get("sources", {})
+    slice_sources = {k: sources[k] for k in resources if k in sources}
+    if not slice_sources:
+        return {}
+    return {
+        "captured_at": manifest.get("captured_at"),
+        "sources": slice_sources,
+    }
+
+
+def _format_versions_for_prose(manifest: dict) -> str:
+    """One-line summary like 'WP 2026-05-10 · GO 2026-01-23 · ...' for prose.
+
+    Returns the empty string if no source is in OK state — callers should
+    branch on truthiness to avoid emitting an awkward bare colon.
+    """
+    sources = (manifest or {}).get("sources", {})
+    tokens = []
+    if sources.get("wikipathways", {}).get("status") == "ok":
+        tokens.append(f"WP {sources['wikipathways'].get('release_date', '?')}")
+    if sources.get("gene_ontology", {}).get("status") == "ok":
+        tokens.append(f"GO {sources['gene_ontology'].get('release_date', '?')}")
+    rx = sources.get("reactome", {})
+    if rx.get("status") == "ok":
+        token = f"Reactome v{rx.get('release_version', '?')}"
+        if rx.get("release_date"):
+            token += f" ({rx['release_date']})"
+        tokens.append(token)
+    if sources.get("aopwiki", {}).get("status") == "ok":
+        tokens.append(f"AOP-Wiki {sources['aopwiki'].get('snapshot_date', '?')}")
+    return " · ".join(tokens)
+
+
+def _build_readme(today: str, wp_n: dict, go_n: dict, rx_n: dict, source_versions: dict | None = None) -> bytes:
+    snapshot_table = _format_snapshot_table_md(source_versions)
     return (
         f"""# Molecular AOP Builder — Curated KE → WikiPathways / GO / Reactome Mappings
 
@@ -132,6 +185,7 @@ Each archive expands to a folder containing:
 
 - `*_{{YYYY-MM-DD}}_{{Level}}.gmt` — Gene Matrix Transposed (GMT) gene-set files, one row per KE → pathway/GO mapping. Gene identifiers are HGNC symbols. Loadable directly by clusterProfiler (`enricher()`) and fgsea (`gmtPathways()`).
 - `*-mappings.ttl` — RDF / Turtle serialisation with full provenance for every approved mapping for that resource: proposer, approving curator, approval timestamp, BioBERT suggestion score, confidence level, connection type. Suitable for SPARQL queries and ontology integration.
+- `source_versions.json` — snapshot manifest pinning this archive to a specific release of each upstream resource (e.g. WikiPathways 2026-05-10, AOP-Wiki 2026-05-06). Mappings approved before the source-versioning rollout have NULL fields on the row itself; the manifest documents the snapshot the dataset reached parity with at backfill time.
 
 ## Confidence levels
 
@@ -152,6 +206,12 @@ A `_<Level>.gmt` file appears only if there is at least one mapping at that leve
 - Reactome IDs follow stable identifiers (`R-HSA-#######`)
 - Every mapping carries a stable UUID, visible in the RDF/Turtle export and in the `/api/v1/...` REST endpoints on the live builder.
 
+## Upstream resource snapshot
+
+This deposit was assembled against the following upstream releases. The same versions are recorded per-mapping in the Turtle exports (predicates `vocab#wpReleaseDate`, `vocab#goReleaseDate`, `vocab#reactomeReleaseVersion`, `vocab#reactomeReleaseDate`, `vocab#aopWikiSnapshotDate`) and as a sidecar `source_versions.json` inside each per-resource ZIP.
+
+{snapshot_table}
+
 ## Citation
 
 If you use these mappings, please cite this Zenodo record (the concept DOI always resolves to the latest version) and acknowledge the upstream resources: AOP-Wiki, WikiPathways, the Gene Ontology Consortium / UniProt-GOA, and Reactome.
@@ -159,22 +219,57 @@ If you use these mappings, please cite this Zenodo record (the concept DOI alway
     ).encode("utf-8")
 
 
-def _build_metadata(today: str) -> dict:
+def _format_snapshot_table_md(manifest: dict | None) -> str:
+    """Markdown table of the source-version manifest, or a fallback note."""
+    sources = (manifest or {}).get("sources", {})
+    if not sources:
+        return "_Snapshot manifest unavailable for this deposit._"
+
+    rows = ["| Resource | Release | Captured |", "|----------|---------|----------|"]
+    _labels = [
+        ("wikipathways", "WikiPathways", "release_date"),
+        ("gene_ontology", "Gene Ontology", "release_date"),
+        ("reactome", "Reactome", None),
+        ("aopwiki", "AOP-Wiki", "snapshot_date"),
+    ]
+    for key, label, primary in _labels:
+        entry = sources.get(key, {})
+        if entry.get("status") != "ok":
+            value = "_unknown_"
+        elif key == "reactome":
+            v = f"v{entry.get('release_version', '?')}"
+            if entry.get("release_date"):
+                v += f" ({entry['release_date']})"
+            value = v
+        else:
+            value = entry.get(primary, "—")
+        captured = (entry.get("captured_at") or "")[:10] or "—"
+        rows.append(f"| {label} | {value} | {captured} |")
+    return "\n".join(rows)
+
+
+def _build_metadata(today: str, source_versions: dict | None = None) -> dict:
+    snapshot_line = _format_versions_for_prose(source_versions)
+    description = (
+        "Curated database of Key Event (KE) mappings to three molecular-pathway and ontology "
+        "resources: WikiPathways (KE-WikiPathways), Gene Ontology Biological Process and "
+        "Molecular Function (KE-GO), and Reactome (KE-Reactome). Mappings are bundled in three "
+        "per-resource ZIP archives, each containing GMT gene-set files split by confidence "
+        "level (All / High / Medium / Low) for clusterProfiler and fgsea, and RDF/Turtle for "
+        "SPARQL and linked-data consumption. Each mapping carries a stable UUID and full "
+        "curation provenance (proposer, approving curator, approval timestamp, BioBERT "
+        "suggestion score, confidence level, connection type). "
+    )
+    if snapshot_line:
+        description += f"Upstream snapshot for this deposit: {snapshot_line}. "
+    description += (
+        "Produced by the Molecular AOP Builder at https://molaop-builder.vhp4safety.nl ; "
+        "source at https://github.com/marvinm2/KE-WP-mapping ."
+    )
     return {
         "title": "Molecular AOP Builder — Curated KE → WikiPathways / GO / Reactome Mappings",
         "upload_type": "dataset",
-        "description": (
-            "Curated database of Key Event (KE) mappings to three molecular-pathway and ontology "
-            "resources: WikiPathways (KE-WikiPathways), Gene Ontology Biological Process and "
-            "Molecular Function (KE-GO), and Reactome (KE-Reactome). Mappings are bundled in three "
-            "per-resource ZIP archives, each containing GMT gene-set files split by confidence "
-            "level (All / High / Medium / Low) for clusterProfiler and fgsea, and RDF/Turtle for "
-            "SPARQL and linked-data consumption. Each mapping carries a stable UUID and full "
-            "curation provenance (proposer, approving curator, approval timestamp, BioBERT "
-            "suggestion score, confidence level, connection type). "
-            "Produced by the Molecular AOP Builder at https://molaop-builder.vhp4safety.nl ; "
-            "source at https://github.com/marvinm2/KE-WP-mapping ."
-        ),
+        "description": description,
         "creators": [{
             "name": "Martens, Marvin",
             "affiliation": "Department of Translational Genomics, Maastricht University",
@@ -332,20 +427,44 @@ def main() -> int:
                 log.info("[SKIP] Mapping counts unchanged since last deposit — nothing to do")
                 return 0
 
+            # Phase E.2: load the upstream source-versions manifest so each
+            # per-resource ZIP gets a sidecar pinning it to a specific
+            # snapshot, and the README + Zenodo description reference the
+            # same versions. Missing or unreadable manifest is degraded
+            # gracefully — deposit still publishes, just without the
+            # snapshot block.
+            source_versions = {}
+            sv_path = Path("data/source_versions.json")
+            try:
+                if sv_path.exists():
+                    source_versions = json.loads(sv_path.read_text(encoding="utf-8"))
+                    log.info("Loaded source_versions manifest from %s", sv_path)
+                else:
+                    log.warning("source_versions.json not found at %s — deposit will omit snapshot block", sv_path)
+            except Exception as e:
+                log.warning("Could not parse source_versions.json: %s — deposit will omit snapshot block", e)
+
             # Build deposit contents
             files = {
                 "KE-WikiPathways.zip": _build_resource_zip(
                     "KE-WikiPathways", generate_ke_wp_gmt, generate_ke_wp_turtle, wp, today,
                     gmt_kwargs={"cache_model": a.cache_model_ref},
+                    source_versions_slice=_slice_source_versions(source_versions, "wikipathways", "aopwiki"),
                 ),
-                "KE-GO.zip":       _build_resource_zip("KE-GO", generate_ke_go_gmt, generate_ke_go_turtle, go, today),
-                "KE-Reactome.zip": _build_resource_zip("KE-Reactome", generate_ke_reactome_gmt, generate_ke_reactome_turtle, rx, today),
-                "README.md":       _build_readme(today, wp_n, go_n, rx_n),
+                "KE-GO.zip":       _build_resource_zip(
+                    "KE-GO", generate_ke_go_gmt, generate_ke_go_turtle, go, today,
+                    source_versions_slice=_slice_source_versions(source_versions, "gene_ontology", "aopwiki"),
+                ),
+                "KE-Reactome.zip": _build_resource_zip(
+                    "KE-Reactome", generate_ke_reactome_gmt, generate_ke_reactome_turtle, rx, today,
+                    source_versions_slice=_slice_source_versions(source_versions, "reactome", "aopwiki"),
+                ),
+                "README.md":       _build_readme(today, wp_n, go_n, rx_n, source_versions=source_versions),
             }
             for name, blob in files.items():
                 log.info("Assembled %s (%d bytes)", name, len(blob))
 
-            metadata = _build_metadata(today)
+            metadata = _build_metadata(today, source_versions=source_versions)
 
             if args.dry_run:
                 log.info("[DRY-RUN] Would publish a new version under existing_id=%s with %d file(s).",

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -304,6 +304,20 @@ html, body {
     color: var(--color-text-muted);
 }
 
+.site-footer__snapshot {
+    color: var(--color-text-muted);
+    font-size: 0.85em;
+}
+.site-footer__snapshot-link {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px dotted var(--color-border-light);
+}
+.site-footer__snapshot-link:hover {
+    color: var(--color-primary-blue);
+    border-bottom-color: var(--color-primary-blue);
+}
+
 /* DataTables specific */
 .dt-center {
     text-align: center;

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -17,6 +17,22 @@
       <span class="site-footer__doi">DOI: <a href="https://doi.org/{{ zenodo_meta.doi }}" target="_blank" rel="noopener">{{ zenodo_meta.concept_doi or zenodo_meta.doi }}</a></span>
       <span class="site-footer__sep">&middot;</span>
       {% endif %}
+      {# Phase E.2: snapshot block. Compact, four short tokens, one per
+         upstream — link to /stats for the full picture. Hidden entirely
+         if no manifest is present (the context processor returns {}). #}
+      {% set _sv = (source_versions.sources if source_versions else {}) %}
+      {% if _sv %}
+        <span class="site-footer__snapshot" title="Upstream resource snapshot the running container is serving. Click for details.">
+          <a href="/stats#source-versions" class="site-footer__snapshot-link">
+            <strong>Snapshot:</strong>
+            {%- if _sv.wikipathways and _sv.wikipathways.status == 'ok' %} WP&nbsp;{{ _sv.wikipathways.release_date }}{% endif %}
+            {%- if _sv.gene_ontology and _sv.gene_ontology.status == 'ok' %} &middot; GO&nbsp;{{ _sv.gene_ontology.release_date }}{% endif %}
+            {%- if _sv.reactome and _sv.reactome.status == 'ok' %} &middot; Reactome&nbsp;v{{ _sv.reactome.release_version }}{% endif %}
+            {%- if _sv.aopwiki and _sv.aopwiki.status == 'ok' %} &middot; AOP-Wiki&nbsp;{{ _sv.aopwiki.snapshot_date }}{% endif %}
+          </a>
+        </span>
+        <span class="site-footer__sep">&middot;</span>
+      {% endif %}
       <span class="site-footer__version">&copy; {{ now().year if now is defined else '2026' }} Molecular AOP Builder</span>
     </div>
   </div>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -60,6 +60,66 @@
         </tbody>
     </table>
 
+    <!-- Phase E.2: Upstream source-version snapshot table. Anchored as
+         #source-versions so the site-footer snapshot link lands here. -->
+    <h2 id="source-versions" style="font-size:18px;margin-bottom:8px;">Upstream resource snapshot</h2>
+    <p class="text-muted" style="font-size:14px;margin-bottom:16px;">
+        The release of each upstream resource the running container is currently serving.
+        New approvals are stamped with these values on the approved mapping row,
+        so downstream consumers can pin analyses against a specific upstream release.
+        See <a href="https://github.com/marvinm2/KE-WP-mapping/blob/main/docs/DMP.md" target="_blank" rel="noopener">DMP §2.4</a> for the rationale.
+    </p>
+    {% set _sv = (source_versions.sources if source_versions else {}) %}
+    {% if _sv %}
+    <table style="width:100%;border-collapse:collapse;margin-bottom:32px;max-width:720px;">
+        <thead>
+            <tr>
+                <th style="padding:10px 14px;text-align:left;">Resource</th>
+                <th style="padding:10px 14px;text-align:left;">Release</th>
+                <th style="padding:10px 14px;text-align:left;">Method</th>
+                <th style="padding:10px 14px;text-align:left;">Captured</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% set _resource_labels = [
+                ('wikipathways', 'WikiPathways', 'release_date'),
+                ('gene_ontology', 'Gene Ontology', 'release_date'),
+                ('reactome', 'Reactome', 'release_version'),
+                ('aopwiki', 'AOP-Wiki', 'snapshot_date'),
+            ] %}
+            {% for key, label, primary_field in _resource_labels %}
+              {% set _entry = _sv.get(key, {}) %}
+              <tr>
+                <td style="padding:8px 14px;font-weight:600;">{{ label }}</td>
+                <td style="padding:8px 14px;">
+                  {% if _entry.get('status') == 'ok' %}
+                    {% if key == 'reactome' %}
+                      v{{ _entry.release_version }}{% if _entry.release_date %} ({{ _entry.release_date }}){% endif %}
+                    {% else %}
+                      {{ _entry.get(primary_field, '—') }}
+                    {% endif %}
+                  {% else %}
+                    <span class="text-muted">unknown</span>{% if _entry.get('reason') %} <span class="text-muted" style="font-size:0.85em;">— {{ _entry.reason }}</span>{% endif %}
+                  {% endif %}
+                </td>
+                <td style="padding:8px 14px;font-size:0.9em;color:var(--color-text-muted, #666);">
+                  {{ _entry.get('method', '—') }}
+                </td>
+                <td style="padding:8px 14px;font-size:0.9em;color:var(--color-text-muted, #666);">
+                  {{ (_entry.get('captured_at') or '')[:10] or '—' }}
+                </td>
+              </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p class="text-muted" style="font-size:14px;margin-bottom:32px;">
+        <em>Snapshot manifest not available — the container may not have a
+        <code>data/source_versions.json</code> yet. Run <code>make capture-versions</code>
+        on the deployed image to generate it.</em>
+    </p>
+    {% endif %}
+
     <!-- Filter + Export Section -->
     <h2 style="font-size:18px;margin-bottom:12px;">Filter and Export</h2>
     <p class="text-muted" style="font-size:14px;margin-bottom:16px;">

--- a/tests/test_source_version_ui_and_zenodo.py
+++ b/tests/test_source_version_ui_and_zenodo.py
@@ -1,0 +1,281 @@
+"""Source-data versioning Phase E.2 — UI + Zenodo metadata tests.
+
+Covers:
+
+1. The `inject_source_versions` context processor — makes the manifest
+   available on every template, gracefully degrades when the file is
+   missing or unreadable.
+
+2. The footer snapshot block — renders only when the manifest has 'ok'
+   sources; uses the same `<a href="/stats#source-versions">` anchor
+   that the Stats-page table is keyed by.
+
+3. The Stats page snapshot table — renders the four-row resource table
+   under `#source-versions`.
+
+4. The Zenodo publish-script helpers — README snapshot table, metadata
+   description snapshot line, per-resource ZIP slice, and the sidecar
+   `source_versions.json` inside each ZIP.
+"""
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------- Context processor + UI surfacing ----------
+
+@pytest.fixture
+def app_with_manifest(tmp_path, monkeypatch):
+    """Boot the app with a tmp `data/source_versions.json` in place."""
+    manifest = {
+        "captured_at": "2026-05-14T21:00:00Z",
+        "sources": {
+            "wikipathways": {
+                "status": "ok",
+                "release_date": "2026-05-10",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+            "gene_ontology": {
+                "status": "ok",
+                "release_date": "2026-01-23",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+            "reactome": {
+                "status": "ok",
+                "release_version": "96",
+                "release_date": "2026-03-25",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+            "aopwiki": {
+                "status": "ok",
+                "snapshot_date": "2026-05-06",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+        },
+    }
+    # The context processor reads "data/source_versions.json" relative to
+    # CWD, so chdir into a tmp dir that has our manifest in place.
+    proj_root = Path(__file__).resolve().parent.parent
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "data").mkdir()
+    (work / "data" / "source_versions.json").write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.chdir(work)
+
+    # Symlink the data dir's other files (templates, etc. are referenced
+    # by absolute path inside the app, so chdir alone is enough for the
+    # context processor read).
+    from app import create_app
+    return create_app()
+
+
+def test_context_processor_injects_source_versions(app_with_manifest):
+    """The injected `source_versions` dict is available in every template."""
+    with app_with_manifest.test_request_context("/"):
+        from flask import render_template_string
+        rendered = render_template_string(
+            "{{ source_versions.sources.wikipathways.release_date }}"
+        )
+        assert rendered == "2026-05-10"
+
+
+def test_footer_renders_snapshot_block(app_with_manifest):
+    client = app_with_manifest.test_client()
+    r = client.get("/")
+    assert r.status_code == 200
+    html = r.data.decode()
+    assert "Snapshot:" in html
+    assert "WP&nbsp;2026-05-10" in html
+    assert "GO&nbsp;2026-01-23" in html
+    assert "Reactome&nbsp;v96" in html
+    assert "AOP-Wiki&nbsp;2026-05-06" in html
+    # Footer links to /stats#source-versions
+    assert 'href="/stats#source-versions"' in html
+
+
+def test_stats_page_has_source_versions_table(app_with_manifest):
+    client = app_with_manifest.test_client()
+    r = client.get("/stats")
+    assert r.status_code == 200
+    html = r.data.decode()
+    # Anchor that the footer link points at
+    assert 'id="source-versions"' in html
+    # Each upstream row
+    assert "WikiPathways" in html
+    assert "2026-05-10" in html
+    assert "Gene Ontology" in html
+    assert "2026-01-23" in html
+    assert "v96" in html
+    assert "2026-03-25" in html
+    assert "AOP-Wiki" in html
+    assert "2026-05-06" in html
+
+
+def test_footer_omits_snapshot_when_manifest_missing(tmp_path, monkeypatch):
+    """If data/source_versions.json doesn't exist, the footer omits the
+    snapshot block entirely (no broken-looking 'Snapshot:' label)."""
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "data").mkdir()  # data dir exists but no manifest file
+    monkeypatch.chdir(work)
+    from app import create_app
+    app = create_app()
+    client = app.test_client()
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "Snapshot:" not in r.data.decode()
+
+
+# ---------- Zenodo deposit helpers ----------
+
+@pytest.fixture
+def _OK_MANIFEST():
+    return {
+        "captured_at": "2026-05-14T21:00:00Z",
+        "sources": {
+            "wikipathways": {
+                "status": "ok", "release_date": "2026-05-10",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+            "gene_ontology": {
+                "status": "ok", "release_date": "2026-01-23",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+            "reactome": {
+                "status": "ok",
+                "release_version": "96", "release_date": "2026-03-25",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+            "aopwiki": {
+                "status": "ok", "snapshot_date": "2026-05-06",
+                "captured_at": "2026-05-14T21:00:00Z",
+            },
+        },
+    }
+
+
+def test_slice_source_versions_returns_only_named_resources(_OK_MANIFEST):
+    from scripts.publish_zenodo import _slice_source_versions
+    s = _slice_source_versions(_OK_MANIFEST, "wikipathways", "aopwiki")
+    assert set(s["sources"].keys()) == {"wikipathways", "aopwiki"}
+    assert s["captured_at"] == _OK_MANIFEST["captured_at"]
+
+
+def test_slice_source_versions_empty_when_no_match(_OK_MANIFEST):
+    from scripts.publish_zenodo import _slice_source_versions
+    assert _slice_source_versions(_OK_MANIFEST, "totally_unknown") == {}
+
+
+def test_format_snapshot_table_md_renders_all_rows(_OK_MANIFEST):
+    from scripts.publish_zenodo import _format_snapshot_table_md
+    md = _format_snapshot_table_md(_OK_MANIFEST)
+    assert "| Resource | Release | Captured |" in md
+    assert "WikiPathways" in md and "2026-05-10" in md
+    assert "Gene Ontology" in md and "2026-01-23" in md
+    assert "Reactome" in md and "v96 (2026-03-25)" in md
+    assert "AOP-Wiki" in md and "2026-05-06" in md
+
+
+def test_format_snapshot_table_md_fallback_when_empty():
+    from scripts.publish_zenodo import _format_snapshot_table_md
+    assert "Snapshot manifest unavailable" in _format_snapshot_table_md({})
+    assert "Snapshot manifest unavailable" in _format_snapshot_table_md(None)
+
+
+def test_format_versions_for_prose_returns_single_line(_OK_MANIFEST):
+    from scripts.publish_zenodo import _format_versions_for_prose
+    line = _format_versions_for_prose(_OK_MANIFEST)
+    assert "WP 2026-05-10" in line
+    assert "GO 2026-01-23" in line
+    assert "Reactome v96 (2026-03-25)" in line
+    assert "AOP-Wiki 2026-05-06" in line
+
+
+def test_format_versions_for_prose_skips_unknown_sources():
+    from scripts.publish_zenodo import _format_versions_for_prose
+    m = {"sources": {
+        "wikipathways": {"status": "ok", "release_date": "2026-05-10"},
+        "gene_ontology": {"status": "unknown"},
+        "reactome": {"status": "unknown"},
+        "aopwiki": {"status": "ok", "snapshot_date": "2026-05-06"},
+    }}
+    line = _format_versions_for_prose(m)
+    assert "WP 2026-05-10" in line
+    assert "AOP-Wiki 2026-05-06" in line
+    assert "GO " not in line
+    assert "Reactome" not in line
+
+
+def test_build_readme_includes_snapshot_section(_OK_MANIFEST):
+    from scripts.publish_zenodo import _build_readme
+    out = _build_readme(
+        "2026-05-15",
+        {"All": 27, "High": 19, "Medium": 7, "Low": 1},
+        {"All": 3, "High": 1, "Medium": 1, "Low": 1},
+        {"All": 0, "High": 0, "Medium": 0, "Low": 0},
+        source_versions=_OK_MANIFEST,
+    ).decode()
+    assert "## Upstream resource snapshot" in out
+    assert "| WikiPathways | 2026-05-10 |" in out
+    assert "v96 (2026-03-25)" in out
+    # Also references the sidecar so consumers know it's in each ZIP
+    assert "source_versions.json" in out
+
+
+def test_build_metadata_description_contains_snapshot_line(_OK_MANIFEST):
+    from scripts.publish_zenodo import _build_metadata
+    meta = _build_metadata("2026-05-15", source_versions=_OK_MANIFEST)
+    assert "Upstream snapshot for this deposit" in meta["description"]
+    assert "WP 2026-05-10" in meta["description"]
+
+
+def test_build_metadata_omits_snapshot_when_manifest_empty():
+    from scripts.publish_zenodo import _build_metadata
+    meta = _build_metadata("2026-05-15", source_versions={})
+    assert "Upstream snapshot" not in meta["description"]
+
+
+def test_resource_zip_includes_source_versions_sidecar(_OK_MANIFEST):
+    """Each per-resource ZIP must carry a source_versions.json sidecar
+    containing the relevant slice of the manifest, so GMT-only consumers
+    can pin against an upstream release."""
+    from scripts.publish_zenodo import _build_resource_zip, _slice_source_versions
+
+    # Build a tiny KE-WP zip using stubbed generators so we don't hit SPARQL.
+    def _stub_gmt(mappings, min_confidence=None, **_):
+        return "KE_X\tdesc\tBRCA1\tTP53\n" if not min_confidence else ""
+
+    def _stub_ttl(mappings):
+        return "@prefix : <https://example/> .\n:m a :Thing .\n"
+
+    raw = _build_resource_zip(
+        "KE-WikiPathways", _stub_gmt, _stub_ttl, mappings=[], today="2026-05-15",
+        source_versions_slice=_slice_source_versions(_OK_MANIFEST, "wikipathways", "aopwiki"),
+    )
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        names = zf.namelist()
+        assert "KE-WikiPathways/source_versions.json" in names
+        sidecar = json.loads(zf.read("KE-WikiPathways/source_versions.json"))
+        assert set(sidecar["sources"].keys()) == {"wikipathways", "aopwiki"}
+        assert sidecar["sources"]["wikipathways"]["release_date"] == "2026-05-10"
+
+
+def test_resource_zip_omits_sidecar_when_no_slice(_OK_MANIFEST):
+    """If the caller passes no slice, no sidecar is emitted."""
+    from scripts.publish_zenodo import _build_resource_zip
+
+    def _stub_gmt(mappings, min_confidence=None, **_):
+        return "row\n" if not min_confidence else ""
+
+    def _stub_ttl(mappings):
+        return "@prefix : <x> .\n"
+
+    raw = _build_resource_zip(
+        "KE-WikiPathways", _stub_gmt, _stub_ttl, mappings=[], today="2026-05-15",
+        source_versions_slice=None,
+    )
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        assert "KE-WikiPathways/source_versions.json" not in zf.namelist()


### PR DESCRIPTION
## Summary

Final slice of **source-data versioning** (DMP §7). Surfaces the manifest in three user-facing places and wires it into every Zenodo deposit so external consumers can pin their analyses against a specific upstream release **without** reading per-row Turtle triples.

After this PR, source-data versioning is complete end-to-end: capture (#170) → schema (#171) → approval stamping (#172) → backfill (#173) → exporter triples (#174) → UI + Zenodo (this PR).

## Surfacing layers

### App-wide context processor (`app.py`)

`inject_source_versions` reads `data/source_versions.json` on every request and exposes `source_versions` in template scope. Missing file → `{}`; templates use truthiness to hide their snapshot blocks entirely rather than render half-empty UI.

### Site footer

Compact one-line block on every page:

```
Snapshot: WP 2026-05-10 · GO 2026-01-23 · Reactome v96 · AOP-Wiki 2026-05-06
```

Only `ok`-status sources render. The block wraps a link to `/stats#source-versions` so a curious user lands on the full table in one click. Muted styling, dotted underline that turns solid + primary-blue on hover.

### Stats page

New `#source-versions` anchored section with a four-row **Resource / Release / Method / Captured** table, plus an inline rationale block (one sentence + link to DMP §2.4) so a viewer understands what they're looking at without leaving the page.

### Zenodo deposit (`scripts/publish_zenodo.py`)

Three new pieces of provenance in every deposit:

- **`_build_resource_zip`** now accepts `source_versions_slice` and emits the slice as `<prefix>/source_versions.json` inside the ZIP. GMT-only consumers (clusterProfiler / fgsea users) can pin against a release without reading the sidecar Turtle.
- **`_build_readme`** has a new "## Upstream resource snapshot" section rendering the manifest as a Markdown table.
- **`_build_metadata`**'s `description` field carries a one-line snapshot prose summary, so the deposit listing on `zenodo.org/record/<n>` states the upstream provenance in plain prose.

`_slice_source_versions(manifest, *resources)` picks the named entries plus the AOP-Wiki anchor — each ZIP carries only its own upstream + AOP-Wiki, never the unrelated other resources.

The orchestrating `main()` loads `data/source_versions.json` once and threads it through every helper. Missing manifest → deposit publishes without a snapshot block (fail-soft, same pattern as the app context processor).

## Tests

`tests/test_source_version_ui_and_zenodo.py` — 15 cases:

- Context processor injects `source_versions` + graceful degradation
- Footer renders the block with the right tokens + correct link target
- Footer hides entirely when manifest is missing
- Stats page exposes `#source-versions` anchor + renders the table
- `_slice_source_versions` returns only named resources
- `_format_snapshot_table_md` + `_format_versions_for_prose` happy paths + fallbacks
- `_build_readme` snapshot section present + references sidecar
- `_build_metadata` description carries the prose + omitted when manifest empty
- `_build_resource_zip` emits sidecar with right slice + omits when no slice passed

Full suite: **389 passed** (was 366 after E.1), coverage **52.78%** (up from 52.43%).

## Live verification

```
$ PYTHONPATH=. python scripts/publish_zenodo.py --dry-run --force
[...]
INFO  Loaded source_versions manifest from data/source_versions.json
INFO  Assembled KE-WikiPathways.zip (11626 bytes)   ← +sidecar
INFO  Assembled KE-GO.zip (6423 bytes)              ← +sidecar
INFO  Assembled KE-Reactome.zip (576 bytes)         ← +sidecar
INFO  Assembled README.md (4661 bytes)              ← +snapshot section
```

README snapshot section:

```markdown
## Upstream resource snapshot

| Resource | Release | Captured |
|----------|---------|----------|
| WikiPathways | 2026-05-10 | 2026-05-14 |
| Gene Ontology | 2026-01-23 | 2026-05-14 |
| Reactome | v96 (2026-03-25) | 2026-05-14 |
| AOP-Wiki | 2026-05-06 | 2026-05-14 |
```

Visual screenshots of footer + stats page confirmed via Playwright.

## Test plan

- [x] Footer renders snapshot block on `/`, `/stats`, `/downloads`.
- [x] Footer hidden when manifest missing.
- [x] Stats page `#source-versions` table renders.
- [x] Zenodo dry-run includes all three sidecars + README snapshot section + metadata snapshot prose.
- [x] Full suite 389 passing.
- [ ] After merge: deploy + visit `/stats#source-versions` on the live container.
- [ ] After merge: next Zenodo release (manual or scheduled) carries the snapshot block.

## What this PR deliberately does *not* do

- **Excel / Parquet exporters**: dict iteration already picks up the new columns (E.1) — explicit field-level documentation can follow if needed.
- **Per-card snapshot on Downloads**: the global footer line covers the same info; per-card would duplicate without adding signal.
- **API serializer fields**: API consumers reading `/api/v1/mappings` already see the columns via dict serialisation (Phase C); explicit OpenAPI doc updates can follow when convenient.

## Done

Source-data versioning is **complete end-to-end**. Three independent ways for downstream users to pin against an upstream release:

1. Per-row Turtle triples (`vocab#wpReleaseDate`, etc.)
2. Per-ZIP `source_versions.json` sidecar
3. Deposit README snapshot table + metadata prose