### PR TITLE
security: fix CodeQL hot findings — path injection, stack-trace exposure, TLS floor

### DIFF
--- a/scripts/download_reactome_annotations.py
+++ b/scripts/download_reactome_annotations.py
@@ -243,6 +243,10 @@ def _get_content_service(path, timeout=60):
         raise RuntimeError("Cannot resolve reactome.org")
 
     ctx = ssl.create_default_context()
+    # Reactome's download path occasionally serves self-signed certs that fail
+    # standard validation; this path is the documented workaround. Still pin
+    # the TLS floor so we never negotiate down to TLS <1.2.
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
 

--- a/scripts/precompute_reactome_embeddings.py
+++ b/scripts/precompute_reactome_embeddings.py
@@ -108,6 +108,10 @@ def _post_content_service(path, data, timeout=60):
         raise RuntimeError("Cannot resolve reactome.org — check network connectivity")
 
     ctx = ssl.create_default_context()
+    # Reactome's POST endpoint occasionally fails standard cert validation;
+    # this path is the documented workaround. Still pin the TLS floor so we
+    # never negotiate down to TLS <1.2.
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
 

--- a/src/blueprints/admin.py
+++ b/src/blueprints/admin.py
@@ -1189,9 +1189,9 @@ def regenerate_exports():
 
         logger.info("Export cache rebuilt: %s", files_written)
         return jsonify({"status": "ok", "files": files_written, "message": f"Rebuilt {len(files_written)} export file(s). Note: KE-WP GMT generation requires WikiPathways SPARQL — may be slow on first run."})
-    except Exception as e:
-        logger.error("Export regeneration failed: %s", e)
-        return jsonify({"status": "error", "message": str(e)}), 500
+    except Exception:
+        logger.exception("Export regeneration failed")
+        return jsonify({"status": "error", "message": "Export regeneration failed"}), 500
 
 
 @admin_bp.route("/exports/publish-zenodo", methods=["POST"])
@@ -1289,11 +1289,18 @@ def publish_zenodo():
                 f"saved to {META_FALLBACK_PATH}; copy it back into place."
             )
         return jsonify(response)
-    except EnvironmentError as e:
-        return jsonify({"status": "error", "message": str(e)}), 503
-    except Exception as e:
-        logger.error("Zenodo publish failed: %s", e)
-        return jsonify({"status": "error", "message": str(e)}), 500
+    except EnvironmentError:
+        logger.exception("Zenodo publish blocked by environment (token / config missing)")
+        return jsonify({
+            "status": "error",
+            "message": "Zenodo publish blocked — check server logs for the missing token or config",
+        }), 503
+    except Exception:
+        logger.exception("Zenodo publish failed")
+        return jsonify({
+            "status": "error",
+            "message": "Zenodo publish failed — see server logs for details",
+        }), 500
 
 
 @admin_bp.route("/ke-descriptions")

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -692,6 +692,12 @@ def downloads():
     return render_template("downloads.html", zenodo_meta=zenodo_meta)
 
 
+_VALID_MAPPING_TYPES = {
+    "wp", "wp-centric", "go", "go-centric", "reactome", "reactome-centric",
+}
+_VALID_MIN_CONFIDENCE = {None, "high", "medium", "low"}
+
+
 def _get_or_generate_gmt(mapping_type: str, min_confidence: str = None):
     """Return (path, filename) for GMT file, generating it if not cached."""
     from src.exporters.gmt_exporter import (
@@ -699,6 +705,13 @@ def _get_or_generate_gmt(mapping_type: str, min_confidence: str = None):
         generate_ke_centric_wp_gmt, generate_ke_centric_go_gmt,
         generate_ke_reactome_gmt, generate_ke_centric_reactome_gmt,
     )
+    # Whitelist user-controlled values that flow into the cache filename below —
+    # without this guard, a crafted min_confidence (e.g. "../etc/passwd") would
+    # let the cache write escape EXPORT_CACHE_DIR.
+    if mapping_type not in _VALID_MAPPING_TYPES:
+        abort(404)
+    if min_confidence not in _VALID_MIN_CONFIDENCE:
+        abort(400)
     today = datetime.today().date().isoformat()
     tier = min_confidence.capitalize() if min_confidence else "All"
     filename = f"KE-{mapping_type.upper()}_{today}_{tier}.gmt"


### PR DESCRIPTION
## Summary

Closes the highest-impact CodeQL findings without trying to address the ~30 log-injection alerts (most of which are CodeQL flagging Flask URL converter values that can't actually contain newlines — see "Out of scope" below).

### Three real fixes

**1. Path injection in `src/blueprints/main.py`** — closes the cluster at `main.py:706–791`

`_get_or_generate_gmt()` builds a cache filename from the user-controlled `?min_confidence=` query param. A crafted value like `../../etc/passwd` would let `cache_path.write_text()` escape `EXPORT_CACHE_DIR`. Added whitelist validation on both `mapping_type` and `min_confidence` at the top of the helper.

**2. Stack-trace exposure in `src/blueprints/admin.py`** — closes findings at `admin.py:1194, 1293, 1296`

The export-regen and Zenodo-publish admin routes returned `str(e)` in their 5xx JSON body. Even on admin-only routes that leaks internal paths and stack details. Replaced with `logger.exception()` + a curated public message.

**3. TLS floor in two `scripts/`** — closes `py/insecure-protocol` findings

`download_reactome_annotations.py` and `precompute_reactome_embeddings.py` call `ctx.wrap_socket()` with `CERT_NONE` as a documented workaround for Reactome's occasionally-broken cert chain. Pinned `minimum_version = TLSv1_2` so we never negotiate down. The `CERT_NONE` / `check_hostname=False` behaviour is preserved — removing it would break the Reactome data pipeline (documented in the docstrings).

### Out of scope — log-injection sweep

The ~30 `py/log-injection` alerts in `admin.py`, `api.py`, and `auth.py` are mostly CodeQL paranoia about `<int:proposal_id>` URL converter values that can't actually contain newlines. The repo already has a `sanitize_log` helper in `src/utils/text.py` and uses it consistently for `str(e)` arguments. Closing these requires a mechanical wrap of every interpolated value (even ints), which is cosmetic — leaving as a follow-up.

Same for the `requests.get(..., verify=False)` fallback in `scripts/download_reactome_annotations.py:69` — that's a documented intentional fallback for Reactome's self-signed cert, with the standard verification path tried first.

## Test plan

- [x] `make test` — 431 passed, 54.15% coverage
- [ ] Manual: hit `/exports/gmt/ke-wp?min_confidence=garbage` — should 400
- [ ] Manual: hit `/exports/gmt/ke-wp?min_confidence=../etc` — should 400 (was: silent path traversal)
- [ ] Manual: trigger an admin export-regen failure (e.g. revoke SPARQL access) — response should be the curated message, not a stack trace