### PR TITLE
ci(security)+deps: bump trivy-action 0.34.0 → 0.35.0 and black 23.12.1 → 26.3.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -214,7 +214,7 @@ jobs:
         cache-from: type=gha
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.34.0
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         image-ref: 'scan-image:latest'
         format: 'sarif'
@@ -227,7 +227,7 @@ jobs:
         sarif_file: 'trivy-results.sarif'
 
     - name: Run Trivy filesystem scan
-      uses: aquasecurity/trivy-action@0.34.0
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -151,7 +151,7 @@ jobs:
         cache-from: type=gha
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.34.0
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         image-ref: 'security-scan:latest'
         format: 'sarif'
@@ -160,7 +160,7 @@ jobs:
         severity: 'CRITICAL,HIGH'
 
     - name: Run Trivy filesystem scan
-      uses: aquasecurity/trivy-action@0.34.0
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 
 # Code Quality & Linting (compatible versions for our Flask setup)
 flake8==6.0.0
-black==23.12.1
+black==26.3.1
 isort==5.12.0
 mypy==1.5.1
 pylint==2.17.7


### PR DESCRIPTION
## Summary

Closes 4 Dependabot alerts in a single grouped PR — dev-only deps and CI action pins, since they share a revert surface that doesn't touch runtime behaviour.

| Alert | Severity | Issue | Action |
|---|---|---|---|
| GHSA-69fq-xp46-6x23 | **CRITICAL** (×2) | `aquasecurity/trivy-action` brief supply-chain compromise window | Pin to 0.35.0 in both `docker.yml` and `security.yml` |
| GHSA-3936-cmfr-pm3m | HIGH | `black` arbitrary file writes from unsanitized cache filename | Bump to 26.3.1 |
| GHSA-fj7x-q9j7-g6q6 | medium | `black` ReDoS (pre-24.3.0) | Closed by same bump |

## Notes

- `black` 23→26 is a major version jump and **may reformat existing files** the next time it runs. If the diff is large, the reformat should land as a separate follow-up commit so this bump stays reviewable.
- Trivy filter improvements live in #177 (independent).

## Test plan

- [ ] CI green
- [ ] Trivy step runs without "deprecated version" warnings