### PR TITLE
deps: bump Flask, requests, python-dotenv, pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-Flask==3.1.2
+Flask==3.1.3
 pandas==2.2.3
-requests==2.32.5
-python-dotenv==1.2.1
+requests==2.33.0
+python-dotenv==1.2.2
 authlib==1.6.12
 Flask-WTF==1.2.1
 Flask-Limiter==4.1.1
 marshmallow==3.26.2
 gunicorn==22.0.0
-pytest==8.3.4
+pytest==9.0.3
 pytest-cov==6.0.0
 pytest-flask==1.3.0
 rdflib==6.3.2


### PR DESCRIPTION
## Summary

Four small Dependabot bumps grouped together — all low blast radius, all closeable in a single test cycle.

| Alert | Severity | Package | Bump |
|---|---|---|---|
| GHSA-68rp-wp8r-4726 | low | `Flask` | 3.1.2 → 3.1.3 (missing `Vary: Cookie` header on some session accesses) |
| GHSA-gc5v-m9x4-r6x2 | medium | `requests` | 2.32.5 → 2.33.0 (insecure temp file reuse in `extract_zipped_paths()`) |
| GHSA-mf9w-mj56-hr94 | medium | `python-dotenv` | 1.2.1 → 1.2.2 (symlink-following in `set_key` allows arbitrary file overwrite) |
| GHSA-6w46-j5rx-g56g | medium | `pytest` | 8.3.4 → 9.0.3 (vulnerable tmpdir handling) |

## Notes

`pytest 8 → 9` is a major version. The repo's test suite uses the modern `tmp_path` fixture (verified — no occurrences of the deprecated `tmpdir` fixture in `tests/`). CI will surface any remaining incompatibility.

## Test plan

- [ ] `make test`
- [ ] `make test-cov`
- [ ] Verify session cookie handling unchanged with a manual login flow