### PR TITLE
ci(security): silence Trivy OS-CVE noise in Security tab

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -219,12 +219,18 @@ jobs:
         image-ref: 'scan-image:latest'
         format: 'sarif'
         output: 'trivy-results.sarif'
+        # Filter to actionable findings only — match the scheduled scan in security.yml.
+        # Without these the Security tab fills with base-image OS CVEs we cannot patch.
+        ignore-unfixed: true
+        severity: 'CRITICAL,HIGH'
+        vuln-type: 'library'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
+        category: 'trivy-docker-build'
 
     - name: Run Trivy filesystem scan
       uses: aquasecurity/trivy-action@0.34.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -158,6 +158,9 @@ jobs:
         output: 'trivy-image-results.sarif'
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
+        # Skip OS-level Debian CVEs (not actionable here — Dependabot covers
+        # pip deps, base image hardening is a separate concern).
+        vuln-type: 'library'
 
     - name: Run Trivy filesystem scan
       uses: aquasecurity/trivy-action@0.34.0
@@ -168,6 +171,7 @@ jobs:
         output: 'trivy-fs-results.sarif'
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
+        vuln-type: 'library'
 
     - name: Upload Trivy image scan results
       uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Summary

The Security tab on this repo is flooded with ~190 base-image Debian CVE alerts (glibc, util-linux, openssl, etc.) that aren't actionable from this codebase and drown out real findings. Two narrow changes:

- **`docker.yml`** — the Trivy scan that runs on every push had no filter at all and uploaded its SARIF straight to the Security tab. Aligned it with the scheduled scan in `security.yml`: `ignore-unfixed: true`, `severity: CRITICAL,HIGH`. Also added a distinct SARIF category (`trivy-docker-build`) so the per-push results don't merge with the scheduled ones.
- **Both workflows** — added `vuln-type: library` so Trivy only reports pip/library CVEs, not Debian package CVEs. Pip is already covered by Dependabot, so this stays as a safety net rather than the primary feed. Base-image hardening is a separate concern.

Docker Scout was suspected but is fine — it uploads as a build artifact (`actions/upload-artifact`), not as SARIF, so it never polluted the Security tab.

## Expected effect

Security-tab CVE-* count drops from ~190 to single digits, leaving real CodeQL findings visible. No code change; no functional impact.

## Test plan

- [ ] CI green on the docker workflow
- [ ] Next scheduled run of security workflow green
- [ ] After merge: GitHub Security tab CVE-* count drops sharply