### PR TITLE
security: final CodeQL tail — recognised path-injection sanitizer + import cleanup

### DIFF
--- a/scripts/publish_zenodo.py
+++ b/scripts/publish_zenodo.py
@@ -77,11 +77,22 @@ from src.exporters.zenodo_assembly import (   # noqa: E402
     changes_significant as _changes_significant_impl,
     build_resource_zip as _build_resource_zip,
     slice_source_versions as _slice_source_versions,
-    format_versions_for_prose as _format_versions_for_prose,  # noqa: F401 — re-exported for tests
-    format_snapshot_table_md as _format_snapshot_table_md,  # noqa: F401 — re-exported for tests
+    format_versions_for_prose as _format_versions_for_prose,
+    format_snapshot_table_md as _format_snapshot_table_md,
     build_readme as _build_readme,
     build_metadata as _build_metadata,
 )
+
+# Explicit re-export list — tests/test_source_version_ui_and_zenodo.py imports
+# `_format_versions_for_prose` and `_format_snapshot_table_md` by their
+# underscore-aliased names from this module. Listing them in __all__ tells
+# static analyzers (ruff, CodeQL) the imports are intentional and used.
+__all__ = [
+    "_counts", "_changes_significant_impl",
+    "_build_resource_zip", "_slice_source_versions",
+    "_format_versions_for_prose", "_format_snapshot_table_md",
+    "_build_readme", "_build_metadata",
+]
 
 
 def _changes_significant(current: dict, last: Optional[dict], min_delta: int) -> bool:

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -648,8 +648,6 @@ def submit_proposal():
 
         # Parse entry data to extract KE and WP IDs
         try:
-            import json
-
             # Handle double-serialized JSON
             if entry_data.startswith('"') and entry_data.endswith('"'):
                 entry_data = json.loads(entry_data)  # First deserialization

--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -718,15 +718,15 @@ def _get_or_generate_gmt(mapping_type: str, min_confidence: str = None):
     today = datetime.today().date().isoformat()
     tier = min_confidence.capitalize() if min_confidence else "All"
     filename = f"KE-{mapping_type.upper()}_{today}_{tier}.gmt"
-    # CodeQL sanitizer pattern: resolve and verify containment, even though the
-    # whitelist above already constrains the inputs to a finite set. CodeQL's
-    # taint analysis doesn't recognise the `not in` check and would otherwise
-    # still flag this as path-injection.
-    cache_root = EXPORT_CACHE_DIR.resolve()
-    candidate = (EXPORT_CACHE_DIR / filename).resolve()
-    if not candidate.is_relative_to(cache_root):
+    # Realpath + str-prefix is the path-injection sanitizer pattern CodeQL
+    # explicitly recognises (see py/path-injection help). Pure `Path.is_relative_to`
+    # is correct defensively but isn't on the sanitizer list, so taint flows
+    # through and every downstream use of cache_path stays flagged.
+    cache_root = os.path.realpath(EXPORT_CACHE_DIR)
+    candidate_real = os.path.realpath(os.path.join(EXPORT_CACHE_DIR, filename))
+    if not (candidate_real == cache_root or candidate_real.startswith(cache_root + os.sep)):
         abort(404)
-    cache_path = candidate
+    cache_path = Path(candidate_real)
     if not cache_path.exists():
         EXPORT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         if mapping_type == "wp":

--- a/tests/test_source_version_stamping.py
+++ b/tests/test_source_version_stamping.py
@@ -22,6 +22,7 @@ import sqlite3
 from pathlib import Path
 
 import pytest
+import src.services.container as cont_mod
 
 from src.core.models import (
     Database,
@@ -35,18 +36,17 @@ from src.core.models import (
 # ---------- Container `source_versions` property ----------
 
 def _make_container(tmp_path: Path, manifest: dict | None):
-    """Mint a bare ServiceContainer with the manifest path overridden."""
-    from src.services.container import ServiceContainer
+    """Mint a bare cont_mod.ServiceContainer with the manifest path overridden."""
+    # ServiceContainer accessed via cont_mod to avoid mixed import styles
 
     class _StubConfig:
         DATABASE_PATH = str(tmp_path / "test.db")
 
-    c = ServiceContainer(_StubConfig())
+    c = cont_mod.ServiceContainer(_StubConfig())
 
     # Redirect the container's manifest lookup at the tmp_path directory.
-    # ServiceContainer.source_versions hard-codes the path under PROJECT_ROOT,
+    # cont_mod.ServiceContainer.source_versions hard-codes the path under PROJECT_ROOT,
     # so we monkeypatch the relevant module-level constant in-place.
-    import src.services.container as cont_mod
 
     if manifest is None:
         # Caller wants the "manifest missing" case — point PROJECT_ROOT at an
@@ -101,7 +101,6 @@ def test_source_versions_returns_empty_dict_when_file_unreadable(tmp_path):
     data_dir = tmp_path / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
     (data_dir / "source_versions.json").write_text("not valid json{", encoding="utf-8")
-    import src.services.container as cont_mod
 
     class _StubConfig:
         DATABASE_PATH = str(tmp_path / "x.db")

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -387,7 +387,7 @@ class TestAssessmentShape:
 
     def test_csv_fields_present(self):
         """Phase 34 fields appended at the END of _MAPPING_CSV_FIELDS."""
-        from src.blueprints.v1_api import _MAPPING_CSV_FIELDS
+        _MAPPING_CSV_FIELDS = v1_mod._MAPPING_CSV_FIELDS
 
         for required in ("connection_type", "assessment_version",
                           "proposed_relationship", "proposed_basis",
@@ -406,7 +406,7 @@ class TestAssessmentShape:
 
     def test_serialize_emits_assessment(self):
         """v2 row (all four answers + version='v2') round-trips through serializer."""
-        from src.blueprints.v1_api import _serialize_mapping
+        _serialize_mapping = v1_mod._serialize_mapping
 
         row = {
             "uuid": "x", "ke_id": "KE 1", "ke_title": "t",
@@ -429,7 +429,7 @@ class TestAssessmentShape:
 
     def test_legacy_v1_serializes_with_null_answers(self):
         """Pre-Phase-34 row (no proposed_*, no assessment_version) → version='v1', NULLs."""
-        from src.blueprints.v1_api import _serialize_mapping
+        _serialize_mapping = v1_mod._serialize_mapping
 
         row = {
             "uuid": "x", "ke_id": "KE 1", "ke_title": "t",
@@ -447,7 +447,7 @@ class TestAssessmentShape:
 
     def test_flatten_for_csv_lifts_assessment(self):
         """_flatten_for_csv lifts the nested assessment object to top-level columns."""
-        from src.blueprints.v1_api import _flatten_for_csv
+        _flatten_for_csv = v1_mod._flatten_for_csv
 
         serialized = {
             "uuid": "x", "ke_id": "KE 1", "ke_name": "t",
@@ -481,7 +481,7 @@ class TestAssessmentShape:
 
     def test_flatten_for_csv_handles_missing_assessment(self):
         """_flatten_for_csv defaults assessment_version='v1' when block is absent."""
-        from src.blueprints.v1_api import _flatten_for_csv
+        _flatten_for_csv = v1_mod._flatten_for_csv
 
         serialized = {
             "uuid": "x", "ke_id": "KE 1", "ke_name": "t",

--- a/tests/test_v1_api_reactome.py
+++ b/tests/test_v1_api_reactome.py
@@ -138,7 +138,7 @@ class TestSerializer:
         forbidden tuple. The remaining forbidden entries guard against
         GO-specific fields leaking into the Reactome shape.
         """
-        from src.blueprints.v1_api import _REACTOME_MAPPING_CSV_FIELDS
+        _REACTOME_MAPPING_CSV_FIELDS = v1_mod._REACTOME_MAPPING_CSV_FIELDS
 
         assert _REACTOME_MAPPING_CSV_FIELDS[0] == "uuid"
         assert "reactome_id" in _REACTOME_MAPPING_CSV_FIELDS
@@ -172,7 +172,7 @@ class TestSerializer:
         The remaining forbidden entries guard against GO-specific fields
         leaking into the Reactome shape.
         """
-        from src.blueprints.v1_api import _serialize_reactome_mapping
+        _serialize_reactome_mapping = v1_mod._serialize_reactome_mapping
 
         row = {
             "uuid": "u1", "ke_id": "KE 1", "ke_title": "Apoptosis",
@@ -223,13 +223,12 @@ class TestSerializer:
 
     def test_serialize_enrichment_fallback(self):
         """When metadata/counts globals are unset/None, serializer must not raise."""
-        from src.blueprints.v1_api import _serialize_reactome_mapping
-        import src.blueprints.v1_api as v1
+        _serialize_reactome_mapping = v1_mod._serialize_reactome_mapping
 
-        original_meta = v1.reactome_metadata
-        original_counts = v1.reactome_gene_counts
-        v1.reactome_metadata = None
-        v1.reactome_gene_counts = None
+        original_meta = v1_mod.reactome_metadata
+        original_counts = v1_mod.reactome_gene_counts
+        v1_mod.reactome_metadata = None
+        v1_mod.reactome_gene_counts = None
         try:
             row = {
                 "uuid": "u1", "ke_id": "KE 1", "ke_title": "Apoptosis",
@@ -240,8 +239,8 @@ class TestSerializer:
             assert out["pathway_description"] is None
             assert out["reactome_gene_count"] == 0
         finally:
-            v1.reactome_metadata = original_meta
-            v1.reactome_gene_counts = original_counts
+            v1_mod.reactome_metadata = original_meta
+            v1_mod.reactome_gene_counts = original_counts
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the residual CodeQL findings remaining after #185 and #183.

| Rule | Count | Fix |
|---|---|---|
| `py/path-injection` | 22 | Swap `is_relative_to()` → `realpath()` + `startswith()` (CodeQL's recognised sanitizer pattern) |
| `py/import-and-import-from` | 5 | Refactor 3 test files to use existing module aliases instead of mixing `import X as alias` + inline `from X import Y` |
| `py/repeated-import` | 1 | Drop inline `import json` in `api.py:651` — top-level already has it |
| `py/unused-import` | 1 | Add `__all__` to `publish_zenodo.py` listing the underscore-aliased re-exports (CodeQL recognises `__all__`; `# noqa: F401` it didn't) |
| `py/unused-global-variable` × 2 | 2 | **Dismiss via API** — CodeQL false positive; `_config_cache` IS read at L945-948 via `global` decl |
| `py/request-without-cert-validation` | 1 | **Re-dismiss via API** — documented intentional Reactome SSL fallback; original dismissal got revoked when a comment block shifted line numbers |

## Details

### Path-injection — the canonical sanitizer

```python
cache_root = os.path.realpath(EXPORT_CACHE_DIR)
candidate_real = os.path.realpath(os.path.join(EXPORT_CACHE_DIR, filename))
if not (candidate_real == cache_root or candidate_real.startswith(cache_root + os.sep)):
    abort(404)
cache_path = Path(candidate_real)
```

CodeQL's `py/path-injection` help explicitly lists `realpath` + prefix check as a recognised sanitizer. `is_relative_to()` is not. Whitelist guard at function entry preserved as defence in depth.

### Test refactor

`tests/test_v1_api.py`, `tests/test_v1_api_reactome.py`, `tests/test_source_version_stamping.py` had inline `from src.X import Y` inside test methods while also having `import src.X as alias` at module scope. CodeQL flags this as ambiguous. Rewrote each inline import as `Y = alias.Y` so the module is only ever imported once.

### `__all__` for test re-exports

`publish_zenodo.py` imports `format_versions_for_prose as _format_versions_for_prose` (and one more) purely so tests can do `from scripts.publish_zenodo import _format_snapshot_table_md`. Added `__all__` listing all the underscore aliases — ruff's `# noqa: F401` satisfied ruff but not CodeQL.

## Test plan

- [x] `pytest tests/` — 431 passed, 54.16% coverage
- [x] All four modified Python files parse cleanly
- [ ] CI confirms no regression
- [ ] After merge, dismiss the 3 documented false-positive alerts via API