### PR TITLE
fix(docker): drop duplicate torch pin so requirements.txt is single source of truth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM python:3.12-slim-bookworm AS builder
 WORKDIR /build
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 COPY requirements.txt .
+# torch's +cpu wheel index URL is needed at install time, but the version
+# itself is pinned in requirements.txt — listing it here too would conflict
+# with bumps (see CI failure on commit 1c51bec). Single source of truth.
 RUN pip install --no-cache-dir --prefix=/install \
-    torch==2.6.0+cpu \
     --extra-index-url https://download.pytorch.org/whl/cpu \
     -r requirements.txt
 


### PR DESCRIPTION
## Summary

**Production-deploy blocker.** The Dockerfile builder stage installs `torch==2.6.0+cpu` explicitly on its own line, then runs `pip install -r requirements.txt`. After #180 bumped `torch` to 2.8.0+cpu in requirements.txt, the two pins conflict and pip refuses:

```
The user requested torch==2.8.0+cpu
ERROR: ResolutionImpossible
```

This caused the `docker-security` CI job on commit 1c51bec (the #180 merge) to fail, and the same failure would have hit production on the next `docker build`.

## Fix

Removed the explicit `torch==2.6.0+cpu` line. Kept the `--extra-index-url https://download.pytorch.org/whl/cpu` because that's what makes the `+cpu` suffix resolve. `requirements.txt` remains the single version source.

## Test plan

- [x] Diff is minimal (3 lines)
- [ ] CI's `docker-security` build succeeds (was failing on previous commit)
- [ ] After merge, `docker build` works locally and on tgx1