### PR TITLE
ci: trigger CI tests and code-quality lint on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,6 +3,8 @@ name: Code Quality
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

The repo currently has zero CI coverage on PR branches — `ci.yml`, `code-quality.yml`, `docker.yml`, and `security.yml` all trigger only on push to main. That means every dependency bump has to be merged blind and regressions only surface after they're on `main`.

This turns on `pull_request:` triggers for the two lightweight workflows:

- **`ci.yml`** — pytest + flake8 lint + app-startup smoke (~3 min)
- **`code-quality.yml`** — bandit + mypy + pylint (~2 min)

`docker.yml` and `security.yml` stay push-only by design — they build Docker images and run full Trivy/Scout/CodeQL scans, which are expensive and aren't useful per-PR. `docker.yml` has an existing comment explicitly preferring this.

## Effect

The 6 open security-bump PRs (#176–181) immediately get a test+lint signal and can be merged based on evidence rather than hope.

## Why this is its own PR

Lands first; every subsequent PR (#176–181) automatically picks up CI on rebase/sync. No code change, no behaviour change — pure CI policy.

## Test plan

- [ ] This PR's own CI run should kick off when the PR opens, demonstrating the trigger works
- [ ] After merge, re-trigger CI on each of #176–181 (push an empty commit or "Update branch") and confirm pytest runs