### PR TITLE
security: use resolve+is_relative_to as CodeQL-recognised path-injection sanitizer

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -715,7 +715,15 @@ def _get_or_generate_gmt(mapping_type: str, min_confidence: str = None):
     today = datetime.today().date().isoformat()
     tier = min_confidence.capitalize() if min_confidence else "All"
     filename = f"KE-{mapping_type.upper()}_{today}_{tier}.gmt"
-    cache_path = EXPORT_CACHE_DIR / filename
+    # CodeQL sanitizer pattern: resolve and verify containment, even though the
+    # whitelist above already constrains the inputs to a finite set. CodeQL's
+    # taint analysis doesn't recognise the `not in` check and would otherwise
+    # still flag this as path-injection.
+    cache_root = EXPORT_CACHE_DIR.resolve()
+    candidate = (EXPORT_CACHE_DIR / filename).resolve()
+    if not candidate.is_relative_to(cache_root):
+        abort(404)
+    cache_path = candidate
     if not cache_path.exists():
         EXPORT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         if mapping_type == "wp":


### PR DESCRIPTION
## Summary

Closes 21 `py/path-injection` alerts at `main.py:719–804`.

[#181](https://github.com/marvinm2/KE-WP-mapping/pull/181) added a whitelist guard at the top of `_get_or_generate_gmt()` that rejects `mapping_type` and `min_confidence` values outside a finite set. Defensively that's already sufficient — but CodeQL's taint analyser doesn't treat `if x not in WHITELIST: abort()` as a sanitizer, so it kept flagging every downstream use of `cache_path`.

Switched to a **resolve-and-contain** check that CodeQL *does* recognise:

```python
cache_root = EXPORT_CACHE_DIR.resolve()
candidate = (EXPORT_CACHE_DIR / filename).resolve()
if not candidate.is_relative_to(cache_root):
    abort(404)
cache_path = candidate
```

This is on the [CodeQL Python path-injection sanitizer list](https://codeql.github.com/codeql-query-help/python/py-path-injection/), so the 21 alerts close.

The whitelist guard is **kept on top** because:
- It's still the cheapest reject for the 99% case
- Two layers is fine for security-sensitive code
- Removing it would re-open the alerts under a different reason

## Test plan

- [x] `pytest tests/` — 431 passed, 54.16% coverage
- [x] `pytest -k export` — 41 passed (all GMT/download routes)
- [ ] Manual: `/exports/gmt/ke-wp?min_confidence=high` returns the high-confidence GMT
- [ ] Manual: `/exports/gmt/ke-wp?min_confidence=../etc` returns 400 (caught by whitelist)
- [ ] Manual: `/exports/gmt/ke-wp` (no filter) returns the all-tier GMT