### PR TITLE
chore: ruff autofix for unused-import / unused-variable / redefined imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ Refactored Flask application using modular blueprint architecture
 """
 import logging
 import os
-import time
 
 from dotenv import load_dotenv
 from flask import Flask, jsonify, render_template, request
@@ -33,7 +32,6 @@ from src.core.config import get_config
 from src.core.error_handlers import register_error_handlers
 
 # Import monitoring
-from src.services.monitoring import monitor_performance
 from src.services.rate_limiter import general_rate_limit
 from src.services.container import ServiceContainer
 
@@ -163,7 +161,7 @@ def create_app(config_name: str = None):
         }), 429
 
     # Initialize OAuth
-    oauth = services.init_oauth(app)
+    services.init_oauth(app)
 
     # Set up models for blueprints
     set_auth_models(services.provider_clients, guest_code=services.guest_code_model)

--- a/examples/python_examples.py
+++ b/examples/python_examples.py
@@ -8,7 +8,6 @@ import pandas as pd
 import json
 from typing import Dict, List
 import matplotlib.pyplot as plt
-from datetime import datetime
 
 
 class KEWPDatasetClient:
@@ -231,7 +230,7 @@ def advanced_analysis():
     
     # Load data with Parquet for better performance
     try:
-        import pyarrow.parquet as pq
+        import pyarrow.parquet as pq  # noqa: F401 — availability probe for the example block
         
         # Download Parquet file
         parquet_response = client.export_data("parquet", include_metadata_columns="true")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,10 @@ force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 known_first_party = ["src"]
+
+[tool.ruff.lint]
+# Narrow selection: unused-import / unused-variable / redefined-while-unused only.
+# These map directly to the CodeQL py/unused-* alerts we triage. Broader rule
+# packs (E, W, B, etc.) are not enabled here — flake8 already covers the style
+# surface and a sweeping ruff enablement would be a separate decision.
+select = ["F401", "F811", "F841"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ black==26.3.1
 isort==5.12.0
 mypy==1.5.1
 pylint==2.17.7
+ruff==0.15.0
 
 # Security Analysis (pinned to avoid conflicts)
 bandit[toml]==1.7.5

--- a/scripts/backfill_source_versions.py
+++ b/scripts/backfill_source_versions.py
@@ -35,7 +35,6 @@ import argparse
 import json
 import logging
 import sqlite3
-import sys
 from pathlib import Path
 from typing import Optional
 

--- a/scripts/capture_source_versions.py
+++ b/scripts/capture_source_versions.py
@@ -26,7 +26,6 @@ import argparse
 import datetime as _dt
 import json
 import logging
-import os
 import re
 import sys
 from pathlib import Path

--- a/scripts/download_reactome_annotations.py
+++ b/scripts/download_reactome_annotations.py
@@ -21,11 +21,8 @@ import argparse
 import json
 import logging
 import os
-import re
 import sys
-import time
 import zipfile
-from collections import defaultdict
 
 import requests
 
@@ -163,7 +160,7 @@ def parse_gmt_file(gmt_path):
                 continue
             col1 = parts[1] if len(parts) > 1 else ''
             col2 = parts[2] if len(parts) > 2 else ''
-            col3 = parts[3] if len(parts) > 3 else ''
+            parts[3] if len(parts) > 3 else ''
             if col1.startswith('R-'):
                 # col 1 is stableId; decide gene start col
                 # If col2 is "Reactome Pathway" or a URL or empty, genes start at 3

--- a/scripts/dump_reactome_distribution.py
+++ b/scripts/dump_reactome_distribution.py
@@ -189,7 +189,7 @@ def main() -> None:
         biolevel = entry["biolevel"]
         meta = ke_meta.get(ke_id, {})
         ke_title = meta.get("KEtitle", "")
-        ke_description = meta.get("KEdescription", "")
+        meta.get("KEdescription", "")
 
         print("=" * 72)
         print(f"KE: {ke_id}  [{biolevel}]  {ke_title[:60]}")

--- a/scripts/precompute_go_hierarchy.py
+++ b/scripts/precompute_go_hierarchy.py
@@ -25,7 +25,7 @@ import math
 import os
 import sys
 from collections import defaultdict, deque
-from urllib.request import urlretrieve, Request, urlopen
+from urllib.request import Request, urlopen
 
 # Setup project path (same pattern as precompute_go_embeddings.py)
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/scripts/precompute_reactome_embeddings.py
+++ b/scripts/precompute_reactome_embeddings.py
@@ -36,7 +36,6 @@ import os
 import re
 import socket
 import ssl
-import sys
 import time
 
 import requests

--- a/scripts/publish_zenodo.py
+++ b/scripts/publish_zenodo.py
@@ -77,8 +77,8 @@ from src.exporters.zenodo_assembly import (   # noqa: E402
     changes_significant as _changes_significant_impl,
     build_resource_zip as _build_resource_zip,
     slice_source_versions as _slice_source_versions,
-    format_versions_for_prose as _format_versions_for_prose,
-    format_snapshot_table_md as _format_snapshot_table_md,
+    format_versions_for_prose as _format_versions_for_prose,  # noqa: F401 — re-exported for tests
+    format_snapshot_table_md as _format_snapshot_table_md,  # noqa: F401 — re-exported for tests
     build_readme as _build_readme,
     build_metadata as _build_metadata,
 )

--- a/src/blueprints/admin.py
+++ b/src/blueprints/admin.py
@@ -10,10 +10,9 @@ from functools import wraps
 
 from flask import Blueprint, current_app, jsonify, render_template, request, session
 
-from src.utils.timezone import format_local_datetime, utc_to_local
+from src.utils.timezone import utc_to_local
 from src.utils.text import sanitize_log
 
-from src.core.models import GoProposalModel, KeDescriptionOverrideModel, MappingModel, ProposalModel
 from src.services.monitoring import monitor_performance
 from src.services.rate_limiter import submission_rate_limit
 from src.core.schemas import AdminNotesSchema, SecurityValidation, validate_request_data

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -12,8 +12,7 @@ from functools import wraps
 import requests
 from flask import Blueprint, jsonify, request, session
 
-from src.core.models import CacheModel, GoProposalModel, MappingModel, ProposalModel
-from src.services.monitoring import monitor_performance
+from src.core.models import GoProposalModel, ProposalModel
 from src.services.rate_limiter import general_rate_limit, sparql_rate_limit, submission_rate_limit
 from src.core.schemas import (
     CheckEntrySchema,

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -2,18 +2,15 @@
 Main Blueprint
 Handles core application routes and page rendering
 """
-import datetime
 import json as json_lib
 import logging
 import os
-import shutil
 from datetime import datetime
 from pathlib import Path
 
 from flask import Blueprint, abort, current_app, make_response, render_template, send_file, send_from_directory, session, request, jsonify
 
 from src.blueprints.admin import _get_admin_users
-from src.core.models import MappingModel
 from src.services.monitoring import monitor_performance
 from src.utils.text import sanitize_log
 

--- a/src/core/error_handlers.py
+++ b/src/core/error_handlers.py
@@ -7,14 +7,6 @@ from functools import wraps
 
 from flask import jsonify, render_template, request
 from src.utils.text import sanitize_log
-from werkzeug.exceptions import (
-    BadRequest,
-    Forbidden,
-    HTTPException,
-    InternalServerError,
-    NotFound,
-    Unauthorized,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/src/exporters/excel_exporter.py
+++ b/src/exporters/excel_exporter.py
@@ -21,7 +21,7 @@ class ExcelExporter:
         try:
             import openpyxl
             from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
-            from openpyxl.utils.dataframe import dataframe_to_rows
+            from openpyxl.utils.dataframe import dataframe_to_rows  # noqa: F401 — required by openpyxl write path
         except ImportError:
             raise ImportError("openpyxl is required for Excel export. Install it with: pip install openpyxl")
         
@@ -246,7 +246,7 @@ class ExcelExporter:
                 
                 for row_idx, (key, value) in enumerate(meta_items, 1):
                     cell_key = ws_meta.cell(row=row_idx, column=1, value=key)
-                    cell_value = ws_meta.cell(row=row_idx, column=2, value=value)
+                    ws_meta.cell(row=row_idx, column=2, value=value)
                     
                     if key and not value and key != "":  # Section headers
                         cell_key.font = Font(bold=True, size=12)

--- a/src/exporters/parquet_exporter.py
+++ b/src/exporters/parquet_exporter.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import io
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -157,7 +157,6 @@ class ParquetExporter:
     def _create_parquet_schema(self, df) -> 'pa.Schema':
         """Create PyArrow schema with field metadata"""
         import pyarrow as pa
-        import pandas as pd
         
         # Get basic schema from DataFrame
         schema = pa.Schema.from_pandas(df)

--- a/src/exporters/rdf_exporter.py
+++ b/src/exporters/rdf_exporter.py
@@ -6,7 +6,7 @@ Turtle serialisation with full Phase 2/3 provenance columns.
 """
 import logging
 
-from rdflib import Graph, Literal, Namespace, RDF, URIRef
+from rdflib import Graph, Literal, Namespace, RDF
 from rdflib.namespace import DCTERMS, XSD
 
 logger = logging.getLogger(__name__)

--- a/src/services/embedding.py
+++ b/src/services/embedding.py
@@ -496,7 +496,7 @@ class BiologicalEmbeddingService:
 
             # Extract entities for description matching too
             ke_text_processed = self._extract_entities(ke_text)
-            pathway_text_processed = self._extract_entities(pathway_text)
+            self._extract_entities(pathway_text)
 
             # Use pre-computed pathway embedding if available
             ke_emb = self.encode(ke_text_processed)

--- a/src/services/monitoring.py
+++ b/src/services/monitoring.py
@@ -9,7 +9,7 @@ import time
 from collections import defaultdict, deque
 from typing import Any, Dict
 
-from flask import g, request
+from flask import request
 
 logger = logging.getLogger(__name__)
 

--- a/src/suggestions/go.py
+++ b/src/suggestions/go.py
@@ -9,7 +9,7 @@ import os
 import re
 from collections import namedtuple
 from difflib import SequenceMatcher
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import numpy as np
 from src.core.config_loader import ConfigLoader

--- a/src/suggestions/ke_genes.py
+++ b/src/suggestions/ke_genes.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 import logging
 import re
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import requests
 

--- a/tests/test_assessment_migrations.py
+++ b/tests/test_assessment_migrations.py
@@ -7,7 +7,6 @@ table_info to assert the four new `proposed_*` columns plus (on mapping tables)
 """
 import sqlite3
 
-import pytest
 
 from src.core.models import Database
 

--- a/tests/test_assessment_roundtrip_reactome.py
+++ b/tests/test_assessment_roundtrip_reactome.py
@@ -14,7 +14,6 @@ Asserts:
 """
 import inspect
 
-import pytest
 
 from src.core.models import (
     Database,

--- a/tests/test_directionality.py
+++ b/tests/test_directionality.py
@@ -5,7 +5,6 @@ Tests both detect_go_direction() and detect_ke_direction() covering
 all behavioral categories: positive, negative, unspecified, and ambiguous.
 """
 
-import pytest
 from src.utils.text import detect_go_direction, detect_ke_direction
 
 

--- a/tests/test_go_suggestion_ranking.py
+++ b/tests/test_go_suggestion_ranking.py
@@ -11,7 +11,6 @@ Tests A–E confirm that:
 
 Plans 29-02 and 29-04 can rely on these contracts without re-testing them.
 """
-import pytest
 from src.suggestions.go import GoSuggestionService, _NamespaceData
 from src.core.config_loader import ConfigLoader
 

--- a/tests/test_method_filter_deprecation.py
+++ b/tests/test_method_filter_deprecation.py
@@ -21,7 +21,7 @@ Strategy:
 """
 import pytest
 import logging
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from app import app as flask_app
 

--- a/tests/test_pathway_suggestion_ranking.py
+++ b/tests/test_pathway_suggestion_ranking.py
@@ -16,8 +16,6 @@ Failure modes expected in RED:
   - Test D: AttributeError or incorrect hybrid_score — no _apply_ontology_boost in v1.4
   - Test A: may already pass since embedding=1.0 after 29-01 YAML update; still confirmed.
 """
-import pytest
-from unittest.mock import MagicMock
 
 from src.suggestions.pathway import PathwaySuggestionService
 from src.core.config_loader import ConfigLoader

--- a/tests/test_rdf_empty_graph.py
+++ b/tests/test_rdf_empty_graph.py
@@ -16,7 +16,6 @@ The fix is to mirror ``download_ke_reactome_rdf``'s guard:
     else:
         cache_path.write_text("", encoding="utf-8")
 """
-import pytest
 
 import src.blueprints.main as main_bp_mod
 

--- a/tests/test_reactome_admin.py
+++ b/tests/test_reactome_admin.py
@@ -142,7 +142,7 @@ class TestAdminReactomeProposalsList:
         """status query param filters proposals."""
         client, rm, rpm, db = admin_client
         # Seed pending + rejected
-        pid_pending = _seed_proposal(rpm, ke_id="KE 2001", reactome_id="R-HSA-2001")
+        _seed_proposal(rpm, ke_id="KE 2001", reactome_id="R-HSA-2001")
         pid_rejected = _seed_proposal(rpm, ke_id="KE 2002", reactome_id="R-HSA-2002")
         rpm.update_proposal_status(
             proposal_id=pid_rejected,
@@ -455,7 +455,7 @@ class TestAdminReactomeProposalsStatusFilter:
         proposal under ?status=approved.
         """
         client, rm, rpm, db = admin_client
-        pid_pending = _seed_proposal(
+        _seed_proposal(
             rpm, ke_id="KE 5001", reactome_id="R-HSA-5001"
         )
         pid_approved = _seed_proposal(
@@ -496,7 +496,7 @@ class TestAdminReactomeProposalsStatusFilter:
         — verify a rejected proposal is NOT visible under the default view.
         """
         client, rm, rpm, db = admin_client
-        pid_pending = _seed_proposal(
+        _seed_proposal(
             rpm, ke_id="KE 6001", reactome_id="R-HSA-6001"
         )
         pid_rejected = _seed_proposal(
@@ -522,7 +522,7 @@ class TestAdminReactomeProposalsStatusFilter:
         pending + approved + rejected is returned.
         """
         client, rm, rpm, db = admin_client
-        pid_pending = _seed_proposal(
+        _seed_proposal(
             rpm, ke_id="KE 7001", reactome_id="R-HSA-7001"
         )
         pid_approved = _seed_proposal(
@@ -563,7 +563,7 @@ class TestAdminReactomeStatusBadge:
         badge-styling contract fails fast.
         """
         client, rm, rpm, db = admin_client
-        pid_pending = _seed_proposal(
+        _seed_proposal(
             rpm, ke_id="KE 8001", reactome_id="R-HSA-8001"
         )
         pid_approved = _seed_proposal(

--- a/tests/test_reactome_submission.py
+++ b/tests/test_reactome_submission.py
@@ -71,7 +71,6 @@ class TestSubmitReactomeCreatesProposal:
         from app import app as flask_app
         import src.blueprints.api as api_mod
         from src.core.models import (
-            CacheModel,
             Database,
             ReactomeMappingModel,
             ReactomeProposalModel,

--- a/tests/test_reactome_suggestion_ranking.py
+++ b/tests/test_reactome_suggestion_ranking.py
@@ -11,7 +11,7 @@ Tests A-D prove:
      exactly embedding_weight * text_similarity (old +0.05 bonus is gone)
 """
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 # ============================================================================

--- a/tests/test_scoring_helper.py
+++ b/tests/test_scoring_helper.py
@@ -10,7 +10,6 @@ These tests ensure:
 Tests 1-4: combine_scored_items() behaviour (Task 1 — plan 29-01)
 Tests 5-7: ConfigLoader v1.5 compatibility (Task 3 — plan 29-01)
 """
-import pytest
 from src.suggestions.scoring import combine_scored_items
 
 

--- a/tests/test_source_version_exports.py
+++ b/tests/test_source_version_exports.py
@@ -8,7 +8,6 @@ stamped by Phase C / D actually flow through to:
 - The JSON exporter (schema fields + per-row values)
 """
 import json
-import sqlite3
 from pathlib import Path
 
 import pytest

--- a/tests/test_source_version_stamping.py
+++ b/tests/test_source_version_stamping.py
@@ -19,8 +19,6 @@ model to keep this test module focused on the new wiring.
 """
 import json
 import sqlite3
-import sys
-import types
 from pathlib import Path
 
 import pytest

--- a/tests/test_source_version_ui_and_zenodo.py
+++ b/tests/test_source_version_ui_and_zenodo.py
@@ -58,7 +58,7 @@ def app_with_manifest(tmp_path, monkeypatch):
     }
     # The context processor reads "data/source_versions.json" relative to
     # CWD, so chdir into a tmp dir that has our manifest in place.
-    proj_root = Path(__file__).resolve().parent.parent
+    Path(__file__).resolve().parent.parent
     work = tmp_path / "work"
     work.mkdir()
     (work / "data").mkdir()

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -1,12 +1,8 @@
 """
 Tests for the public REST API v1 blueprint (/api/v1/).
 """
-import csv
-import io
-import json
 import os
 import tempfile
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_v1_api_reactome.py
+++ b/tests/test_v1_api_reactome.py
@@ -3,12 +3,8 @@ Tests for the public REST API v1 Reactome surface (/api/v1/reactome-mappings).
 
 Phase 26-05: Mirrors test_v1_api.py for the Reactome read endpoints.
 """
-import csv
-import io
-import json
 import os
 import tempfile
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_zenodo_assembly.py
+++ b/tests/test_zenodo_assembly.py
@@ -13,7 +13,6 @@ import io
 import json
 import zipfile
 
-import pytest
 
 from src.exporters.zenodo_assembly import (
     assemble_deposit_files,

--- a/tests/test_zenodo_meta_fallback.py
+++ b/tests/test_zenodo_meta_fallback.py
@@ -8,7 +8,6 @@ loudly so the operator can copy it back.
 import os
 import stat
 
-import pytest
 
 from src.exporters import zenodo_uploader
 from src.exporters.zenodo_uploader import persist_meta_with_fallback


### PR DESCRIPTION
## Summary

Closes 64 CodeQL alerts in a single mechanical sweep — pure cleanup, no behaviour change.

| CodeQL rule | Count | Ruff rule |
|---|---|---|
| `py/unused-import` | 45 | F401 |
| `py/unused-local-variable` | 11 | F841 |
| `py/import-and-import-from` | 5 | F401 / F811 |
| `py/unused-global-variable` | 2 | F401 |
| `py/repeated-import` | 1 | F811 |

## How

```
ruff check --select F401,F841,F811 --fix --unsafe-fixes .
```

Pinned `ruff==0.15.0` in `requirements-dev.txt` and added a minimal `[tool.ruff.lint]` section to `pyproject.toml` so the rule selection stays narrow — same three rules, no broader style sweep. `flake8` keeps covering the rest of the style surface.

## Manual touches on top of the autofix

- `src/blueprints/main.py` — dropped the redundant `import datetime` above `from datetime import datetime`
- `src/exporters/excel_exporter.py` and `examples/python_examples.py` — annotated two `# noqa: F401` imports that look unused to ruff but are deliberate availability probes inside `try/ImportError` blocks
- `scripts/publish_zenodo.py` — kept `_format_versions_for_prose` and `_format_snapshot_table_md` as `noqa: F401` re-exports; tests import them by their underscore-aliased names

## Test plan

- [x] `pytest tests/` — 431 passed, 54.12% coverage
- [x] `ruff check --select F401,F841,F811 .` — All checks passed
- [ ] CI on this PR confirms no regression