### PR TITLE
deps: bump authlib 1.6.7 → 1.6.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==3.1.2
 pandas==2.2.3
 requests==2.32.5
 python-dotenv==1.2.1
-authlib==1.6.7
+authlib==1.6.12
 Flask-WTF==1.2.1
 Flask-Limiter==4.1.1
 marshmallow==3.26.2


### PR DESCRIPTION
## Summary

Bumps `authlib` to close 5 Dependabot alerts:

| Alert | Severity | Issue | Fixed in |
|---|---|---|---|
| GHSA-wvwj-cvrp-7pv5 | **CRITICAL** | JWS JWK header injection — signature verification bypass | 1.6.9 |
| GHSA-7432-952r-cw78 | HIGH | JWE RSA1_5 Bleichenbacher padding oracle | 1.6.9 |
| GHSA-m344-f55w-2m6j | HIGH | Fail-open cryptographic verification in OIDC hash binding | 1.6.9 |
| GHSA-jj8c-mmj3-mmgv | medium | CSRF when using cache | 1.6.11 |
| GHSA-r95x-qfjj-fjj2 | medium | OIDC implicit/hybrid open redirect | 1.6.12 |

Authlib drives all four OAuth providers (GitHub, ORCID, LS Login, SURFconext), which is why this gets its own isolated bump with a clean revert path.

## Test plan

- [ ] CI green
- [ ] `make test`
- [ ] Local: `python app.py`, complete login flow for each of the four providers against the dev callback
- [ ] Confirm session cookie + `is_admin` context processor still work after login