### PR TITLE
deps: bump transformers 4.48.3 → 4.53.0 and torch 2.6.0+cpu → 2.8.0+cpu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ pytest-flask==1.3.0
 rdflib==6.3.2
 
 # BioBERT embedding support
-transformers==4.48.3
+transformers==4.53.0
 sentence-transformers==3.4.1
-torch==2.6.0+cpu
+torch==2.8.0+cpu
 numpy==1.26.4
 tqdm==4.67.3


### PR DESCRIPTION
## Summary

**Draft** — closes 12 Dependabot alerts but needs embeddings-drift verification before merge. See test plan below.

Coupled bump because transformers pins a `torch >=` floor and the BioBERT embedding path imports both; bumping one in isolation risks ABI drift.

### transformers (10 alerts, all medium/low — ReDoS or input validation)

GHSA-fpwr-67px-3qhx, GHSA-qq3j-4f4f-9583, GHSA-q2wp-rjmx-x6x9, GHSA-jjph-296x-mrcr, GHSA-phhr-52qp-3mj4, GHSA-37mw-44qp-f5jm, GHSA-9356-575x-2w9m, GHSA-59p9-h35m-wg4g, GHSA-rcv9-qm8p-9p6j, GHSA-4w7r-h757-3r74 — fixed across 4.50.0–4.53.0.

### torch (2 alerts)

- GHSA-3749-ghw9-m3mg (low) — local DoS, fixed in 2.7.1-rc1
- GHSA-887c-mr87-cxwp (medium) — improper resource shutdown, fixed in 2.8.0

### Why not transformers 5.0.0rc3?

Release candidate. The 4.x → 5.0 jump fixes one extra alert (GHSA-69w3-r845-3855, arbitrary code exec in `Trainer`), but this app uses `AutoModel` + `AutoTokenizer` for inference only — never `Trainer` — so that finding is not reachable. Stay on 4.53.x line until 5.0 is GA.

## Test plan (must do before un-drafting)

- [ ] `make test` green
- [ ] **Embedding drift check**: regenerate one or two embeddings with the new stack and compare cosine sim against `data/` NPZ — should be ≥0.9999. If lower, model loading semantics changed and pre-computed embeddings need a full `/rebuild-embeddings` pass before this can deploy.
- [ ] Smoke `/suggest` for a known KE — top-5 pathway suggestions should match current production ranking
- [ ] Docker image builds cleanly with the new wheels (CPU torch wheel size jumps ~30% — confirm container start time still under SLA)

## Deploy gate

Do **not** deploy without first running the embedding drift check on the running container. BioBERT embeddings are pre-computed and live in `/mnt/gluster/docker/molaop-builder/data` on tgx1 — a silent drift would only show up later as ranking changes.