### PR TITLE
security: wrap remaining log args in sanitize_log to clear CodeQL log-injection

### DIFF
--- a/src/blueprints/admin.py
+++ b/src/blueprints/admin.py
@@ -295,7 +295,7 @@ def admin_proposal_detail(proposal_id: int):
         return jsonify(proposal)
 
     except Exception as e:
-        logger.error("Error getting proposal %s: %s", proposal_id, sanitize_log(str(e)))
+        logger.error("Error getting proposal %s: %s", sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to load proposal"}), 500
 
 
@@ -443,7 +443,7 @@ def approve_proposal(proposal_id: int):
             )
 
             logger.info(
-                "Proposal %s approved by %s, mapping %s", proposal_id, sanitize_log(admin_username), action
+                "Proposal %s approved by %s, mapping %s", sanitize_log(proposal_id), sanitize_log(admin_username), action
             )
             return (
                 jsonify(
@@ -458,7 +458,7 @@ def approve_proposal(proposal_id: int):
             return jsonify({"error": f"Failed to {action.rstrip('d')} mapping"}), 500
 
     except Exception as e:
-        logger.error("Error approving proposal %s: %s", proposal_id, sanitize_log(str(e)))
+        logger.error("Error approving proposal %s: %s", sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to approve proposal"}), 500
 
 
@@ -519,13 +519,13 @@ def reject_proposal(proposal_id: int):
         )
 
         if success:
-            logger.info("Proposal %s rejected by %s", proposal_id, sanitize_log(admin_username))
+            logger.info("Proposal %s rejected by %s", sanitize_log(proposal_id), sanitize_log(admin_username))
             return jsonify({"message": "Proposal rejected successfully."}), 200
         else:
             return jsonify({"error": "Failed to reject proposal"}), 500
 
     except Exception as e:
-        logger.error("Error rejecting proposal %s: %s", proposal_id, sanitize_log(str(e)))
+        logger.error("Error rejecting proposal %s: %s", sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to reject proposal"}), 500
 
 
@@ -608,7 +608,7 @@ def admin_go_proposal_detail(proposal_id: int):
         return jsonify(proposal)
 
     except Exception as e:
-        logger.error("Error getting GO proposal %s: %s", proposal_id, sanitize_log(str(e)))
+        logger.error("Error getting GO proposal %s: %s", sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to load GO proposal"}), 500
 
 
@@ -727,7 +727,7 @@ def approve_go_proposal(proposal_id: int):
             )
             logger.info(
                 "GO proposal %s approved by %s, mapping %s created",
-                proposal_id, sanitize_log(admin_username), new_mapping_id,
+                sanitize_log(proposal_id), sanitize_log(admin_username), sanitize_log(new_mapping_id),
             )
             return jsonify({
                 "message": "GO proposal approved successfully. Mapping created.",
@@ -737,7 +737,7 @@ def approve_go_proposal(proposal_id: int):
             return jsonify({"error": "Failed to create GO mapping (pair may already exist)"}), 500
 
     except Exception as e:
-        logger.error("Error approving GO proposal %s: %s", proposal_id, sanitize_log(str(e)))
+        logger.error("Error approving GO proposal %s: %s", sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to approve GO proposal"}), 500
 
 
@@ -780,13 +780,13 @@ def reject_go_proposal(proposal_id: int):
         )
 
         if success:
-            logger.info("GO proposal %s rejected by %s", proposal_id, sanitize_log(admin_username))
+            logger.info("GO proposal %s rejected by %s", sanitize_log(proposal_id), sanitize_log(admin_username))
             return jsonify({"message": "GO proposal rejected successfully."}), 200
         else:
             return jsonify({"error": "Failed to reject GO proposal"}), 500
 
     except Exception as e:
-        logger.error("Error rejecting GO proposal %s: %s", proposal_id, sanitize_log(str(e)))
+        logger.error("Error rejecting GO proposal %s: %s", sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to reject GO proposal"}), 500
 
 
@@ -850,7 +850,7 @@ def admin_reactome_proposal_detail(proposal_id: int):
 
     except Exception as e:
         logger.error("Error getting Reactome proposal %s: %s",
-                     proposal_id, sanitize_log(str(e)))
+                     sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to load Reactome proposal"}), 500
 
 
@@ -925,7 +925,7 @@ def approve_reactome_proposal(proposal_id: int):
             logger.error(
                 "Reactome proposal %s status flip failed after mapping %s "
                 "created; rolling back mapping",
-                proposal_id, new_mapping_id,
+                sanitize_log(proposal_id), sanitize_log(new_mapping_id),
             )
             reactome_mapping_model.delete_mapping(new_mapping_id)
             return jsonify({
@@ -934,7 +934,7 @@ def approve_reactome_proposal(proposal_id: int):
 
         logger.info(
             "Reactome proposal %s approved by %s, mapping %s created",
-            proposal_id, sanitize_log(admin_username), new_mapping_id,
+            sanitize_log(proposal_id), sanitize_log(admin_username), sanitize_log(new_mapping_id),
         )
         return jsonify({
             "message": "Reactome proposal approved successfully. Mapping created.",
@@ -943,7 +943,7 @@ def approve_reactome_proposal(proposal_id: int):
 
     except Exception as e:
         logger.error("Error approving Reactome proposal %s: %s",
-                     proposal_id, sanitize_log(str(e)))
+                     sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to approve Reactome proposal"}), 500
 
 
@@ -988,14 +988,14 @@ def reject_reactome_proposal(proposal_id: int):
 
         if success:
             logger.info("Reactome proposal %s rejected by %s",
-                        proposal_id, sanitize_log(admin_username))
+                        sanitize_log(proposal_id), sanitize_log(admin_username))
             return jsonify({"message": "Reactome proposal rejected successfully."}), 200
         else:
             return jsonify({"error": "Failed to reject Reactome proposal"}), 500
 
     except Exception as e:
         logger.error("Error rejecting Reactome proposal %s: %s",
-                     proposal_id, sanitize_log(str(e)))
+                     sanitize_log(proposal_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to reject Reactome proposal"}), 500
 
 
@@ -1086,13 +1086,13 @@ def revoke_guest_code(code_id: int):
         success = guest_code_model.revoke_code(code_id, admin_username)
 
         if success:
-            logger.info("Guest code %d revoked by %s", code_id, sanitize_log(admin_username))
+            logger.info("Guest code %d revoked by %s", sanitize_log(code_id), sanitize_log(admin_username))
             return jsonify({"message": "Guest code revoked."}), 200
         else:
             return jsonify({"error": "Failed to revoke guest code."}), 500
 
     except Exception as e:
-        logger.error("Error revoking guest code %d: %s", code_id, sanitize_log(str(e)))
+        logger.error("Error revoking guest code %d: %s", sanitize_log(code_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to revoke guest code."}), 500
 
 
@@ -1388,5 +1388,5 @@ def toggle_ke_description(ke_id: str):
             return jsonify({"error": "Failed to save override"}), 500
 
     except Exception as e:
-        logger.error("Error toggling KE description for %s: %s", ke_id, e)
+        logger.error("Error toggling KE description for %s: %s", sanitize_log(ke_id), sanitize_log(str(e)))
         return jsonify({"error": "Failed to toggle description"}), 500

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -104,7 +104,7 @@ def _log_method_filter_deprecation(filter_value: str, endpoint_name: str) -> Non
             "DEPRECATED: method_filter=%s on %s — this query parameter is deprecated "
             "and will be removed in v2. Frontend no longer sends it; backend still honors "
             "it for backward compatibility. Pure-semantic ranking is the v1.5 default.",
-            filter_value, endpoint_name,
+            sanitize_log(filter_value), sanitize_log(endpoint_name),
         )
 
 
@@ -859,7 +859,7 @@ def search_pathways():
         elif limit < 1:
             limit = 20
             
-        logger.info("Searching pathways with query: '%s', threshold: %s", sanitize_log(query), threshold)
+        logger.info("Searching pathways with query: '%s', threshold: %s", sanitize_log(query), sanitize_log(threshold))
         
         # Perform search
         results = pathway_suggestion_service.search_pathways(
@@ -1414,7 +1414,7 @@ def search_go_terms():
         elif limit < 1:
             limit = 10
 
-        logger.info("Searching GO terms with query: '%s', threshold: %s", sanitize_log(query), threshold)
+        logger.info("Searching GO terms with query: '%s', threshold: %s", sanitize_log(query), sanitize_log(threshold))
 
         results = go_suggestion_service.search_go_terms(query, threshold, limit)
 
@@ -1779,7 +1779,7 @@ def search_reactome():
 
         logger.info(
             "Searching Reactome pathways with query: '%s', threshold: %s",
-            sanitize_log(query), threshold,
+            sanitize_log(query), sanitize_log(threshold),
         )
 
         results = reactome_suggestion_service.search_reactome_terms(
@@ -1828,7 +1828,7 @@ def flag_proposal_stale():
             ok = proposal_model.flag_proposal_stale(proposal_id, flagged_by)
 
         if ok:
-            logger.info("Proposal %s flagged stale by %s", proposal_id, flagged_by)
+            logger.info("Proposal %s flagged stale by %s", sanitize_log(proposal_id), sanitize_log(flagged_by))
             return jsonify({"message": "Proposal flagged as stale for admin review."}), 200
         else:
             return jsonify({"error": "Failed to flag proposal"}), 500

--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -7,6 +7,7 @@ import logging
 from flask import Blueprint, redirect, render_template, request, session, url_for
 
 from src.services.rate_limiter import submission_rate_limit
+from src.utils.text import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ def login_provider(provider):
     """Initiate OAuth login flow for the given provider"""
     client = provider_clients.get(provider)
     if not client:
-        logger.error("OAuth client not found for provider: %s", provider)
+        logger.error("OAuth client not found for provider: %s", sanitize_log(provider))
         return redirect(url_for("main.index"))
 
     next_url = request.args.get("next") or request.referrer
@@ -45,7 +46,7 @@ def oauth_callback(provider):
     """Handle OAuth callback for the given provider"""
     client = provider_clients.get(provider)
     if not client:
-        logger.error("OAuth callback for unknown provider: %s", provider)
+        logger.error("OAuth callback for unknown provider: %s", sanitize_log(provider))
         return redirect(url_for("main.index"))
 
     try:
@@ -72,11 +73,11 @@ def oauth_callback(provider):
             "email": email,
             "provider": provider,
         }
-        logger.info("User %s logged in via %s", prefixed_username, provider)
+        logger.info("User %s logged in via %s", sanitize_log(prefixed_username), sanitize_log(provider))
         next_url = session.pop("login_next_url", None) or url_for("main.index")
         return redirect(next_url)
     except Exception as e:
-        logger.error("OAuth callback error for %s: %s", provider, e)
+        logger.error("OAuth callback error for %s: %s", sanitize_log(provider), sanitize_log(str(e)))
         session.pop("login_next_url", None)
         return redirect(url_for("main.index"))
 


### PR DESCRIPTION
## Summary

Closes 29 `py/log-injection` CodeQL alerts. Most are paranoia about `<int:proposal_id>` URL-converter values that can't actually contain newlines, but wrapping them is idempotent for ints and a real defence for the genuinely user-controlled callsites (`provider`, `query`, deprecated `method_filter`).

## Changes

| File | Alerts | What |
|---|---|---|
| `src/blueprints/auth.py` | 5 | `provider` from URL converter is real user input — wrapped at every callsite. Added the missing `sanitize_log` import. |
| `src/blueprints/admin.py` | 19 | Bulk-wrapped `proposal_id`, `code_id`, `new_mapping_id`, `ke_id` args to `logger.*` calls. Also fixed L1391 where `e` was unwrapped. |
| `src/blueprints/api.py` | 5 | Wrapped `filter_value`, `endpoint_name`, `threshold`, `proposal_id`, `flagged_by` — all flow from query string or path. |

## Test plan

- [x] `pytest tests/` — 431 passed, 54.17% coverage
- [x] All three blueprint modules parse cleanly
- [ ] CI confirms no regression
- [ ] Next CodeQL scan closes the 29 `py/log-injection` alerts