### PR TITLE
fix: mapper UX (#194/#195/#196) + GO/Reactome suggestion corpus & search (#193/#196)

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 from dotenv import load_dotenv
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, jsonify, render_template, request, session
 from werkzeug.middleware.proxy_fix import ProxyFix
 from flask_wtf import CSRFProtect
 from flask_wtf.csrf import CSRFError
@@ -143,8 +143,30 @@ def create_app(config_name: str = None):
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):
         logger.warning("CSRF error: %s from %s", sanitize_log(str(e.description)), sanitize_log(request.remote_addr))
-        if request.is_json:
+        # A session-bound CSRF token becomes invalid the moment the login session
+        # expires, so a CSRF failure with no logged-in user is really an expired
+        # session — surface it as 401 so the client can prompt re-login and preserve
+        # the in-progress assessment, instead of a misleading generic error (#195).
+        session_expired = "user" not in session
+        # The mapper submits form-encoded data via jQuery ($.post), so request.is_json
+        # is False; detect AJAX via X-Requested-With so these posts still get a JSON
+        # body the client can key on (rather than an HTML error page).
+        wants_json = (
+            request.is_json
+            or request.headers.get("X-Requested-With") == "XMLHttpRequest"
+        )
+        if wants_json:
+            if session_expired:
+                return jsonify({"error": "session_expired"}), 401
             return jsonify({"error": "CSRF token missing or invalid"}), 400
+        if session_expired:
+            return (
+                render_template(
+                    "error.html",
+                    error="Your session has expired. Please log in again.",
+                ),
+                401,
+            )
         return (
             render_template(
                 "error.html", error="Security token expired. Please refresh the page."

--- a/scripts/download_reactome_annotations.py
+++ b/scripts/download_reactome_annotations.py
@@ -49,6 +49,17 @@ DISEASE_ROOT = "R-HSA-1643685"
 MIN_GENES = 10
 MAX_GENES = 500
 
+# Umbrella pathways that best fit generic upstream KEs but whose gene set exceeds
+# MAX_GENES, so the ceiling drops them and curators can neither suggest nor search
+# them (#196). Force-included past the ceiling. Disease-branch exclusion and the
+# MIN_GENES floor still apply. Extend as new generic KEs surface.
+UMBRELLA_WHITELIST = {
+    "R-HSA-5357801": "Programmed Cell Death",
+    "R-HSA-109581": "Apoptosis",
+    "R-HSA-73894": "DNA Repair",
+    "R-HSA-3299685": "Detoxification of Reactive Oxygen Species",
+}
+
 # Output file paths
 OUTPUT_PATH = "data/reactome_gene_annotations.json"
 FILTERED_STIDS_PATH = "data/reactome_filtered_stids.json"
@@ -370,20 +381,36 @@ def filter_annotations(raw_annotations, disease_ids, min_genes=MIN_GENES, max_ge
     filtered = {}
     n_disease = 0
     n_genecount = 0
+    n_whitelisted = 0
 
     for stid, genes in raw_annotations.items():
         if stid in disease_ids:
             n_disease += 1
             continue
-        if not (min_genes <= len(genes) <= max_genes):
+        n = len(genes)
+        if n < min_genes:
             n_genecount += 1
             continue
+        if n > max_genes:
+            # Umbrella pathways bypass the upper bound so generic KEs can map to them.
+            if stid in UMBRELLA_WHITELIST:
+                n_whitelisted += 1
+            else:
+                n_genecount += 1
+                continue
         filtered[stid] = genes
 
+    missing_whitelist = sorted(set(UMBRELLA_WHITELIST) - set(filtered))
     logger.info(
-        "Filter results: %d kept (from %d raw) | excluded: %d disease branch, %d gene count out of bounds",
-        len(filtered), len(raw_annotations), n_disease, n_genecount
+        "Filter results: %d kept (from %d raw) | excluded: %d disease branch, "
+        "%d gene count out of bounds | +%d umbrella-whitelisted",
+        len(filtered), len(raw_annotations), n_disease, n_genecount, n_whitelisted
     )
+    if missing_whitelist:
+        logger.warning(
+            "Umbrella-whitelisted pathways absent from the raw GMT (renamed/withdrawn?): %s",
+            ", ".join(missing_whitelist),
+        )
     return filtered
 
 

--- a/scripts/precompute_go_hierarchy.py
+++ b/scripts/precompute_go_hierarchy.py
@@ -27,6 +27,7 @@ import json
 import logging
 import math
 import os
+import re
 import sys
 from collections import defaultdict, deque
 from urllib.request import Request, urlopen
@@ -66,6 +67,53 @@ NAMESPACE_ROOTS = {
 # Mirrors the Reactome filter in download_reactome_annotations.py.
 MIN_GENES = 10
 MAX_GENES = 500
+
+# Canonical generic BP process terms that recur across many AOPs (cell death,
+# inflammation, DNA damage, ROS, oxidative stress). Their PROPAGATED gene sets
+# exceed MAX_GENES, so the gene-count ceiling drops them and curators can neither
+# suggest nor search them for generic upstream KEs (#193). These IDs are
+# force-included in the suggestion corpus regardless of gene count. Keep neutral,
+# non-obsolete terms only — extend as new generic KEs surface.
+GENERIC_BP_WHITELIST = {
+    "GO:0006954": "inflammatory response",
+    "GO:0008219": "cell death",
+    "GO:0006915": "apoptotic process",
+    "GO:0012501": "programmed cell death",
+    "GO:0006974": "DNA damage response",
+    "GO:0072593": "reactive oxygen species metabolic process",
+    "GO:0006979": "response to oxidative stress",
+}
+
+# Directional / signed GO labels must never be suggested for a KE Process slot:
+# direction belongs in the KE's PATO Action slot, not the GO term (see the
+# amigo-ke-go-mapping skill's directionality lexicon). Terms whose label matches
+# any of these operators are excluded from the suggestion corpus entirely (#193).
+# NOTE: neutral "regulation of X" (no sign), bare "X activation" (e.g. "T cell
+# activation"), and "... activity" MF terms are deliberately NOT matched.
+DIRECTIONAL_LABEL_RE = re.compile(
+    "|".join([
+        r"\bpositive regulation of\b",
+        r"\bnegative regulation of\b",
+        r"\bactivation of\b",
+        r"\binhibition of\b",
+        r"\binduction of\b",
+        r"\brepression of\b",
+        r"\bsuppression of\b",
+        r"\bstimulation of\b",
+        r"\bup[- ]?regulation\b",
+        r"\bdown[- ]?regulation\b",
+        r"\bincreased?\b",
+        r"\bdecreased?\b",
+        r"\bactivated\b",
+        r"\binhibited\b",
+    ]),
+    re.IGNORECASE,
+)
+
+
+def is_directional_label(name: str) -> bool:
+    """True if a GO label encodes a sign/direction (excluded from the corpus)."""
+    return bool(name and DIRECTIONAL_LABEL_RE.search(name))
 
 
 def download_go_obo(url=GO_BASIC_OBO_URL, local_path=GO_BASIC_OBO_LOCAL, force=False):
@@ -440,20 +488,46 @@ def main():
 
     # Write the filtered-ID list: terms whose propagated gene set is in
     # [MIN_GENES, MAX_GENES]. Drives the embedding-corpus subset (subset_go_corpus.py).
-    in_range = sorted(
+    in_range_ids = {
         go_id for go_id, c in propagated_counts.items()
         if MIN_GENES <= c <= MAX_GENES
-    )
+    }
     dropped_zero = sum(1 for c in propagated_counts.values() if c == 0)
     dropped_low = sum(1 for c in propagated_counts.values() if 0 < c < MIN_GENES)
     dropped_high = sum(1 for c in propagated_counts.values() if c > MAX_GENES)
+
+    # Force-include the curated generic BP terms dropped by the gene-count ceiling
+    # so they are suggestable/searchable for generic upstream KEs (#193, BP only).
+    whitelist = set(GENERIC_BP_WHITELIST) if namespace == 'bp' else set()
+    forced = {gid for gid in whitelist if gid in terms}
+    missing_whitelist = sorted(whitelist - forced)
+    n_whitelisted = len(forced - in_range_ids)
+
+    # Exclude directional/signed terms entirely — direction lives in the KE's PATO
+    # Action slot, not the GO term, so signed variants must never be suggested (#193).
+    candidate_ids = in_range_ids | forced
+    kept, n_directional_excluded = set(), 0
+    for gid in candidate_ids:
+        if is_directional_label((terms.get(gid) or {}).get('name') or ''):
+            n_directional_excluded += 1
+            continue
+        kept.add(gid)
+    in_range = sorted(kept)
+
     with open(filtered_ids_path, 'w', encoding='utf-8') as f:
         json.dump(in_range, f, indent=2)
     logger.info(
-        "Filter [%d,%d] genes: %d kept (of %d) | dropped: %d zero-gene, %d <%d, %d >%d -> %s",
+        "Filter [%d,%d] genes: %d kept (of %d) | dropped: %d zero-gene, %d <%d, %d >%d | "
+        "+%d generic-whitelisted, -%d directional-excluded -> %s",
         MIN_GENES, MAX_GENES, len(in_range), len(propagated_counts),
-        dropped_zero, dropped_low, MIN_GENES, dropped_high, MAX_GENES, filtered_ids_path,
+        dropped_zero, dropped_low, MIN_GENES, dropped_high, MAX_GENES,
+        n_whitelisted, n_directional_excluded, filtered_ids_path,
     )
+    if missing_whitelist:
+        logger.warning(
+            "Whitelisted generic terms not found in parsed %s namespace (obsolete/renamed?): %s",
+            namespace, ", ".join(missing_whitelist),
+        )
     logger.info("Done.")
 
 

--- a/src/blueprints/admin.py
+++ b/src/blueprints/admin.py
@@ -998,6 +998,319 @@ def reject_reactome_proposal(proposal_id: int):
         return jsonify({"error": "Failed to reject Reactome proposal"}), 500
 
 
+# ---------------------------------------------------------------------------
+# Bulk-approve routes (Phase 38 ADMIN-01/06)
+# ---------------------------------------------------------------------------
+
+
+@admin_bp.route("/proposals/bulk-approve", methods=["POST"])
+@admin_required
+@submission_rate_limit
+def bulk_approve_proposals():
+    """
+    Approve a batch of WP new-pair proposals in a single transaction.
+
+    Accepts a JSON body: {"ids": [int, ...], "admin_notes": "optional string"}.
+    Only new-pair proposals (mapping_id IS NULL, not proposed_delete) are
+    handled here; revision/delete proposals go through the single-approve
+    route.
+
+    Returns: {"approved": [mapping_uuid_str, ...], "failed": [{"id": int, "reason": str}, ...]}
+
+    Whole-batch rollback on any transaction error (H-1 invariant).
+    """
+    try:
+        if not request.is_json:
+            return jsonify({"error": "JSON body required"}), 400
+
+        admin_data = {"admin_notes": request.json.get("admin_notes", "")}
+
+        is_valid, validated_data, errors = validate_request_data(
+            AdminNotesSchema, admin_data
+        )
+        if not is_valid:
+            logger.warning("Invalid admin notes in WP bulk-approve: %s", errors)
+            return jsonify({"error": "Invalid input data", "details": errors}), 400
+
+        admin_notes = SecurityValidation.sanitize_string(
+            validated_data["admin_notes"], max_length=1000
+        )
+        admin_username = session.get("user", {}).get("username")
+
+        if not SecurityValidation.validate_username(admin_username):
+            logger.error(
+                "Invalid admin username in WP bulk-approve: %s",
+                sanitize_log(str(admin_username)),
+            )
+            return jsonify({"error": "Authentication error"}), 401
+
+        # Coerce and validate the ID list
+        raw_ids = request.json.get("ids", [])
+        failed = []
+        int_ids = []
+        for pid in raw_ids:
+            if not isinstance(pid, int):
+                failed.append({"id": pid, "reason": "invalid id"})
+            else:
+                int_ids.append(pid)
+
+        # PRE-FLIGHT: read-only checks; never enter the transaction for invalid IDs
+        valid_proposals = []
+        for pid in int_ids:
+            p = proposal_model.get_proposal_by_id(pid)
+            if not p:
+                failed.append({"id": pid, "reason": "not found"})
+            elif p["status"] != "pending":
+                failed.append({"id": pid, "reason": f"already {p['status']}"})
+            elif p.get("proposed_delete") or p.get("mapping_id") is not None:
+                # Bulk path only handles new-pair proposals
+                failed.append({"id": pid, "reason": "not a new-pair proposal"})
+            else:
+                valid_proposals.append((pid, p))
+
+        if not valid_proposals:
+            return jsonify({"approved": [], "failed": failed}), 200
+
+        # SINGLE TRANSACTION
+        wp_version_fields = _source_version_fields("wp")
+        conn = mapping_model.db.get_connection()
+        approved_uuids = []
+        try:
+            for pid, proposal in valid_proposals:
+                mapping_uuid = mapping_model._approve_on_conn(
+                    conn, proposal, admin_username, **wp_version_fields
+                )
+                proposal_model._update_status_on_conn(
+                    conn, pid, "approved", admin_username, admin_notes
+                )
+                approved_uuids.append(mapping_uuid)
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            logger.error("WP bulk-approve transaction failed: %s", exc)
+            failed.extend(
+                {"id": pid, "reason": "transaction failed"}
+                for pid, _ in valid_proposals
+            )
+            return jsonify({"approved": [], "failed": failed}), 500
+        finally:
+            conn.close()
+
+        # AUDIT (ADMIN-06)
+        logger.info(
+            "AUDIT bulk-approve wp: admin=%s approved=%s",
+            sanitize_log(admin_username), approved_uuids,
+        )
+
+        return jsonify({"approved": approved_uuids, "failed": failed}), 200
+
+    except Exception as e:
+        logger.error("Error in WP bulk-approve: %s", sanitize_log(str(e)))
+        return jsonify({"error": "Failed to bulk-approve WP proposals"}), 500
+
+
+@admin_bp.route("/go-proposals/bulk-approve", methods=["POST"])
+@admin_required
+@submission_rate_limit
+def bulk_approve_go_proposals():
+    """
+    Approve a batch of GO new-pair proposals in a single transaction.
+
+    Accepts a JSON body: {"ids": [int, ...], "admin_notes": "optional string"}.
+    Uses stored confidence fallback (no admin re-score widget), assessment_version="v1".
+
+    Returns: {"approved": [mapping_uuid_str, ...], "failed": [{"id": int, "reason": str}, ...]}
+
+    Whole-batch rollback on any transaction error (H-1 invariant).
+    """
+    try:
+        if not request.is_json:
+            return jsonify({"error": "JSON body required"}), 400
+
+        admin_data = {"admin_notes": request.json.get("admin_notes", "")}
+
+        is_valid, validated_data, errors = validate_request_data(
+            AdminNotesSchema, admin_data
+        )
+        if not is_valid:
+            logger.warning("Invalid admin notes in GO bulk-approve: %s", errors)
+            return jsonify({"error": "Invalid input data", "details": errors}), 400
+
+        admin_notes = SecurityValidation.sanitize_string(
+            validated_data["admin_notes"], max_length=1000
+        )
+        admin_username = session.get("user", {}).get("username")
+
+        if not SecurityValidation.validate_username(admin_username):
+            logger.error(
+                "Invalid admin username in GO bulk-approve: %s",
+                sanitize_log(str(admin_username)),
+            )
+            return jsonify({"error": "Authentication error"}), 401
+
+        # Coerce and validate the ID list
+        raw_ids = request.json.get("ids", [])
+        failed = []
+        int_ids = []
+        for pid in raw_ids:
+            if not isinstance(pid, int):
+                failed.append({"id": pid, "reason": "invalid id"})
+            else:
+                int_ids.append(pid)
+
+        # PRE-FLIGHT: read-only checks
+        valid_proposals = []
+        for pid in int_ids:
+            p = go_proposal_model.get_go_proposal_by_id(pid)
+            if not p:
+                failed.append({"id": pid, "reason": "not found"})
+            elif p["status"] != "pending":
+                failed.append({"id": pid, "reason": f"already {p['status']}"})
+            else:
+                valid_proposals.append((pid, p))
+
+        if not valid_proposals:
+            return jsonify({"approved": [], "failed": failed}), 200
+
+        # SINGLE TRANSACTION
+        go_version_fields = _source_version_fields("go")
+        conn = go_mapping_model.db.get_connection()
+        approved_uuids = []
+        try:
+            for pid, proposal in valid_proposals:
+                mapping_uuid = go_mapping_model._approve_on_conn(
+                    conn, proposal, admin_username, **go_version_fields
+                )
+                go_proposal_model._update_status_on_conn(
+                    conn, pid, "approved", admin_username, admin_notes
+                )
+                approved_uuids.append(mapping_uuid)
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            logger.error("GO bulk-approve transaction failed: %s", exc)
+            failed.extend(
+                {"id": pid, "reason": "transaction failed"}
+                for pid, _ in valid_proposals
+            )
+            return jsonify({"approved": [], "failed": failed}), 500
+        finally:
+            conn.close()
+
+        # AUDIT (ADMIN-06)
+        logger.info(
+            "AUDIT bulk-approve go: admin=%s approved=%s",
+            sanitize_log(admin_username), approved_uuids,
+        )
+
+        return jsonify({"approved": approved_uuids, "failed": failed}), 200
+
+    except Exception as e:
+        logger.error("Error in GO bulk-approve: %s", sanitize_log(str(e)))
+        return jsonify({"error": "Failed to bulk-approve GO proposals"}), 500
+
+
+@admin_bp.route("/reactome-proposals/bulk-approve", methods=["POST"])
+@admin_required
+@submission_rate_limit
+def bulk_approve_reactome_proposals():
+    """
+    Approve a batch of Reactome new-pair proposals in a single transaction.
+
+    Accepts a JSON body: {"ids": [int, ...], "admin_notes": "optional string"}.
+    Confidence is straight pass-through from proposal -> mapping (D-02).
+
+    Returns: {"approved": [mapping_uuid_str, ...], "failed": [{"id": int, "reason": str}, ...]}
+
+    Whole-batch rollback on any transaction error (H-1 invariant).
+    """
+    try:
+        if not request.is_json:
+            return jsonify({"error": "JSON body required"}), 400
+
+        admin_data = {"admin_notes": request.json.get("admin_notes", "")}
+
+        is_valid, validated_data, errors = validate_request_data(
+            AdminNotesSchema, admin_data
+        )
+        if not is_valid:
+            logger.warning("Invalid admin notes in Reactome bulk-approve: %s", errors)
+            return jsonify({"error": "Invalid input data", "details": errors}), 400
+
+        admin_notes = SecurityValidation.sanitize_string(
+            validated_data["admin_notes"], max_length=1000
+        )
+        admin_username = session.get("user", {}).get("username")
+
+        if not SecurityValidation.validate_username(admin_username):
+            logger.error(
+                "Invalid admin username in Reactome bulk-approve: %s",
+                sanitize_log(str(admin_username)),
+            )
+            return jsonify({"error": "Authentication error"}), 401
+
+        # Coerce and validate the ID list
+        raw_ids = request.json.get("ids", [])
+        failed = []
+        int_ids = []
+        for pid in raw_ids:
+            if not isinstance(pid, int):
+                failed.append({"id": pid, "reason": "invalid id"})
+            else:
+                int_ids.append(pid)
+
+        # PRE-FLIGHT: read-only checks
+        valid_proposals = []
+        for pid in int_ids:
+            p = reactome_proposal_model.get_proposal_by_id(pid)
+            if not p:
+                failed.append({"id": pid, "reason": "not found"})
+            elif p["status"] != "pending":
+                failed.append({"id": pid, "reason": f"already {p['status']}"})
+            else:
+                valid_proposals.append((pid, p))
+
+        if not valid_proposals:
+            return jsonify({"approved": [], "failed": failed}), 200
+
+        # SINGLE TRANSACTION
+        reactome_version_fields = _source_version_fields("reactome")
+        conn = reactome_mapping_model.db.get_connection()
+        approved_uuids = []
+        try:
+            for pid, _proposal in valid_proposals:
+                mapping_uuid = reactome_mapping_model._create_approved_on_conn(
+                    conn, pid, admin_username, **reactome_version_fields
+                )
+                reactome_proposal_model._update_status_on_conn(
+                    conn, pid, "approved", admin_username, admin_notes
+                )
+                approved_uuids.append(mapping_uuid)
+            conn.commit()
+        except Exception as exc:
+            conn.rollback()
+            logger.error("Reactome bulk-approve transaction failed: %s", exc)
+            failed.extend(
+                {"id": pid, "reason": "transaction failed"}
+                for pid, _ in valid_proposals
+            )
+            return jsonify({"approved": [], "failed": failed}), 500
+        finally:
+            conn.close()
+
+        # AUDIT (ADMIN-06)
+        logger.info(
+            "AUDIT bulk-approve reactome: admin=%s approved=%s",
+            sanitize_log(admin_username), approved_uuids,
+        )
+
+        return jsonify({"approved": approved_uuids, "failed": failed}), 200
+
+    except Exception as e:
+        logger.error("Error in Reactome bulk-approve: %s", sanitize_log(str(e)))
+        return jsonify({"error": "Failed to bulk-approve Reactome proposals"}), 500
+
+
 @admin_bp.route("/guest-codes")
 @admin_required
 @monitor_performance

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -2199,6 +2199,120 @@ class MappingModel:
         finally:
             conn.close()
 
+    def _approve_on_conn(
+        self,
+        conn,
+        proposal: dict,
+        approved_by_curator: str,
+        approved_at_curator: str = None,
+        # Phase C — source-data versioning kwargs; nullable, stamped from manifest.
+        wp_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
+    ) -> str:
+        """Approve a WP new-pair proposal on a caller-managed connection.
+
+        Executes the create_mapping INSERT followed by the update_mapping provenance
+        UPDATE, both on `conn`, without calling conn.commit() or conn.close().
+        Returns the new mapping UUID string for the audit log.
+
+        Only handles new-pair proposals (proposal["mapping_id"] is None and not
+        proposal["proposed_delete"]). Raises on IntegrityError or any DB error so
+        the bulk-approve caller's outer try/except can roll back the entire batch.
+
+        Phase 38 (ADMIN-02): caller-managed transaction helper for bulk-approve.
+        """
+        if approved_at_curator is None:
+            approved_at_curator = datetime.utcnow().isoformat()
+
+        mapping_uuid = str(uuid_lib.uuid4())
+
+        proposed_relationship = proposal.get("proposed_relationship")
+        proposed_basis = proposal.get("proposed_basis")
+        proposed_specificity = proposal.get("proposed_specificity")
+        proposed_coverage = proposal.get("proposed_coverage")
+
+        effective_connection_type = (
+            proposed_relationship if proposed_relationship is not None
+            else (proposal.get("new_pair_connection_type") or proposal.get("proposed_connection_type"))
+        )
+        assessment_version = _classify_assessment_version(
+            proposed_relationship, proposed_basis, proposed_specificity, proposed_coverage
+        )
+
+        cursor = conn.execute(
+            """
+            INSERT INTO mappings (ke_id, ke_title, wp_id, wp_title, connection_type,
+                                  confidence_level, created_by, uuid,
+                                  proposed_relationship, proposed_basis,
+                                  proposed_specificity, proposed_coverage,
+                                  assessment_version,
+                                  wp_release_date, aopwiki_snapshot_date)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                proposal["ke_id"],
+                proposal["ke_title"],
+                proposal["wp_id"],
+                proposal["wp_title"],
+                effective_connection_type,
+                proposal.get("new_pair_confidence_level") or proposal.get("proposed_confidence"),
+                proposal.get("provider_username") or approved_by_curator,
+                mapping_uuid,
+                proposed_relationship,
+                proposed_basis,
+                proposed_specificity,
+                proposed_coverage,
+                assessment_version,
+                wp_release_date,
+                aopwiki_snapshot_date,
+            ),
+        )
+        new_mapping_id = cursor.lastrowid
+
+        # Write provenance (approved_by, approved_at, suggestion_score, proposed_by)
+        update_clauses = [
+            "approved_by_curator = ?",
+            "approved_at_curator = ?",
+            "proposed_by = ?",
+            "updated_at = CURRENT_TIMESTAMP",
+        ]
+        params = [
+            approved_by_curator,
+            approved_at_curator,
+            proposal.get("provider_username"),
+        ]
+        proposal_score = proposal.get("suggestion_score")
+        if proposal_score is not None:
+            update_clauses.append("suggestion_score = ?")
+            params.append(proposal_score)
+        # Re-thread assessment for defense-in-depth on the update path
+        if proposed_relationship is not None:
+            update_clauses.append("proposed_relationship = ?")
+            params.append(proposed_relationship)
+        if proposed_basis is not None:
+            update_clauses.append("proposed_basis = ?")
+            params.append(proposed_basis)
+        if proposed_specificity is not None:
+            update_clauses.append("proposed_specificity = ?")
+            params.append(proposed_specificity)
+        if proposed_coverage is not None:
+            update_clauses.append("proposed_coverage = ?")
+            params.append(proposed_coverage)
+        if assessment_version is not None:
+            update_clauses.append("assessment_version = ?")
+            params.append(assessment_version)
+
+        params.append(new_mapping_id)
+        conn.execute(
+            f"UPDATE mappings SET {', '.join(update_clauses)} WHERE id = ?",
+            params,
+        )
+        logger.info(
+            "WP _approve_on_conn: KE=%s, WP=%s, UUID=%s (caller-managed tx)",
+            proposal["ke_id"], proposal["wp_id"], mapping_uuid,
+        )
+        return mapping_uuid
+
     def get_mapping_by_uuid(self, mapping_uuid: str) -> Optional[Dict]:
         """Get a mapping by its stable UUID"""
         conn = self.db.get_connection()
@@ -3005,6 +3119,107 @@ class GoMappingModel:
             return False
         finally:
             conn.close()
+
+    def _approve_on_conn(
+        self,
+        conn,
+        proposal: dict,
+        approved_by_curator: str,
+        approved_at_curator: str = None,
+        # Phase C — source-data versioning kwargs; nullable, stamped from manifest.
+        go_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
+    ) -> str:
+        """Approve a GO new-pair proposal on a caller-managed connection.
+
+        Uses the proposal's stored new_pair_confidence_level / proposed_confidence
+        directly (skips admin re-score widget per D-15/Pitfall 4). assessment_version
+        is always "v1" for the bulk path.
+
+        Executes the create_mapping INSERT and then the update_go_mapping provenance
+        UPDATE both on `conn` without calling conn.commit() or conn.close(). Returns
+        the new mapping UUID string for the audit log. Raises on IntegrityError or
+        any DB error so the bulk caller's outer try/except can roll back the batch.
+
+        Phase 38 (ADMIN-02): caller-managed transaction helper for bulk-approve.
+        """
+        if approved_at_curator is None:
+            approved_at_curator = datetime.utcnow().isoformat()
+
+        mapping_uuid = str(uuid_lib.uuid4())
+
+        # D-15/Pitfall 4: use stored confidence fallback; do NOT read dimension scores.
+        confidence_level = (
+            proposal.get("new_pair_confidence_level")
+            or proposal.get("proposed_confidence")
+        )
+        # Bulk path always uses v1 (no admin re-score widget)
+        assessment_version = "v1"
+
+        go_name = proposal.get("go_name", "")
+        go_direction = None
+        if go_name:
+            detected = detect_go_direction(go_name)
+            go_direction = detected if detected != "unspecified" else None
+
+        cursor = conn.execute(
+            """
+            INSERT INTO ke_go_mappings (ke_id, ke_title, go_id, go_name, connection_type,
+                                       confidence_level, evidence_code, created_by, uuid,
+                                       go_direction, connection_score, specificity_score,
+                                       evidence_score, assessment_version, go_namespace,
+                                       go_release_date, aopwiki_snapshot_date)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                proposal["ke_id"],
+                proposal["ke_title"],
+                proposal["go_id"],
+                go_name,
+                proposal.get("new_pair_connection_type") or proposal.get("proposed_connection_type"),
+                confidence_level,
+                None,   # evidence_code not carried for bulk path
+                proposal.get("provider_username") or approved_by_curator,
+                mapping_uuid,
+                go_direction,
+                None,   # connection_score — bulk skips admin re-score (D-15)
+                None,   # specificity_score
+                None,   # evidence_score
+                assessment_version,
+                proposal.get("go_namespace", "biological_process"),
+                go_release_date,
+                aopwiki_snapshot_date,
+            ),
+        )
+        new_mapping_id = cursor.lastrowid
+
+        # Write provenance (approved_by, approved_at, suggestion_score, proposed_by)
+        update_clauses = [
+            "approved_by_curator = ?",
+            "approved_at_curator = ?",
+            "proposed_by = ?",
+            "updated_at = CURRENT_TIMESTAMP",
+        ]
+        params = [
+            approved_by_curator,
+            approved_at_curator,
+            proposal.get("provider_username"),
+        ]
+        proposal_score = proposal.get("suggestion_score")
+        if proposal_score is not None:
+            update_clauses.append("suggestion_score = ?")
+            params.append(proposal_score)
+
+        params.append(new_mapping_id)
+        conn.execute(
+            f"UPDATE ke_go_mappings SET {', '.join(update_clauses)} WHERE id = ?",
+            params,
+        )
+        logger.info(
+            "GO _approve_on_conn: KE=%s, GO=%s, UUID=%s (caller-managed tx)",
+            proposal["ke_id"], proposal["go_id"], mapping_uuid,
+        )
+        return mapping_uuid
 
     def get_go_mappings_paginated(
         self,
@@ -3891,6 +4106,104 @@ class ReactomeMappingModel:
             return None
         finally:
             conn.close()
+
+    def _create_approved_on_conn(
+        self,
+        conn,
+        proposal_id: int,
+        approved_by_curator: str,
+        approved_at_curator: str = None,
+        # Phase C — source-data versioning kwargs; nullable, stamped from manifest.
+        reactome_release_version: Optional[str] = None,
+        reactome_release_date: Optional[str] = None,
+        aopwiki_snapshot_date: Optional[str] = None,
+    ) -> str:
+        """Single-INSERT approved Reactome mapping on a caller-managed connection.
+
+        Body is identical to create_approved_mapping (REACTOME_PROPOSAL_CARRY_FIELDS-
+        driven INSERT, new_pair_confidence_level alias map, _classify_assessment_version
+        call) minus conn management. Returns the new mapping UUID string for the audit
+        log. Raises on IntegrityError or any DB error — caller is responsible for
+        rollback; no conn.commit() or conn.close() is called.
+
+        Phase 38 (ADMIN-02): caller-managed transaction helper for bulk-approve.
+        """
+        if approved_at_curator is None:
+            approved_at_curator = datetime.utcnow().isoformat()
+
+        mapping_uuid = str(uuid_lib.uuid4())
+
+        # Load the proposal row — all carry-field values live here.
+        proposal_row = conn.execute(
+            "SELECT * FROM ke_reactome_proposals WHERE id = ?",
+            (proposal_id,),
+        ).fetchone()
+        if proposal_row is None:
+            raise ValueError(
+                f"_create_approved_on_conn: proposal {proposal_id} not found"
+            )
+        proposal_row = dict(proposal_row)
+
+        # Phase 34 (ASMT-10): carry-field column list is constant-driven.
+        # Column name alias: ke_reactome_proposals stores confidence as
+        # 'new_pair_confidence_level' while the mapping table expects 'confidence_level'.
+        _proposal_col_alias = {
+            'confidence_level': (
+                proposal_row.get("new_pair_confidence_level")
+                or proposal_row.get("proposed_confidence")
+                or proposal_row.get("confidence_level")
+            ),
+        }
+        carry_cols = list(REACTOME_PROPOSAL_CARRY_FIELDS)
+        carry_values = tuple(
+            _proposal_col_alias[col] if col in _proposal_col_alias
+            else proposal_row.get(col)
+            for col in carry_cols
+        )
+
+        ke_id = proposal_row.get("ke_id")
+        ke_title = proposal_row.get("ke_title")
+        reactome_id = proposal_row.get("reactome_id")
+        proposed_by = proposal_row.get("provider_username")
+
+        assessment_version = _classify_assessment_version(
+            proposal_row.get("proposed_relationship"),
+            proposal_row.get("proposed_basis"),
+            proposal_row.get("proposed_specificity"),
+            proposal_row.get("proposed_coverage"),
+        )
+
+        fixed_cols = (
+            'ke_id', 'ke_title', 'reactome_id',
+            'created_by', 'uuid',
+            'approved_by_curator', 'approved_at_curator', 'proposed_by',
+            'assessment_version',
+            'reactome_release_version', 'reactome_release_date',
+            'aopwiki_snapshot_date',
+        )
+        fixed_values = (
+            ke_id, ke_title, reactome_id,
+            proposed_by or approved_by_curator,
+            mapping_uuid,
+            approved_by_curator, approved_at_curator, proposed_by,
+            assessment_version,
+            reactome_release_version, reactome_release_date,
+            aopwiki_snapshot_date,
+        )
+
+        all_cols = fixed_cols + tuple(carry_cols)
+        placeholders = ', '.join('?' for _ in all_cols)
+        conn.execute(
+            f"INSERT INTO ke_reactome_mappings ({', '.join(all_cols)}) "
+            f"VALUES ({placeholders})",
+            fixed_values + carry_values,
+        )
+        logger.info(
+            "Reactome _create_approved_on_conn: KE=%s, Reactome=%s, "
+            "approved_by=%s, UUID=%s (caller-managed tx)",
+            ke_id, reactome_id, approved_by_curator, mapping_uuid,
+        )
+        return mapping_uuid
 
     def delete_mapping(self, mapping_id: int) -> bool:
         """Delete a mapping row by id. Used to roll back on partial failure

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -2667,6 +2667,38 @@ class ProposalModel:
         finally:
             conn.close()
 
+    def _update_status_on_conn(
+        self,
+        conn,
+        proposal_id: int,
+        status: str,
+        admin_username: str,
+        admin_notes: str,
+    ) -> None:
+        """Update WP proposal status on a caller-managed connection.
+
+        Raises ValueError for invalid status. Executes the UPDATE on `conn`
+        without calling conn.commit() or conn.close(). Any DB error propagates
+        to the caller for rollback.
+
+        Phase 38 (ADMIN-02): caller-managed transaction helper for bulk-approve.
+        """
+        if status not in ["approved", "rejected"]:
+            raise ValueError(f"Invalid status: {status}")
+        if status == "approved":
+            query = """
+                UPDATE proposals
+                SET status = ?, approved_by = ?, admin_notes = ?, approved_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            """
+        else:
+            query = """
+                UPDATE proposals
+                SET status = ?, rejected_by = ?, admin_notes = ?, rejected_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            """
+        conn.execute(query, (status, admin_username, admin_notes, proposal_id))
+
     def flag_proposal_stale(self, proposal_id: int, flagged_by: str) -> bool:
         """
         Flag a pending proposal as stale for admin review.
@@ -3515,6 +3547,38 @@ class GoProposalModel:
             return False
         finally:
             conn.close()
+
+    def _update_status_on_conn(
+        self,
+        conn,
+        proposal_id: int,
+        status: str,
+        admin_username: str,
+        admin_notes: str,
+    ) -> None:
+        """Update GO proposal status on a caller-managed connection.
+
+        Raises ValueError for invalid status. Executes the UPDATE on `conn`
+        without calling conn.commit() or conn.close(). Any DB error propagates
+        to the caller for rollback.
+
+        Phase 38 (ADMIN-02): caller-managed transaction helper for bulk-approve.
+        """
+        if status not in ["approved", "rejected"]:
+            raise ValueError(f"Invalid status: {status}")
+        if status == "approved":
+            query = """
+                UPDATE ke_go_proposals
+                SET status = ?, approved_by = ?, admin_notes = ?, approved_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            """
+        else:
+            query = """
+                UPDATE ke_go_proposals
+                SET status = ?, rejected_by = ?, admin_notes = ?, rejected_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            """
+        conn.execute(query, (status, admin_username, admin_notes, proposal_id))
 
     def flag_go_proposal_stale(self, proposal_id: int, flagged_by: str) -> bool:
         """
@@ -4876,3 +4940,35 @@ class ReactomeProposalModel:
             return False
         finally:
             conn.close()
+
+    def _update_status_on_conn(
+        self,
+        conn,
+        proposal_id: int,
+        status: str,
+        admin_username: str,
+        admin_notes: str,
+    ) -> None:
+        """Update Reactome proposal status on a caller-managed connection.
+
+        Raises ValueError for invalid status. Executes the UPDATE on `conn`
+        without calling conn.commit() or conn.close(). Any DB error propagates
+        to the caller for rollback.
+
+        Phase 38 (ADMIN-02): caller-managed transaction helper for bulk-approve.
+        """
+        if status not in ["approved", "rejected"]:
+            raise ValueError(f"Invalid status: {status}")
+        if status == "approved":
+            query = """
+                UPDATE ke_reactome_proposals
+                SET status = ?, approved_by = ?, admin_notes = ?, approved_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            """
+        else:
+            query = """
+                UPDATE ke_reactome_proposals
+                SET status = ?, rejected_by = ?, admin_notes = ?, rejected_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            """
+        conn.execute(query, (status, admin_username, admin_notes, proposal_id))

--- a/src/suggestions/go.py
+++ b/src/suggestions/go.py
@@ -16,7 +16,12 @@ from src.core.config_loader import ConfigLoader
 from src.suggestions.ke_genes import get_genes_from_ke
 from src.suggestions.scoring import combine_scored_items
 from src.utils.description_toggle import resolve_description_usage
-from src.utils.text import remove_directionality_terms, detect_ke_direction, detect_go_direction
+from src.utils.text import (
+    remove_directionality_terms,
+    detect_ke_direction,
+    detect_go_direction,
+    is_directional_go_label,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -395,6 +400,14 @@ class GoSuggestionService:
         # Apply direction-based score adjustments (boost/penalty)
         combined = self._apply_direction_adjustment(combined, ke_title, ns_data)
 
+        # Never suggest signed/directional GO terms — direction belongs in the KE's
+        # PATO Action slot, not the GO Process term (#193). This runtime guard holds
+        # even before the corpus is rebuilt to exclude them at the source.
+        combined = [
+            s for s in combined
+            if not is_directional_go_label(s.get('go_name', ''))
+        ]
+
         return combined
 
     def get_go_suggestions(
@@ -480,8 +493,24 @@ class GoSuggestionService:
             go_name = metadata.get('name', '')
             go_definition = metadata.get('definition', '')
 
+            # Signed/directional terms are never valid KE Process terms (#193).
+            if is_directional_go_label(go_name):
+                continue
+
             name_clean = self._clean_text(go_name)
             name_similarity = SequenceMatcher(None, query_clean, name_clean).ratio()
+
+            # Exact/whole-word/substring boost so an exact label match wins over a
+            # fuzzy near-miss (e.g. "cell death" must beat "cell growth"), with the
+            # fuzzy ratio kept only as a tiebreaker. Mirrors the Reactome search
+            # substring boost, extended with exact + whole-word tiers (#193).
+            if name_clean:
+                if query_clean == name_clean:
+                    name_similarity = 1.0
+                elif f" {query_clean} " in f" {name_clean} ":
+                    name_similarity = max(name_similarity, 0.92)
+                elif query_clean in name_clean:
+                    name_similarity = max(name_similarity, 0.85)
 
             def_similarity = 0.0
             if go_definition:

--- a/src/suggestions/go.py
+++ b/src/suggestions/go.py
@@ -238,19 +238,35 @@ class GoSuggestionService:
         suggestions.sort(key=lambda x: x['hybrid_score'], reverse=True)
         return suggestions
 
-    def _filter_redundant_ancestors(self, suggestions, ns_data: _NamespaceData):
+    def _filter_redundant_ancestors(self, suggestions, ns_data: _NamespaceData, ke_title: str = ""):
         """Remove ancestor GO terms when a more specific descendant is present.
 
         An ancestor is removed unless its hybrid_score exceeds the child's score
         by more than redundancy_threshold (default 20%).
+
+        Exception: an ancestor whose label exactly matches the (direction-stripped)
+        KE title is never pruned. For a generic KE ("Cell death"), the umbrella term
+        IS the intended annotation, so a fractionally-higher-scoring descendant
+        ("programmed cell death") must not evict it (#193).
         """
         go_cfg = ns_data.config
         hierarchy_cfg = getattr(go_cfg, 'hierarchy', {}) if go_cfg else {}
         threshold = hierarchy_cfg.get('redundancy_threshold', 0.20) if isinstance(hierarchy_cfg, dict) else 0.20
 
-        # Build lookup of suggestion go_ids to their scores
+        # Build lookup of suggestion go_ids to their scores + names
         suggestion_ids = {s['go_id'] for s in suggestions}
         score_map = {s['go_id']: s['hybrid_score'] for s in suggestions}
+        name_map = {s['go_id']: s.get('go_name', '') for s in suggestions}
+
+        # Terms whose label matches the KE title (exact or whole-word phrase) are
+        # protected from pruning — for a generic KE the umbrella term is the answer,
+        # so a more-specific descendant must not evict it.
+        ke_clean = self._clean_text(remove_directionality_terms(ke_title)) if ke_title else ""
+        protected = (
+            {gid for gid, nm in name_map.items()
+             if self._title_match_kind(ke_clean, self._clean_text(nm))}
+            if ke_clean else set()
+        )
 
         # Collect ancestors to remove
         ancestors_to_remove = set()
@@ -261,6 +277,9 @@ class GoSuggestionService:
 
             for anc_id in ancestors:
                 if anc_id not in suggestion_ids:
+                    continue
+                if anc_id in protected:
+                    # exact KE-title match — never redundant
                     continue
                 # anc_id is an ancestor of go_id and both are in suggestions
                 child_score = score_map[go_id]
@@ -274,6 +293,69 @@ class GoSuggestionService:
             logger.info("Removing %d redundant ancestor GO terms", len(ancestors_to_remove))
 
         return [s for s in suggestions if s['go_id'] not in ancestors_to_remove]
+
+    # Title-match / proxy weighting constants (multiplicative, applied to hybrid_score).
+    # Consistent with the existing directionality match_boost/mismatch_penalty style.
+    _TITLE_EXACT_BOOST = 1.25    # GO label == KE title (direction-stripped)
+    _TITLE_NEAR_BOOST = 1.10     # KE title is a whole-word phrase of the label (or vice-versa)
+    _REGULATION_PROXY_PENALTY = 0.90  # "regulation of X" — the control layer, not the event
+    # Neutral "regulation of X" only. Signed variants are already excluded from the
+    # corpus/suggestions. "response to X" is deliberately NOT penalised — it is the
+    # canonical process term for stress/stimulus KEs (e.g. response to oxidative stress).
+    _REGULATION_PROXY_RE = re.compile(r"^regulation of\b", re.IGNORECASE)
+
+    @staticmethod
+    def _title_match_kind(ke_clean: str, name_clean: str):
+        """Return 'exact', 'near', or None for a cleaned label vs a cleaned KE title.
+
+        'near' = the KE title is a whole-word phrase of the label, or vice-versa
+        (e.g. KE "DNA damage" ~ "DNA damage response").
+        """
+        if not ke_clean or not name_clean:
+            return None
+        if name_clean == ke_clean:
+            return 'exact'
+        if f" {ke_clean} " in f" {name_clean} " or f" {name_clean} " in f" {ke_clean} ":
+            return 'near'
+        return None
+
+    def _apply_title_and_proxy_weighting(self, suggestions, ke_title: str):
+        """Boost KE-title-matching terms; down-rank 'regulation of X' proxies.
+
+        For a generic KE ("Cell death", "Apoptotic process"), the generic process
+        term is the intended annotation, but BioBERT similarity tends to float
+        specific children and "regulation of X" proxies above it. This stage:
+          - multiplies a term's hybrid_score by _TITLE_EXACT_BOOST when its label
+            exactly matches the direction-stripped KE title, _TITLE_NEAR_BOOST when
+            the title is a whole-word phrase of the label (or vice-versa);
+          - multiplies "regulation of X" labels by _REGULATION_PROXY_PENALTY.
+        Boost and penalty compose (a "regulation of <title>" term gets both).
+        """
+        if not ke_title:
+            return suggestions
+        ke_clean = self._clean_text(remove_directionality_terms(ke_title))
+        if not ke_clean:
+            return suggestions
+
+        for s in suggestions:
+            name = s.get('go_name', '')
+            name_clean = self._clean_text(name)
+            factor = 1.0
+            kind = self._title_match_kind(ke_clean, name_clean)
+            if kind == 'exact':
+                factor *= self._TITLE_EXACT_BOOST
+                s['title_match'] = 'exact'
+            elif kind == 'near':
+                factor *= self._TITLE_NEAR_BOOST
+                s['title_match'] = 'near'
+            if self._REGULATION_PROXY_RE.match(name):
+                factor *= self._REGULATION_PROXY_PENALTY
+                s['regulation_proxy'] = True
+            if factor != 1.0:
+                s['hybrid_score'] = s.get('hybrid_score', 0.0) * factor
+
+        suggestions.sort(key=lambda x: x['hybrid_score'], reverse=True)
+        return suggestions
 
     def _apply_direction_adjustment(self, suggestions, ke_title, ns_data: _NamespaceData):
         """Apply direction-based score boost or penalty to GO suggestions.
@@ -395,10 +477,15 @@ class GoSuggestionService:
             hierarchy_cfg = getattr(go_cfg, 'hierarchy', {}) if go_cfg else {}
             if isinstance(hierarchy_cfg, dict) and hierarchy_cfg.get('enabled', True):
                 combined = self._apply_ic_boost(combined, ns_data)
-                combined = self._filter_redundant_ancestors(combined, ns_data)
+                combined = self._filter_redundant_ancestors(combined, ns_data, ke_title)
 
         # Apply direction-based score adjustments (boost/penalty)
         combined = self._apply_direction_adjustment(combined, ke_title, ns_data)
+
+        # Surface the generic process term for generic KEs: boost terms whose label
+        # matches the KE title and down-rank "regulation of X" control-layer proxies
+        # so the process itself outranks its regulation (#193, KE->GO skill Rule 5).
+        combined = self._apply_title_and_proxy_weighting(combined, ke_title)
 
         # Never suggest signed/directional GO terms — direction belongs in the KE's
         # PATO Action slot, not the GO Process term (#193). This runtime guard holds

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -196,6 +196,38 @@ def detect_go_direction(go_name: str) -> str:
     return "unspecified"
 
 
+# Directional / signed GO-label operators. A KE's direction belongs in its PATO
+# Action slot, not in the GO Process term, so signed terms must never be suggested
+# or searched for a KE (#193). Patterns mirror the amigo-ke-go-mapping skill's
+# directionality lexicon and the corpus-build filter in precompute_go_hierarchy.py
+# (keep the two in sync). Neutral "regulation of X", bare "X activation" (e.g.
+# "T cell activation"), and "... activity" MF terms are deliberately NOT matched.
+_DIRECTIONAL_GO_LABEL_RE = re.compile(
+    "|".join([
+        r"\bpositive regulation of\b",
+        r"\bnegative regulation of\b",
+        r"\bactivation of\b",
+        r"\binhibition of\b",
+        r"\binduction of\b",
+        r"\brepression of\b",
+        r"\bsuppression of\b",
+        r"\bstimulation of\b",
+        r"\bup[- ]?regulation\b",
+        r"\bdown[- ]?regulation\b",
+        r"\bincreased?\b",
+        r"\bdecreased?\b",
+        r"\bactivated\b",
+        r"\binhibited\b",
+    ]),
+    re.IGNORECASE,
+)
+
+
+def is_directional_go_label(go_name: str) -> bool:
+    """True if a GO label encodes a sign/direction (excluded from suggestions)."""
+    return bool(go_name and _DIRECTIONAL_GO_LABEL_RE.search(go_name))
+
+
 def detect_ke_direction(ke_title: str) -> str:
     """
     Detect the direction of a KE from its title via regex pattern matching.

--- a/static/js/admin_proposals.js
+++ b/static/js/admin_proposals.js
@@ -1,0 +1,620 @@
+/**
+ * AdminProposals IIFE
+ *
+ * Shared admin-queue JS for WP, GO, and Reactome proposal queues.
+ * Provides: bulk-select, keyboard shortcuts with focus guard, auto-advancing
+ * side panel, cheat-sheet modal, and the bulk-approve flow (Plan 38-03).
+ *
+ * Usage: AdminProposals.init(config) where config is:
+ *   { resource, detailUrl, approveUrl, rejectUrl, bulkApproveUrl,
+ *     tableId, csrfToken, stepLabels (optional override) }
+ */
+var AdminProposals = (function () {
+    'use strict';
+
+    // -------------------------------------------------------------------------
+    // Private state
+    // -------------------------------------------------------------------------
+    var _config = null;
+    var _currentProposalId = null;
+    var _pendingQueue = [];   // [{id, data}, ...] — ordered list of pending rows
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    // Phase 32/37 XSS contract: escapeHtml at every interpolation into innerHTML.
+    // Moved verbatim from templates/admin_proposals.html:154-162.
+    function escapeHtml(s) {
+        if (s === null || s === undefined) return '';
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    // Phase 37 ASMT-05/06: key→label map for four-question assessment answers.
+    // Moved verbatim from templates/admin_proposals.html:168-173.
+    var stepLabels = {
+        step1: { causative: 'Causative', responsive: 'Responsive', bidirectional: 'Bidirectional', unclear: 'Unclear' },
+        step2: { known: 'Known connection', likely: 'Likely connection', possible: 'Possible connection', uncertain: 'Uncertain connection' },
+        step3: { specific: 'KE-specific', includes: 'Includes KE', loose: 'Loosely related' },
+        step4: { complete: 'Complete mechanism', keysteps: 'Key steps only', minor: 'Minor aspects' }
+    };
+
+    // -------------------------------------------------------------------------
+    // DataTable init
+    // -------------------------------------------------------------------------
+    function _initDataTable() {
+        var tableId = _config.tableId;
+        if (!tableId || !window.DataTableConfig) return;
+
+        var $table = $('#' + tableId);
+        if (!$table.length) return;
+
+        // Count existing columns to set targets correctly
+        var colCount = $table.find('thead tr th').length;
+        // Build column definitions — checkbox column at index 0, rest shifted by 1
+        var colDefs = [
+            { orderable: false, searchable: false, targets: 0 },
+            { width: '3%', targets: 0 }
+        ];
+
+        // Shift existing column targets (7-8 column tables) by 1
+        var existingTargets;
+        if (colCount === 8) {
+            // GO/Reactome: 8 columns before checkbox → 9 after
+            existingTargets = [
+                { width: '5%', targets: 1 },
+                { width: '22%', targets: 2 },
+                { width: '17%', targets: 3 },
+                { width: '10%', targets: 4 },
+                { width: '7%', targets: 5 },
+                { width: '8%', targets: 6 },
+                { width: '9%', targets: 7 },
+                { width: '12%', targets: 8, orderable: false }
+            ];
+        } else {
+            // WP: 7 columns before checkbox → 8 after
+            existingTargets = [
+                { width: '5%', targets: 1 },
+                { width: '22%', targets: 2 },
+                { width: '18%', targets: 3 },
+                { width: '18%', targets: 4 },
+                { width: '9%', targets: 5 },
+                { width: '9%', targets: 6 },
+                { width: '12%', targets: 7, orderable: false }
+            ];
+        }
+
+        $table.DataTable(
+            DataTableConfig.merge('base', {
+                order: [[1, 'desc']],
+                pageLength: 25,
+                responsive: true,
+                columnDefs: colDefs.concat(existingTargets)
+            })
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Pending queue management
+    // -------------------------------------------------------------------------
+    function _buildPendingQueue() {
+        _pendingQueue = [];
+        var $rows = $('tr[data-proposal-id][data-status="pending"]');
+        $rows.each(function () {
+            var $row = $(this);
+            var id = parseInt($row.data('proposal-id'), 10);
+            if (!isNaN(id)) {
+                _pendingQueue.push({ id: id, $row: $row });
+            }
+        });
+    }
+
+    function _currentQueueIndex() {
+        if (_currentProposalId === null) return -1;
+        for (var i = 0; i < _pendingQueue.length; i++) {
+            if (_pendingQueue[i].id === _currentProposalId) return i;
+        }
+        return -1;
+    }
+
+    // -------------------------------------------------------------------------
+    // Checkbox / bulk-select
+    // -------------------------------------------------------------------------
+    function _initCheckboxes() {
+        // Select-all checkbox
+        $(document).on('change', '#selectAll', function () {
+            var checked = this.checked;
+            $('.proposal-select:not(:disabled)').prop('checked', checked);
+            _updateBulkBar();
+        });
+
+        // Per-row checkbox
+        $(document).on('change', '.proposal-select', function () {
+            var total = $('.proposal-select:not(:disabled)').length;
+            var selectedTotal = $('.proposal-select:not(:disabled):checked').length;
+            $('#selectAll').prop('indeterminate', selectedTotal > 0 && selectedTotal < total);
+            $('#selectAll').prop('checked', total > 0 && selectedTotal === total);
+            _updateBulkBar();
+        });
+    }
+
+    function _updateBulkBar() {
+        var count = $('.proposal-select:checked').length;
+        $('#selectedCount').text(count);
+        var $btn = $('#bulkApproveBtn');
+        if (count > 0) {
+            $btn.prop('disabled', false);
+            $('#bulkActionBar').show();
+        } else {
+            $btn.prop('disabled', true);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Side panel
+    // -------------------------------------------------------------------------
+    function _initSidePanel() {
+        _buildPendingQueue();
+
+        // Row click → set current and load panel
+        $(document).on('click', 'tr[data-proposal-id]', function (e) {
+            // Ignore clicks on checkboxes or action buttons
+            if ($(e.target).is(':checkbox') || $(e.target).closest('.proposal-actions').length) return;
+            var id = parseInt($(this).data('proposal-id'), 10);
+            if (!isNaN(id)) {
+                _setCurrentProposal(id);
+            }
+        });
+
+        // Auto-load first pending proposal
+        if (_pendingQueue.length > 0) {
+            _setCurrentProposal(_pendingQueue[0].id);
+        } else {
+            _renderPanelEmpty('No pending proposals in queue.');
+        }
+    }
+
+    function _setCurrentProposal(id) {
+        _currentProposalId = id;
+
+        // Highlight current row
+        $('tr[data-proposal-id]').removeClass('proposal-row-active');
+        $('tr[data-proposal-id="' + id + '"]').addClass('proposal-row-active');
+
+        // Try to populate from data-* attrs first (synchronous, per Pitfall 6)
+        var $row = $('tr[data-proposal-id="' + id + '"]');
+        if ($row.length && $row.data('ke-id')) {
+            var proposal = _rowToProposal($row);
+            _renderPanel(proposal);
+        } else {
+            // Fall back to detail endpoint fetch
+            _fetchAndRenderPanel(id);
+        }
+    }
+
+    function _rowToProposal($row) {
+        return {
+            id: parseInt($row.data('proposal-id'), 10),
+            status: $row.data('status') || '',
+            ke_id: $row.data('ke-id') || '',
+            ke_title: $row.data('ke-title') || '',
+            pathway_id: $row.data('pathway-id') || '',
+            pathway_title: $row.data('pathway-title') || '',
+            confidence: $row.data('confidence') || '',
+            connection_type: $row.data('connection-type') || '',
+            proposed_relationship: $row.data('proposed-relationship') || null,
+            proposed_basis: $row.data('proposed-basis') || null,
+            proposed_specificity: $row.data('proposed-specificity') || null,
+            proposed_coverage: $row.data('proposed-coverage') || null,
+            suggestion_score: $row.data('suggestion-score') || null,
+            user_name: $row.data('user-name') || '',
+            submitted_by: $row.data('submitted-by') || '',
+            created_at: $row.data('created-at') || '',
+            admin_notes: $row.data('admin-notes') || '',
+            uuid: $row.data('uuid') || '',
+            _from_row: true
+        };
+    }
+
+    function _fetchAndRenderPanel(id) {
+        var url = _config.detailUrl + '/' + id;
+        $('#reviewPanelContent').html('<p style="color:var(--color-text-muted,#6c757d);">Loading&hellip;</p>');
+        $.get(url)
+            .done(function (proposal) {
+                _renderPanel(proposal);
+            })
+            .fail(function (xhr) {
+                $('#reviewPanelContent').html(
+                    '<p style="color:var(--color-primary-pink,#E6007E);">Failed to load proposal: ' +
+                    escapeHtml((xhr.responseJSON && xhr.responseJSON.error) || 'Unknown error') + '</p>'
+                );
+            });
+    }
+
+    function _renderPanel(proposal) {
+        var isPending = (proposal.status === 'pending');
+
+        // Determine pathway/GO/Reactome ID+title display
+        var pathwayId = escapeHtml(proposal.wp_id || proposal.go_id || proposal.reactome_id || proposal.pathway_id || '');
+        var pathwayTitle = escapeHtml(proposal.wp_title || proposal.go_name || proposal.pathway_name || proposal.pathway_title || '');
+        var pathwayLabel = 'Pathway/Term';
+        if (proposal.wp_id) pathwayLabel = 'WikiPathways';
+        else if (proposal.go_id) pathwayLabel = 'GO Term';
+        else if (proposal.reactome_id) pathwayLabel = 'Reactome Pathway';
+
+        // Confidence field
+        var confidence = escapeHtml(
+            proposal.new_pair_confidence_level ||
+            proposal.proposed_confidence ||
+            proposal.confidence || ''
+        );
+
+        // Submitter
+        var submittedBy = escapeHtml(
+            proposal.provider_username ||
+            proposal.github_username ||
+            proposal.user_name ||
+            proposal.submitted_by || ''
+        );
+
+        // Score
+        var scoreText = '&mdash;';
+        var rawScore = proposal.suggestion_score;
+        if (rawScore !== null && rawScore !== undefined && rawScore !== '') {
+            scoreText = Number(rawScore).toFixed(3);
+        }
+
+        // Admin notes area UUID
+        var panelNotesId = 'panelAdminNotes';
+
+        // Assessment block (verbatim from admin_proposals.html:280-296)
+        var assessmentHtml = (function () {
+            var p = proposal;
+            var hasAssessment = p.proposed_relationship != null && p.proposed_relationship !== ''
+                || p.proposed_basis != null && p.proposed_basis !== ''
+                || p.proposed_specificity != null && p.proposed_specificity !== ''
+                || p.proposed_coverage != null && p.proposed_coverage !== '';
+            var body;
+            if (hasAssessment) {
+                body = '<div><strong>Relationship:</strong> ' + escapeHtml(stepLabels.step1[p.proposed_relationship] || p.proposed_relationship || '—') + '</div>' +
+                       '<div><strong>Basis:</strong> ' + escapeHtml(stepLabels.step2[p.proposed_basis] || p.proposed_basis || '—') + '</div>' +
+                       '<div><strong>Specificity:</strong> ' + escapeHtml(stepLabels.step3[p.proposed_specificity] || p.proposed_specificity || '—') + '</div>' +
+                       '<div><strong>Coverage:</strong> ' + escapeHtml(stepLabels.step4[p.proposed_coverage] || p.proposed_coverage || '—') + '</div>';
+            } else {
+                body = '<div style="font-size:13px;color:var(--color-text-muted,#6c757d);">No assessment submitted (legacy proposal)</div>';
+            }
+            return '<div style="margin-bottom:16px;border-top:1px solid var(--color-border-light,#dee2e6);padding-top:14px;">' +
+                   '<h4 style="margin-bottom:8px;font-size:14px;">Assessment</h4>' + body + '</div>';
+        }());
+
+        // Status-specific actions
+        var actionsHtml = '';
+        if (isPending) {
+            actionsHtml = '<div style="display:flex;gap:8px;margin-top:16px;flex-wrap:wrap;">' +
+                '<button class="btn-approve panel-approve-btn" onclick="AdminProposals.handleApprove()">Approve</button>' +
+                '<button class="btn-reject panel-reject-btn" onclick="AdminProposals.handleReject()">Reject</button>' +
+                '</div>';
+        } else {
+            var statusEsc = escapeHtml(proposal.status || '');
+            actionsHtml = '<div style="margin-top:16px;"><span class="status-' + statusEsc + '">' + statusEsc + '</span></div>';
+        }
+
+        var html = '<div style="font-size:14px;line-height:1.5;">' +
+
+            // Header
+            '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">' +
+            '<h4 style="margin:0;font-size:15px;color:var(--color-primary-dark,#29235C);">Proposal #' + escapeHtml(String(proposal.id || '')) + '</h4>' +
+            '<span class="status-' + escapeHtml(proposal.status || '') + '">' + escapeHtml(proposal.status || '') + '</span>' +
+            '</div>' +
+
+            // Mapping info
+            '<div style="margin-bottom:12px;">' +
+            '<div><strong>KE:</strong> ' + escapeHtml(proposal.ke_id || '') + ' &mdash; ' + escapeHtml(proposal.ke_title || '') + '</div>' +
+            '<div><strong>' + escapeHtml(pathwayLabel) + ':</strong> ' + pathwayId + ' &mdash; ' + pathwayTitle + '</div>' +
+            '<div><strong>Confidence:</strong> ' + confidence + '</div>' +
+            '<div><strong>Score:</strong> ' + scoreText + '</div>' +
+            '<div><strong>Submitted by:</strong> ' + submittedBy + '</div>' +
+            '<div><strong>Date:</strong> ' + escapeHtml(proposal.created_at_formatted || proposal.created_at || '') + '</div>' +
+            '</div>' +
+
+            // Assessment
+            assessmentHtml +
+
+            // Admin notes
+            '<div style="margin-bottom:12px;">' +
+            '<label for="' + escapeHtml(panelNotesId) + '" style="display:block;font-weight:600;font-size:13px;margin-bottom:4px;">Admin notes (optional):</label>' +
+            '<textarea id="' + escapeHtml(panelNotesId) + '" style="width:100%;height:70px;font-size:13px;padding:6px;border:1px solid var(--color-border-light,#dee2e6);border-radius:4px;resize:vertical;box-sizing:border-box;" placeholder="Add notes&hellip;"></textarea>' +
+            '</div>' +
+
+            // Actions
+            actionsHtml +
+
+            '</div>';
+
+        $('#reviewPanelContent').html(html);
+    }
+
+    function _renderPanelEmpty(msg) {
+        $('#reviewPanelContent').html('<p style="color:var(--color-text-muted,#6c757d);">' + escapeHtml(msg) + '</p>');
+    }
+
+    // -------------------------------------------------------------------------
+    // Keyboard handler
+    // -------------------------------------------------------------------------
+    function _initKeyboardHandler() {
+        document.addEventListener('keydown', function (e) {
+            // Focus guard: suppress keyboard actions when user is in an input field
+            var tag = document.activeElement ? document.activeElement.tagName.toUpperCase() : '';
+            if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return;
+
+            if (e.key === 'a') { e.preventDefault(); _handleApprove(); }
+            else if (e.key === 'r') { e.preventDefault(); _handleReject(); }
+            else if (e.key === '?') { e.preventDefault(); _openCheatSheet(); }
+            else if (e.key === 'ArrowUp') { e.preventDefault(); _navigatePanel(-1); }
+            else if (e.key === 'ArrowDown') { e.preventDefault(); _navigatePanel(1); }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+    function _navigatePanel(direction) {
+        _buildPendingQueue();
+        if (_pendingQueue.length === 0) return;
+        var idx = _currentQueueIndex();
+        var newIdx = idx + direction;
+        if (newIdx < 0) newIdx = 0;
+        if (newIdx >= _pendingQueue.length) newIdx = _pendingQueue.length - 1;
+        if (newIdx !== idx) {
+            _setCurrentProposal(_pendingQueue[newIdx].id);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Approve / Reject (single — keyboard a/r and panel buttons)
+    // D-08: a/r are ALWAYS single-current-proposal; never branch on checked set
+    // -------------------------------------------------------------------------
+    function _handleApprove() {
+        if (_currentProposalId === null) return;
+        var adminNotes = _getPanelNotes();
+        _singleApprove(_currentProposalId, adminNotes);
+    }
+
+    function _handleReject() {
+        if (_currentProposalId === null) return;
+        var adminNotes = _getPanelNotes();
+        _singleReject(_currentProposalId, adminNotes);
+    }
+
+    function _getPanelNotes() {
+        var el = document.getElementById('panelAdminNotes');
+        return el ? el.value : '';
+    }
+
+    function _singleApprove(proposalId, adminNotes) {
+        var formData = new FormData();
+        formData.append('admin_notes', adminNotes || '');
+        formData.append('csrf_token', _config.csrfToken);
+
+        fetch(_config.approveUrl + '/' + proposalId + '/approve', {
+            method: 'POST',
+            body: formData
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (data.message) {
+                _removeRowAndAdvance(proposalId);
+            } else {
+                alert('Error: ' + (data.error || 'Unknown error'));
+            }
+        })
+        .catch(function (err) {
+            alert('Error: ' + err);
+        });
+    }
+
+    function _singleReject(proposalId, adminNotes) {
+        var formData = new FormData();
+        formData.append('admin_notes', adminNotes || 'No reason provided');
+        formData.append('csrf_token', _config.csrfToken);
+
+        fetch(_config.rejectUrl + '/' + proposalId + '/reject', {
+            method: 'POST',
+            body: formData
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (data.message) {
+                _removeRowAndAdvance(proposalId);
+            } else {
+                alert('Error: ' + (data.error || 'Unknown error'));
+            }
+        })
+        .catch(function (err) {
+            alert('Error: ' + err);
+        });
+    }
+
+    function _removeRowAndAdvance(proposalId) {
+        // Find current index before rebuild
+        _buildPendingQueue();
+        var idx = _currentQueueIndex();
+
+        // Remove row from table and uncheck its checkbox
+        var $row = $('tr[data-proposal-id="' + proposalId + '"]');
+        // Update DataTable if active
+        var tableId = _config.tableId;
+        if (tableId && $.fn.DataTable && $.fn.DataTable.isDataTable('#' + tableId)) {
+            var dt = $('#' + tableId).DataTable();
+            var dtRow = dt.row($row);
+            if (dtRow.length) {
+                dtRow.remove().draw(false);
+            } else {
+                $row.remove();
+            }
+        } else {
+            $row.remove();
+        }
+
+        // Rebuild queue and advance
+        _buildPendingQueue();
+        _currentProposalId = null;
+
+        if (_pendingQueue.length === 0) {
+            _renderPanelEmpty('All proposals reviewed.');
+            return;
+        }
+
+        // Advance: try the same index position, or last
+        var nextIdx = Math.min(idx, _pendingQueue.length - 1);
+        _setCurrentProposal(_pendingQueue[nextIdx].id);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bulk approve
+    // -------------------------------------------------------------------------
+    function _bulkApprove() {
+        var selectedIds = [];
+        $('.proposal-select:checked').each(function () {
+            var id = parseInt($(this).data('id'), 10);
+            if (!isNaN(id)) selectedIds.push(id);
+        });
+
+        if (selectedIds.length === 0) return;
+
+        // D-12: confirm only when n > 1
+        if (selectedIds.length > 1) {
+            if (!confirm('Approve ' + selectedIds.length + ' proposals? This cannot be undone.')) return;
+        }
+
+        var adminNotes = _getPanelNotes() || '';
+
+        fetch(_config.bulkApproveUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': _config.csrfToken
+            },
+            body: JSON.stringify({ ids: selectedIds, admin_notes: adminNotes })
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            var approved = data.approved || [];
+            var failed = data.failed || [];
+
+            // Remove approved rows from table
+            if (approved.length > 0) {
+                // Remove by id — we need to find which proposal ids were approved.
+                // approved contains UUIDs; remove all checked rows that are now gone.
+                // Re-fetch the table to get fresh state — simplest reliable approach.
+                // Also uncheck the selectAll
+                $('.proposal-select:checked').each(function () {
+                    var $cb = $(this);
+                    var id = parseInt($cb.data('id'), 10);
+                    var $row = $cb.closest('tr');
+                    // Remove from DataTable
+                    var tableId = _config.tableId;
+                    if (tableId && $.fn.DataTable && $.fn.DataTable.isDataTable('#' + tableId)) {
+                        var dt = $('#' + tableId).DataTable();
+                        var dtRow = dt.row($row);
+                        if (dtRow.length) dtRow.remove();
+                    } else {
+                        $row.remove();
+                    }
+                });
+
+                // Redraw DataTable
+                var tableId = _config.tableId;
+                if (tableId && $.fn.DataTable && $.fn.DataTable.isDataTable('#' + tableId)) {
+                    $('#' + tableId).DataTable().draw(false);
+                }
+
+                $('#selectAll').prop('checked', false).prop('indeterminate', false);
+                _updateBulkBar();
+            }
+
+            if (failed.length > 0) {
+                var reasons = failed.map(function (f) {
+                    return 'ID ' + f.id + ': ' + f.reason;
+                }).join('\n');
+                alert('Some proposals could not be approved:\n' + reasons);
+            } else if (approved.length > 0) {
+                // Success summary
+                var msg = 'Approved ' + approved.length + ' proposal(s).';
+                if (approved.length === 1) {
+                    // No confirm needed for single — just show brief status
+                    console.log(msg);
+                } else {
+                    alert(msg);
+                }
+            }
+
+            // Rebuild panel
+            _buildPendingQueue();
+            _currentProposalId = null;
+            if (_pendingQueue.length > 0) {
+                _setCurrentProposal(_pendingQueue[0].id);
+            } else {
+                _renderPanelEmpty('All proposals reviewed.');
+            }
+        })
+        .catch(function (err) {
+            alert('Bulk approve error: ' + err);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Cheat-sheet modal
+    // -------------------------------------------------------------------------
+    function _openCheatSheet() {
+        var modal = document.getElementById('cheatSheetModal');
+        var overlay = document.getElementById('cheatSheetOverlay');
+        if (modal) modal.style.display = 'block';
+        if (overlay) overlay.style.display = 'block';
+    }
+
+    function _closeCheatSheet() {
+        var modal = document.getElementById('cheatSheetModal');
+        var overlay = document.getElementById('cheatSheetOverlay');
+        if (modal) modal.style.display = 'none';
+        if (overlay) overlay.style.display = 'none';
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+    return {
+        init: function (config) {
+            _config = config;
+            // Merge stepLabels override if provided
+            if (config.stepLabels) {
+                stepLabels = config.stepLabels;
+            }
+
+            $(document).ready(function () {
+                _initDataTable();
+                _initCheckboxes();
+                _initKeyboardHandler();
+                _initSidePanel();
+
+                // Wire bulk approve button
+                $(document).on('click', '#bulkApproveBtn', function () {
+                    _bulkApprove();
+                });
+            });
+        },
+
+        // Exposed for panel button onclick attributes and cheat-sheet close
+        handleApprove: function () { _handleApprove(); },
+        handleReject: function () { _handleReject(); },
+        openCheatSheet: function () { _openCheatSheet(); },
+        closeCheatSheet: function () { _closeCheatSheet(); }
+    };
+}());
+
+window.AdminProposals = AdminProposals;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1274,7 +1274,12 @@ class KEWPApp {
                     console.log('Status:', xhr.status, 'Response:', xhr.responseText);
                     
                     if (xhr.status === 401 || xhr.status === 403) {
-                        this.showMessage("Please log in to submit mappings.", "error");
+                        const expired = xhr.responseJSON?.error === "session_expired";
+                        this.showMessage(
+                            expired
+                                ? "Your session has expired — please log in again. Your assessment has been saved."
+                                : "Please log in to submit mappings.",
+                            "error");
                         setTimeout(() => {
                             this.saveFormState();
                             window.location.href = '/auth/login';
@@ -4665,7 +4670,12 @@ This helps identify gaps in existing pathways for future development.">❓</span
             })
             .fail((xhr) => {
                 if (xhr.status === 401 || xhr.status === 403) {
-                    this.showGoMessage("Please log in to submit mappings.", "error");
+                    const expired = xhr.responseJSON?.error === "session_expired";
+                    this.showGoMessage(
+                        expired
+                            ? "Your session has expired — please log in again, then resubmit."
+                            : "Please log in to submit mappings.",
+                        "error");
                     setTimeout(() => {
                         this.saveFormState();
                         window.location.href = '/auth/login';
@@ -4706,6 +4716,52 @@ This helps identify gaps in existing pathways for future development.">❓</span
                 <div>
                     <strong class="text-dark-heading">Confidence:</strong><br>
                     <span class="text-muted">${formData.confidence_level.charAt(0).toUpperCase() + formData.confidence_level.slice(1)}</span>
+                </div>
+            </div>
+        `;
+
+        $("#submissionSummary").html(summaryHtml);
+        const modal = $("#thankYouModal");
+        modal.css("display", "flex");
+
+        $("#closeThankYouModal").off("click").on("click", () => modal.hide());
+        modal.off("click").on("click", (e) => {
+            if (e.target.id === "thankYouModal") modal.hide();
+        });
+        setTimeout(() => modal.fadeOut(), 10000);
+    }
+
+    showReactomeSuccessMessage(payload) {
+        // Bind the Thank-You modal to the just-submitted Reactome record.
+        // Mirrors showGoSuccessMessage; Reactome has no namespace badge, and
+        // its connection type (relationship from step1) is only shown when present.
+        const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : "—");
+        const connectionBlock = payload.connection_type
+            ? `<div>
+                    <strong class="text-dark-heading">Connection:</strong><br>
+                    <span class="text-muted">${cap(payload.connection_type)}</span>
+                </div>`
+            : "";
+
+        const summaryHtml = `
+            <div style="margin-bottom: 15px;">
+                <div style="margin-bottom: 10px;">
+                    <strong class="text-dark-heading">Key Event:</strong><br>
+                    <span class="text-muted" style="font-family: monospace; font-size: 13px;">${payload.ke_id}</span><br>
+                    <span style="font-size: 14px;">${payload.ke_title}</span>
+                </div>
+                <div style="text-align: center; margin: 10px 0; font-size: 20px;" class="text-link-blue">&#8595;</div>
+                <div style="margin-bottom: 10px;">
+                    <strong class="text-dark-heading">Reactome Pathway:</strong><br>
+                    <span class="text-muted" style="font-family: monospace; font-size: 13px;">${payload.reactome_id}</span><br>
+                    <span style="font-size: 14px;">${payload.pathway_name}</span>
+                </div>
+            </div>
+            <div style="border-top: 1px solid var(--color-border-light); padding-top: 15px; display: flex; justify-content: space-around; font-size: 14px;">
+                ${connectionBlock}
+                <div>
+                    <strong class="text-dark-heading">Confidence:</strong><br>
+                    <span class="text-muted">${cap(payload.confidence_level)}</span>
                 </div>
             </div>
         `;
@@ -5224,13 +5280,18 @@ This helps identify gaps in existing pathways for future development.">❓</span
 
         $.post('/submit_reactome_mapping', payload)
             .done(() => {
-                $('#thankYouModal').css('display', 'flex');
-                $('#closeThankYouModal').off('click').on('click', () => $('#thankYouModal').hide());
+                // Populate + show the success modal from the captured payload
+                // BEFORE resetReactomeTab() nulls selectedReactomePathway (#194).
+                this.showReactomeSuccessMessage(payload);
                 this.resetReactomeTab();
             })
             .fail((xhr) => {
                 if (xhr && (xhr.status === 401 || xhr.status === 403)) {
-                    $('#reactome-message').text('Please log in to submit mappings.')
+                    const expired = xhr.responseJSON && xhr.responseJSON.error === 'session_expired';
+                    $('#reactome-message').text(
+                        expired
+                            ? 'Your session has expired — please log in again, then resubmit.'
+                            : 'Please log in to submit mappings.')
                         .css('color', 'var(--color-status-low)');
                     setTimeout(() => {
                         this.saveFormState();

--- a/templates/admin_go_proposals.html
+++ b/templates/admin_go_proposals.html
@@ -47,416 +47,140 @@
 
         <div class="existing-entries-container">
             <h2>KE-GO Proposal Dashboard</h2>
-            <p>Review and approve or reject KE-GO mapping proposals submitted by curators.</p>
+            <p>Review and approve or reject KE-GO mapping proposals submitted by curators. Use <kbd>a</kbd>/<kbd>r</kbd> to approve/reject, <kbd>↑</kbd>/<kbd>↓</kbd> to navigate, <kbd>?</kbd> for shortcuts.</p>
 
-            <table id="goProposalsTable" class="display" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>KE &rarr; GO Pair</th>
-                        <th>Proposed Values</th>
-                        <th>Submitted By</th>
-                        <th>Score</th>
-                        <th>Status</th>
-                        <th>Submitted</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for proposal in proposals %}
-                    <tr>
-                        <td>{{ proposal.id }}</td>
-                        <td>
-                            <strong>{{ proposal.ke_id }}</strong> &rarr; <strong>{{ proposal.go_id }}</strong><br>
-                            <div class="proposal-detail">
-                                {{ proposal.ke_title }}<br>
-                                &rarr; {{ proposal.go_name }}
-                            </div>
-                        </td>
-                        <td>
-                            <div>Connection: <strong>{{ proposal.new_pair_connection_type or proposal.proposed_connection_type }}</strong></div>
-                            <div>Confidence: <strong>{{ proposal.new_pair_confidence_level or proposal.proposed_confidence }}</strong></div>
-                        </td>
-                        <td>
-                            <div><strong>{{ proposal.github_username or proposal.user_name }}</strong></div>
-                        </td>
-                        <td>{{ "%.3f"|format(proposal.suggestion_score) if proposal.suggestion_score else '&mdash;' }}</td>
-                        <td>
-                            <span class="status-{{ proposal.status }}">{{ proposal.status|title }}</span>
-                            {% if proposal.admin_notes %}
-                                <div class="proposal-detail">{{ proposal.admin_notes }}</div>
-                            {% endif %}
-                        </td>
-                        <td>{{ proposal.created_at_formatted if proposal.created_at_formatted else 'Unknown' }}</td>
-                        <td>
-                            <div class="proposal-actions">
-                                {% if proposal.status == 'pending' %}
-                                    <button class="btn-approve" onclick="approveGoProposal({{ proposal.id }})">Approve</button>
-                                    <button class="btn-reject" onclick="rejectGoProposal({{ proposal.id }})">Reject</button>
-                                {% endif %}
-                                <button class="btn-view" onclick="viewGoProposal({{ proposal.id }})">Details</button>
-                            </div>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            <!-- Two-column layout: table left, side panel right -->
+            <div style="display: grid; grid-template-columns: 1fr 380px; gap: 20px; align-items: start;">
+                <!-- LEFT: bulk action bar + table -->
+                <div>
+                    <div id="bulkActionBar" style="margin-bottom: 12px; display: none;">
+                        <button id="bulkApproveBtn" class="btn-approve" disabled>
+                            Approve selected (<span id="selectedCount">0</span>)
+                        </button>
+                    </div>
+
+                    <table id="goProposalsTable" class="display" style="width:100%">
+                        <thead>
+                            <tr>
+                                <th><input type="checkbox" id="selectAll" title="Select all pending"></th>
+                                <th>ID</th>
+                                <th>KE &rarr; GO Pair</th>
+                                <th>Proposed Values</th>
+                                <th>Submitted By</th>
+                                <th>Score</th>
+                                <th>Status</th>
+                                <th>Submitted</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for proposal in proposals %}
+                            <tr data-proposal-id="{{ proposal.id }}"
+                                data-status="{{ proposal.status|e }}"
+                                data-ke-id="{{ proposal.ke_id|e }}"
+                                data-ke-title="{{ proposal.ke_title|e }}"
+                                data-pathway-id="{{ proposal.go_id|e }}"
+                                data-pathway-title="{{ proposal.go_name|e }}"
+                                data-confidence="{{ (proposal.new_pair_confidence_level or proposal.proposed_confidence)|e }}"
+                                data-connection-type="{{ (proposal.new_pair_connection_type or proposal.proposed_connection_type)|e }}"
+                                data-proposed-relationship="{{ proposal.proposed_relationship|e if proposal.proposed_relationship else '' }}"
+                                data-proposed-basis="{{ proposal.proposed_basis|e if proposal.proposed_basis else '' }}"
+                                data-proposed-specificity="{{ proposal.proposed_specificity|e if proposal.proposed_specificity else '' }}"
+                                data-proposed-coverage="{{ proposal.proposed_coverage|e if proposal.proposed_coverage else '' }}"
+                                data-suggestion-score="{{ proposal.suggestion_score|e if proposal.suggestion_score else '' }}"
+                                data-submitted-by="{{ (proposal.github_username or proposal.user_name)|e }}"
+                                data-created-at="{{ (proposal.created_at_formatted or proposal.created_at)|e }}">
+                                <td>
+                                    {% if proposal.status == 'pending' %}
+                                    <input type="checkbox" class="proposal-select"
+                                           data-id="{{ proposal.id }}"
+                                           data-status="{{ proposal.status }}">
+                                    {% endif %}
+                                </td>
+                                <td>{{ proposal.id }}</td>
+                                <td>
+                                    <strong>{{ proposal.ke_id }}</strong> &rarr; <strong>{{ proposal.go_id }}</strong><br>
+                                    <div class="proposal-detail">
+                                        {{ proposal.ke_title }}<br>
+                                        &rarr; {{ proposal.go_name }}
+                                    </div>
+                                </td>
+                                <td>
+                                    <div>Connection: <strong>{{ proposal.new_pair_connection_type or proposal.proposed_connection_type }}</strong></div>
+                                    <div>Confidence: <strong>{{ proposal.new_pair_confidence_level or proposal.proposed_confidence }}</strong></div>
+                                </td>
+                                <td>
+                                    <div><strong>{{ proposal.github_username or proposal.user_name }}</strong></div>
+                                </td>
+                                <td>{{ "%.3f"|format(proposal.suggestion_score) if proposal.suggestion_score else '&mdash;' }}</td>
+                                <td>
+                                    <span class="status-{{ proposal.status }}">{{ proposal.status|title }}</span>
+                                    {% if proposal.admin_notes %}
+                                        <div class="proposal-detail">{{ proposal.admin_notes }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>{{ proposal.created_at_formatted if proposal.created_at_formatted else 'Unknown' }}</td>
+                                <td>
+                                    <div class="proposal-actions">
+                                        {% if proposal.status == 'pending' %}
+                                            <button class="btn-approve" onclick="AdminProposals.handleApprove()">Approve</button>
+                                            <button class="btn-reject" onclick="AdminProposals.handleReject()">Reject</button>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- RIGHT: docked side panel -->
+                <div id="reviewPanel" style="position: sticky; top: 20px; border: 1px solid var(--color-border-light, #dee2e6); border-radius: 6px; padding: 16px; min-height: 300px; background: white;">
+                    <div id="reviewPanelContent">
+                        <p style="color: var(--color-text-muted, #6c757d);">Select a proposal to review.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
-    <!-- Detail Modal -->
-    <div id="goProposalModal" class="modal-panel" style="display: none; width: 600px; max-height: 80vh; overflow-y: auto;">
-        <h3>GO Proposal Details</h3>
-        <div id="goModalContent"></div>
-        <div style="margin-top: 20px;">
-            <textarea id="goAdminNotes" placeholder="Add admin notes (optional)" style="width: 100%; height: 80px; margin-bottom: 15px;"></textarea>
-        </div>
-        <div style="text-align: right;">
-            <button onclick="closeGoModal()" class="btn-clear" style="margin-right: 8px;">Close</button>
-            <button id="goModalApproveBtn" onclick="confirmGoApprove()" class="btn-approve" style="display: none; padding:8px 16px;">Approve Proposal</button>
-            <button id="goModalRejectBtn" onclick="confirmGoReject()" class="btn-reject" style="display: none; padding:8px 16px;">Reject Proposal</button>
+    <!-- Cheat-sheet modal -->
+    <div id="cheatSheetModal" class="modal-panel" style="display: none; width: 400px;">
+        <h3>Keyboard Shortcuts</h3>
+        <table style="border-collapse: collapse; width: 100%;">
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>a</kbd></td><td>Approve current proposal</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>r</kbd></td><td>Reject current proposal</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Navigate pending queue</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>?</kbd></td><td>Toggle this cheat sheet</td></tr>
+        </table>
+        <div style="margin-top: 16px; text-align: right;">
+            <button onclick="AdminProposals.closeCheatSheet()" class="btn-secondary">Close</button>
         </div>
     </div>
-    <div id="goModalOverlay" class="modal-overlay" style="display: none;" onclick="closeGoModal()"></div>
+    <div id="cheatSheetOverlay" class="modal-overlay" style="display: none;"
+         onclick="AdminProposals.closeCheatSheet()"></div>
 
     {% include 'components/footer.html' %}
 
     <script src="{{ url_for('static', filename='js/datatable-config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/admin_proposals.js') }}"></script>
     <script>
-        let currentGoProposalId = null;
-        const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
-        // Phase 32 review C-1 port: escape user-controlled values before
-        // injecting into innerHTML to prevent stored XSS. go_name, go_id,
-        // ke_title, admin_notes, github_username, etc. flow into the detail
-        // modal and are curator-controlled at proposal-submit time. Mirrors
-        // the policy in admin_reactome_proposals.html.
-        function escapeHtml(s) {
-            if (s === null || s === undefined) return '';
-            return String(s)
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;')
-                .replace(/'/g, '&#39;');
-        }
-
-        // GO scoring config cache for admin dimension preview
-        let goScoringConfig = null;
-
-        async function loadGoScoringConfig() {
-            if (goScoringConfig) return goScoringConfig;
-            try {
-                const resp = await fetch('/api/go-scoring-config');
-                if (resp.ok) {
-                    const data = await resp.json();
-                    goScoringConfig = data.ke_go_assessment;
-                }
-            } catch (e) {
-                console.warn('Failed to load GO scoring config for admin modal, using defaults');
-            }
-            if (!goScoringConfig) {
-                goScoringConfig = {
-                    dimension_weights: { connection: 0.33, specificity: 0.33, evidence: 0.34 },
-                    dimension_thresholds: { high: 2.5, medium: 1.5 }
-                };
-            }
-            return goScoringConfig;
-        }
-
-        function computeDimensionConfidence(connScore, specScore, evScore, config) {
-            const weights = (config && config.dimension_weights) || { connection: 0.33, specificity: 0.33, evidence: 0.34 };
-            const thresholds = (config && config.dimension_thresholds) || { high: 2.5, medium: 1.5 };
-            const weightedAvg = (connScore * weights.connection) + (specScore * weights.specificity) + (evScore * weights.evidence);
-            let label;
-            if (weightedAvg >= thresholds.high) { label = 'high'; }
-            else if (weightedAvg >= thresholds.medium) { label = 'medium'; }
-            else { label = 'low'; }
-            return { label, score: weightedAvg };
-        }
-
-        function scoreToLabel(score) {
-            if (score === 3) return 'High';
-            if (score === 2) return 'Medium';
-            if (score === 1) return 'Low';
-            return '&mdash;';
-        }
-
-        function renderAdminDimensionToggles(dimension, prefilledScore) {
-            const tooltips = {
-                connection: 'How directly does this GO term relate to the key event\'s biological mechanism? High: direct mechanistic link. Medium: functionally related process. Low: broadly associated.',
-                specificity: 'How precisely does this GO term describe the key event? High: exact match to the biological process. Medium: correct but broader/narrower. Low: tangentially relevant.',
-                evidence: 'How strong is the literature evidence linking this GO term to this key event? High: multiple experimental studies. Medium: curated or computational evidence. Low: inferred or assumed.'
-            };
-            const labels = { connection: 'Connection (biological relevance)', specificity: 'Specificity (term precision)', evidence: 'Evidence (literature support)' };
-            const scores = [3, 2, 1];
-            const scoreLabels = { 3: 'High', 2: 'Medium', 1: 'Low' };
-            // Phase 32 review C-1 port: although these values are derived
-            // from hardcoded objects above, CONTEXT.md "no exceptions" policy
-            // requires every interpolation in HTML-producing template
-            // literals to be escaped — future-proof against any of these
-            // becoming data-driven.
-            const dimEsc = escapeHtml(dimension);
-            const btns = scores.map(s => {
-                const sel = s === prefilledScore ? ' selected' : '';
-                return `<button type="button" class="btn-option admin-dim-btn${escapeHtml(sel)}" data-dimension="${dimEsc}" data-score="${escapeHtml(String(s))}">${escapeHtml(scoreLabels[s])}</button>`;
-            }).join('');
-            return `
-                <div class="go-dimension-row" style="display: flex; align-items: center; gap: 8px; margin-bottom: 10px;">
-                    <span style="font-weight: 600; min-width: 220px; font-size: 14px;">${escapeHtml(labels[dimension])}
-                        <span title="${escapeHtml(tooltips[dimension])}" style="cursor: help; font-size: 13px; color: var(--color-text-muted, #6c757d);">&#9432;</span>
-                    </span>
-                    <div class="btn-group go-btn-group" data-dimension="${dimEsc}" style="margin: 0;">
-                        ${btns}
-                    </div>
-                </div>`;
-        }
-
-        function updateAdminDimensionPreview() {
-            const connScore = parseInt($('.admin-dim-btn.selected[data-dimension="connection"]').data('score') || 0);
-            const specScore = parseInt($('.admin-dim-btn.selected[data-dimension="specificity"]').data('score') || 0);
-            const evScore = parseInt($('.admin-dim-btn.selected[data-dimension="evidence"]').data('score') || 0);
-            const $badge = $('#admin-dimension-badge');
-            const $preview = $('#admin-dimension-preview');
-            const $approveBtn = document.getElementById('goModalApproveBtn');
-
-            if (connScore && specScore && evScore) {
-                const result = computeDimensionConfidence(connScore, specScore, evScore, goScoringConfig);
-                $badge
-                    .text(result.label.charAt(0).toUpperCase() + result.label.slice(1))
-                    .removeClass('badge-status-high badge-status-medium badge-status-low')
-                    .addClass('badge-status-' + result.label);
-                $preview.show();
-                if ($approveBtn) $approveBtn.disabled = false;
-            } else {
-                $preview.hide();
-                if ($approveBtn) $approveBtn.disabled = true;
-            }
-        }
-
-        $(document).ready(function() {
-            $('#goProposalsTable').DataTable(
-                DataTableConfig.merge('base', {
-                    order: [[0, 'desc']],
-                    pageLength: 25,
-                    responsive: true,
-                    columnDefs: [
-                        { width: '5%', targets: 0 },
-                        { width: '25%', targets: 1 },
-                        { width: '18%', targets: 2 },
-                        { width: '12%', targets: 3 },
-                        { width: '8%', targets: 4 },
-                        { width: '8%', targets: 5 },
-                        { width: '10%', targets: 6 },
-                        { width: '14%', targets: 7, orderable: false }
-                    ]
-                })
-            );
-
-            // Admin dimension toggle handler
-            $(document).on('click', '.admin-dim-btn', function() {
-                const $btn = $(this);
-                $btn.closest('.go-btn-group').find('.admin-dim-btn').removeClass('selected');
-                $btn.addClass('selected');
-                updateAdminDimensionPreview();
-            });
-        });
-
         function filterGoProposals() {
-            const status = document.getElementById('statusFilter').value;
-            const currentUrl = new URL(window.location);
+            var status = document.getElementById('statusFilter').value;
+            var currentUrl = new URL(window.location);
             currentUrl.searchParams.set('status', status);
             window.location = currentUrl.toString();
         }
 
-        function viewGoProposal(proposalId) {
-            currentGoProposalId = proposalId;
-            loadGoScoringConfig().then(function() {
-                $.get(`/admin/go-proposals/${proposalId}`)
-                    .done(function(proposal) { showGoProposalModal(proposal); })
-                    .fail(function(xhr) { alert('Error loading GO proposal: ' + (xhr.responseJSON?.error || 'Unknown error')); });
-            });
-        }
-
-        function showGoProposalModal(proposal) {
-            const modal = document.getElementById('goProposalModal');
-            const overlay = document.getElementById('goModalOverlay');
-            const content = document.getElementById('goModalContent');
-            const approveBtn = document.getElementById('goModalApproveBtn');
-            const rejectBtn = document.getElementById('goModalRejectBtn');
-
-            // Curator's proposed dimension scores
-            const cConn = proposal.proposed_connection_score;
-            const cSpec = proposal.proposed_specificity_score;
-            const cEv = proposal.proposed_evidence_score;
-            const hasCuratorScores = cConn !== null && cConn !== undefined
-                                  && cSpec !== null && cSpec !== undefined
-                                  && cEv !== null && cEv !== undefined;
-
-            // Pre-escape curator dimension labels per "no exceptions" policy
-            // (even though scoreToLabel returns hardcoded strings).
-            const cConnEsc = escapeHtml(scoreToLabel(cConn));
-            const cSpecEsc = escapeHtml(scoreToLabel(cSpec));
-            const cEvEsc = escapeHtml(scoreToLabel(cEv));
-            const curatorScoreHtml = hasCuratorScores
-                ? `<div style="margin-top: 6px; font-size: 13px; color: var(--color-text-muted, #6c757d);">
-                       Curator's assessment: Connection=${cConnEsc}, Specificity=${cSpecEsc}, Evidence=${cEvEsc}
-                   </div>`
-                : `<div style="margin-top: 6px; font-size: 13px; color: var(--color-text-muted, #6c757d);">No dimension assessment submitted (legacy proposal)</div>`;
-
-            // Admin toggles pre-filled with curator's scores if available
-            const adminDimHtml = renderAdminDimensionToggles('connection', hasCuratorScores ? cConn : null)
-                               + renderAdminDimensionToggles('specificity', hasCuratorScores ? cSpec : null)
-                               + renderAdminDimensionToggles('evidence', hasCuratorScores ? cEv : null);
-
-            // Check if curator's scores are all pre-filled (enable approve immediately)
-            const allPreFilled = hasCuratorScores;
-
-            const rawNs = proposal.go_namespace || 'biological_process';
-            const nsShort = rawNs === 'molecular_function' ? 'MF' : 'BP';
-            const nsBadgeClass = rawNs === 'molecular_function' ? 'badge-go-mf' : 'badge-go-bp';
-            // Even though nsShort/nsBadgeClass are derived from a closed set of
-            // hardcoded literals here, CONTEXT.md "no exceptions" policy
-            // requires every interpolation in the modal-body innerHTML to be
-            // escaped — future-proof against go_namespace becoming a
-            // pass-through field.
-            const nsShortEsc = escapeHtml(nsShort);
-            const nsBadgeClassEsc = escapeHtml(nsBadgeClass);
-            const nsBadgeHtml = `<span class="${nsBadgeClassEsc}" style="margin-left: 6px;">${nsShortEsc}</span>`;
-
-            // Status is a DB enum (pending/approved/rejected) but escape both
-            // the class fragment and display text for defense-in-depth.
-            const statusRaw = proposal.status || '';
-            const statusEsc = escapeHtml(statusRaw);
-
-            content.innerHTML = `
-                <div style="margin-bottom: 20px;">
-                    <h4>Mapping Information</h4>
-                    <div><strong>KE ID:</strong> ${proposal.ke_id ? escapeHtml(proposal.ke_id) : '&mdash;'}</div>
-                    <div><strong>KE Title:</strong> ${proposal.ke_title ? escapeHtml(proposal.ke_title) : '&mdash;'}</div>
-                    <div><strong>GO ID:</strong> ${proposal.go_id ? escapeHtml(proposal.go_id) : '&mdash;'}</div>
-                    <div><strong>GO Name:</strong> ${proposal.go_name ? escapeHtml(proposal.go_name) : '&mdash;'}</div>
-                    <div><strong>GO Namespace:</strong> ${nsBadgeHtml}</div>
-                </div>
-                <div style="margin-bottom: 20px;">
-                    <h4>Proposed Values</h4>
-                    <div><strong>Connection Type:</strong> ${escapeHtml(proposal.new_pair_connection_type || proposal.proposed_connection_type || '') || '&mdash;'}</div>
-                    <div><strong>Confidence Level:</strong> ${escapeHtml(proposal.new_pair_confidence_level || proposal.proposed_confidence || '') || '&mdash;'}</div>
-                    <div><strong>BioBERT Score:</strong> ${proposal.suggestion_score !== null && proposal.suggestion_score !== undefined ? escapeHtml(Number(proposal.suggestion_score).toFixed(3)) : '&mdash;'}</div>
-                </div>
-                <div style="margin-bottom: 20px;">
-                    <h4>Submission Details</h4>
-                    <div><strong>Submitted By:</strong> ${escapeHtml(proposal.github_username || proposal.user_name || '') || '&mdash;'}</div>
-                    <div><strong>Submitted At:</strong> ${escapeHtml(proposal.created_at_formatted || proposal.created_at || '') || '&mdash;'}</div>
-                    <div><strong>Status:</strong> <span class="status-${statusEsc}">${statusEsc}</span></div>
-                    ${proposal.admin_notes ? `<div><strong>Admin Notes:</strong> ${escapeHtml(proposal.admin_notes)}</div>` : ''}
-                    ${proposal.approved_at_formatted ? `<div><strong>Reviewed At:</strong> ${escapeHtml(proposal.approved_at_formatted)}</div>` : ''}
-                </div>
-                <div style="margin-bottom: 20px; border-top: 1px solid var(--color-border-light); padding-top: 16px;">
-                    <h4 style="margin-bottom: 10px;">Assessment</h4>
-                    ${curatorScoreHtml}
-                    <div style="margin-top: 14px;">
-                        <div style="font-weight: 600; margin-bottom: 8px; font-size: 14px;">Admin dimension scores:</div>
-                        ${adminDimHtml}
-                    </div>
-                    <div id="admin-dimension-preview" style="display: none; margin-top: 10px; padding: 8px 12px; background: var(--color-bg-subtle, #f8f9fa); border-radius: 4px; border: 1px solid var(--color-border-light);">
-                        Computed confidence: <span id="admin-dimension-badge" class="badge-status-medium" style="font-size: 13px;">--</span>
-                    </div>
-                </div>
-            `;
-
-            if (proposal.status === 'pending') {
-                approveBtn.style.display = 'inline-block';
-                rejectBtn.style.display = 'inline-block';
-                // Gate approve button: disabled until all three admin dimensions selected
-                approveBtn.disabled = !allPreFilled;
-                // If pre-filled, show initial preview
-                if (allPreFilled) {
-                    updateAdminDimensionPreview();
-                }
-            } else {
-                approveBtn.style.display = 'none';
-                rejectBtn.style.display = 'none';
-            }
-
-            modal.style.display = 'block';
-            overlay.style.display = 'block';
-        }
-
-        function closeGoModal() {
-            document.getElementById('goProposalModal').style.display = 'none';
-            document.getElementById('goModalOverlay').style.display = 'none';
-            currentGoProposalId = null;
-        }
-
-        function approveGoProposal(proposalId) {
-            currentGoProposalId = proposalId;
-            if (!confirm('Approve this KE-GO proposal? This will create a live mapping.')) return;
-            $.post(`/admin/go-proposals/${proposalId}/approve`, { admin_notes: '', csrf_token: csrfToken })
-                .done(function(response) {
-                    alert(response.message || 'GO proposal approved.');
-                    location.reload();
-                })
-                .fail(function(xhr) {
-                    alert('Error: ' + (xhr.responseJSON?.error || 'Failed to approve GO proposal'));
-                });
-        }
-
-        function rejectGoProposal(proposalId) {
-            currentGoProposalId = proposalId;
-            const reason = prompt('Reason for rejection (optional):') || '';
-            $.post(`/admin/go-proposals/${proposalId}/reject`, { admin_notes: reason, csrf_token: csrfToken })
-                .done(function(response) {
-                    alert(response.message || 'GO proposal rejected.');
-                    location.reload();
-                })
-                .fail(function(xhr) {
-                    alert('Error: ' + (xhr.responseJSON?.error || 'Failed to reject GO proposal'));
-                });
-        }
-
-        function confirmGoApprove() {
-            if (currentGoProposalId) {
-                const notes = document.getElementById('goAdminNotes').value;
-                const connScore = parseInt($('.admin-dim-btn.selected[data-dimension="connection"]').data('score') || 0);
-                const specScore = parseInt($('.admin-dim-btn.selected[data-dimension="specificity"]').data('score') || 0);
-                const evScore = parseInt($('.admin-dim-btn.selected[data-dimension="evidence"]').data('score') || 0);
-                if (!connScore || !specScore || !evScore) {
-                    alert('Please select all three dimension scores before approving.');
-                    return;
-                }
-                $.post(`/admin/go-proposals/${currentGoProposalId}/approve`, {
-                    admin_notes: notes,
-                    connection_score: connScore,
-                    specificity_score: specScore,
-                    evidence_score: evScore,
-                    csrf_token: csrfToken
-                })
-                    .done(function(response) {
-                        alert(response.message || 'GO proposal approved.');
-                        closeGoModal();
-                        location.reload();
-                    })
-                    .fail(function(xhr) {
-                        alert('Error: ' + (xhr.responseJSON?.error || 'Failed to approve GO proposal'));
-                    });
-            }
-        }
-
-        function confirmGoReject() {
-            if (currentGoProposalId) {
-                const notes = document.getElementById('goAdminNotes').value;
-                $.post(`/admin/go-proposals/${currentGoProposalId}/reject`, { admin_notes: notes, csrf_token: csrfToken })
-                    .done(function(response) {
-                        alert(response.message || 'GO proposal rejected.');
-                        closeGoModal();
-                        location.reload();
-                    })
-                    .fail(function(xhr) {
-                        alert('Error: ' + (xhr.responseJSON?.error || 'Failed to reject GO proposal'));
-                    });
-            }
-        }
+        AdminProposals.init({
+            resource: 'go',
+            detailUrl: '/admin/go-proposals',
+            approveUrl: '/admin/go-proposals',
+            rejectUrl: '/admin/go-proposals',
+            bulkApproveUrl: '/admin/go-proposals/bulk-approve',
+            tableId: 'goProposalsTable',
+            csrfToken: '{{ csrf_token() }}'
+        });
     </script>
 </body>
 </html>

--- a/templates/admin_proposals.html
+++ b/templates/admin_proposals.html
@@ -53,334 +53,150 @@
 
         <div class="existing-entries-container">
             <h2>Proposal Management Dashboard</h2>
-            <p>Review and manage user-submitted proposals for mapping changes.</p>
+            <p>Review and manage user-submitted proposals for mapping changes. Use <kbd>a</kbd>/<kbd>r</kbd> to approve/reject, <kbd>↑</kbd>/<kbd>↓</kbd> to navigate, <kbd>?</kbd> for shortcuts.</p>
 
-            <table id="proposalsTable" class="display" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Mapping</th>
-                        <th>Proposed Changes</th>
-                        <th>User Details</th>
-                        <th>Status</th>
-                        <th>Submitted</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for proposal in proposals %}
-                    <tr>
-                        <td>{{ proposal.id }}</td>
-                        <td>
-                            <strong>{{ proposal.ke_id }}</strong> → <strong>{{ proposal.wp_id }}</strong><br>
-                            <div class="proposal-detail">
-                                {{ proposal.ke_title }}<br>
-                                → {{ proposal.wp_title }}
-                            </div>
-                        </td>
-                        <td>
-                            {% if proposal.proposed_delete %}
-                                <span class="btn-danger" style="font-size: 12px; padding: 4px 8px;">DELETE MAPPING</span>
-                            {% else %}
-                                {% if proposal.proposed_confidence %}
-                                    <div>Confidence: <strong>{{ proposal.current_confidence_level }}</strong> → <strong>{{ proposal.proposed_confidence }}</strong></div>
-                                {% endif %}
-                                {% if proposal.proposed_connection_type %}
-                                    <div>Type: <strong>{{ proposal.current_connection_type }}</strong> → <strong>{{ proposal.proposed_connection_type }}</strong></div>
-                                {% endif %}
-                            {% endif %}
-                        </td>
-                        <td>
-                            <div><strong>{{ proposal.user_name }}</strong></div>
-                            <div class="proposal-detail">{{ proposal.user_email }}</div>
-                            <div class="proposal-detail">{{ proposal.user_affiliation }}</div>
-                            <div class="proposal-detail">GitHub: {{ proposal.github_username }}</div>
-                        </td>
-                        <td>
-                            <span class="status-{{ proposal.status }}">{{ proposal.status|title }}</span>
-                            {% if proposal.admin_notes %}
-                                <div class="proposal-detail">{{ proposal.admin_notes }}</div>
-                            {% endif %}
-                        </td>
-                        <td>{{ proposal.created_at_formatted if proposal.created_at_formatted else 'Unknown' }}</td>
-                        <td>
-                            <div class="proposal-actions">
-                                {% if proposal.status == 'pending' %}
-                                    <button class="btn-approve" onclick="approveProposal({{ proposal.id }})">Approve</button>
-                                    <button class="btn-reject" onclick="rejectProposal({{ proposal.id }})">Reject</button>
-                                {% endif %}
-                                <button class="btn-view" onclick="viewProposal({{ proposal.id }})">Details</button>
-                            </div>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            <!-- Two-column layout: table left, side panel right -->
+            <div style="display: grid; grid-template-columns: 1fr 380px; gap: 20px; align-items: start;">
+                <!-- LEFT: bulk action bar + table -->
+                <div>
+                    <div id="bulkActionBar" style="margin-bottom: 12px; display: none;">
+                        <button id="bulkApproveBtn" class="btn-approve" disabled>
+                            Approve selected (<span id="selectedCount">0</span>)
+                        </button>
+                    </div>
+
+                    <table id="proposalsTable" class="display" style="width:100%">
+                        <thead>
+                            <tr>
+                                <th><input type="checkbox" id="selectAll" title="Select all pending"></th>
+                                <th>ID</th>
+                                <th>Mapping</th>
+                                <th>Proposed Changes</th>
+                                <th>User Details</th>
+                                <th>Status</th>
+                                <th>Submitted</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for proposal in proposals %}
+                            <tr data-proposal-id="{{ proposal.id }}"
+                                data-status="{{ proposal.status|e }}"
+                                data-ke-id="{{ proposal.ke_id|e }}"
+                                data-ke-title="{{ proposal.ke_title|e }}"
+                                data-pathway-id="{{ proposal.wp_id|e }}"
+                                data-pathway-title="{{ proposal.wp_title|e }}"
+                                data-confidence="{{ (proposal.proposed_confidence or proposal.current_confidence_level)|e }}"
+                                data-connection-type="{{ (proposal.proposed_connection_type or proposal.current_connection_type)|e }}"
+                                data-proposed-relationship="{{ proposal.proposed_relationship|e if proposal.proposed_relationship else '' }}"
+                                data-proposed-basis="{{ proposal.proposed_basis|e if proposal.proposed_basis else '' }}"
+                                data-proposed-specificity="{{ proposal.proposed_specificity|e if proposal.proposed_specificity else '' }}"
+                                data-proposed-coverage="{{ proposal.proposed_coverage|e if proposal.proposed_coverage else '' }}"
+                                data-suggestion-score="{{ proposal.suggestion_score|e if proposal.suggestion_score else '' }}"
+                                data-submitted-by="{{ (proposal.github_username or proposal.user_name)|e }}"
+                                data-created-at="{{ (proposal.created_at_formatted or proposal.created_at)|e }}"
+                                data-uuid="{{ proposal.uuid|e if proposal.uuid else '' }}">
+                                <td>
+                                    {% if proposal.status == 'pending' %}
+                                    <input type="checkbox" class="proposal-select"
+                                           data-id="{{ proposal.id }}"
+                                           data-status="{{ proposal.status }}">
+                                    {% endif %}
+                                </td>
+                                <td>{{ proposal.id }}</td>
+                                <td>
+                                    <strong>{{ proposal.ke_id }}</strong> → <strong>{{ proposal.wp_id }}</strong><br>
+                                    <div class="proposal-detail">
+                                        {{ proposal.ke_title }}<br>
+                                        → {{ proposal.wp_title }}
+                                    </div>
+                                </td>
+                                <td>
+                                    {% if proposal.proposed_delete %}
+                                        <span class="btn-danger" style="font-size: 12px; padding: 4px 8px;">DELETE MAPPING</span>
+                                    {% else %}
+                                        {% if proposal.proposed_confidence %}
+                                            <div>Confidence: <strong>{{ proposal.current_confidence_level }}</strong> → <strong>{{ proposal.proposed_confidence }}</strong></div>
+                                        {% endif %}
+                                        {% if proposal.proposed_connection_type %}
+                                            <div>Type: <strong>{{ proposal.current_connection_type }}</strong> → <strong>{{ proposal.proposed_connection_type }}</strong></div>
+                                        {% endif %}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <div><strong>{{ proposal.user_name }}</strong></div>
+                                    <div class="proposal-detail">{{ proposal.user_email }}</div>
+                                    <div class="proposal-detail">{{ proposal.user_affiliation }}</div>
+                                    <div class="proposal-detail">GitHub: {{ proposal.github_username }}</div>
+                                </td>
+                                <td>
+                                    <span class="status-{{ proposal.status }}">{{ proposal.status|title }}</span>
+                                    {% if proposal.admin_notes %}
+                                        <div class="proposal-detail">{{ proposal.admin_notes }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>{{ proposal.created_at_formatted if proposal.created_at_formatted else 'Unknown' }}</td>
+                                <td>
+                                    <div class="proposal-actions">
+                                        {% if proposal.status == 'pending' %}
+                                            <button class="btn-approve" onclick="AdminProposals.handleApprove()">Approve</button>
+                                            <button class="btn-reject" onclick="AdminProposals.handleReject()">Reject</button>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- RIGHT: docked side panel -->
+                <div id="reviewPanel" style="position: sticky; top: 20px; border: 1px solid var(--color-border-light, #dee2e6); border-radius: 6px; padding: 16px; min-height: 300px; background: white;">
+                    <div id="reviewPanelContent">
+                        <p style="color: var(--color-text-muted, #6c757d);">Select a proposal to review.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
-    <!-- Proposal Detail Modal -->
-    <div id="proposalModal" class="modal-panel" style="display: none; width: 600px; max-height: 80vh; overflow-y: auto;">
-        <h3 id="modalTitle">Proposal Details</h3>
-        <div id="modalContent"></div>
-        <div style="margin-top: 20px;">
-            <textarea id="adminNotes" placeholder="Add admin notes (optional)" style="width: 100%; height: 80px; margin-bottom: 15px;"></textarea>
-        </div>
-        <div style="text-align: right;">
-            <button onclick="closeModal()" class="btn-secondary">Close</button>
-            <button id="modalApproveBtn" onclick="confirmApprove()" class="btn-approve" style="display: none;">Approve Proposal</button>
-            <button id="modalRejectBtn" onclick="confirmReject()" class="btn-reject" style="display: none;">Reject Proposal</button>
+    <!-- Cheat-sheet modal (reuse modal-panel shell) -->
+    <div id="cheatSheetModal" class="modal-panel" style="display: none; width: 400px;">
+        <h3>Keyboard Shortcuts</h3>
+        <table style="border-collapse: collapse; width: 100%;">
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>a</kbd></td><td>Approve current proposal</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>r</kbd></td><td>Reject current proposal</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Navigate pending queue</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>?</kbd></td><td>Toggle this cheat sheet</td></tr>
+        </table>
+        <div style="margin-top: 16px; text-align: right;">
+            <button onclick="AdminProposals.closeCheatSheet()" class="btn-secondary">Close</button>
         </div>
     </div>
-
-    <!-- Modal Overlay -->
-    <div id="modalOverlay" class="modal-overlay" style="display: none;" onclick="closeModal()"></div>
+    <div id="cheatSheetOverlay" class="modal-overlay" style="display: none;"
+         onclick="AdminProposals.closeCheatSheet()"></div>
 
     {% include 'components/footer.html' %}
 
     <script src="{{ url_for('static', filename='js/datatable-config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/admin_proposals.js') }}"></script>
     <script>
-        let currentProposalId = null;
-
-        // Setup CSRF token for all AJAX requests
-        const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
-        // Phase 32 review C-1 port: escape user-controlled values before
-        // injecting into innerHTML to prevent stored XSS. user_name, user_email,
-        // user_affiliation, ke_title, wp_title, admin_notes, github_username
-        // and other proposer-supplied fields flow into the detail modal and
-        // are curator-controlled at proposal-submit time. Mirrors the helper
-        // defined in templates/admin_reactome_proposals.html (Phase 25 review C-1).
-        function escapeHtml(s) {
-            if (s === null || s === undefined) return '';
-            return String(s)
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;')
-                .replace(/'/g, '&#39;');
-        }
-
-        // Phase 37 ASMT-06: key→label map for four-question assessment answers.
-        // Sourced verbatim from main.js:1394-1397 — single source of truth is
-        // the submit-side form; this copy enables read-only display in the admin
-        // modal without importing main.js into the admin template.
-        const stepLabels = {
-            step1: { causative: 'Causative', responsive: 'Responsive', bidirectional: 'Bidirectional', unclear: 'Unclear' },
-            step2: { known: 'Known connection', likely: 'Likely connection', possible: 'Possible connection', uncertain: 'Uncertain connection' },
-            step3: { specific: 'KE-specific', includes: 'Includes KE', loose: 'Loosely related' },
-            step4: { complete: 'Complete mechanism', keysteps: 'Key steps only', minor: 'Minor aspects' }
-        };
-
-        $(document).ready(function() {
-            // Setup DataTable using shared configuration
-            $('#proposalsTable').DataTable(
-                DataTableConfig.merge('base', {
-                    order: [[0, 'desc']],
-                    pageLength: 25,
-                    responsive: true,
-                    columnDefs: [
-                        { width: '5%', targets: 0 },
-                        { width: '25%', targets: 1 },
-                        { width: '20%', targets: 2 },
-                        { width: '20%', targets: 3 },
-                        { width: '10%', targets: 4 },
-                        { width: '10%', targets: 5 },
-                        { width: '10%', targets: 6, orderable: false }
-                    ]
-                })
-            );
-        });
-
         function filterProposals() {
-            const status = document.getElementById('statusFilter').value;
-            const currentUrl = new URL(window.location);
+            var status = document.getElementById('statusFilter').value;
+            var currentUrl = new URL(window.location);
             currentUrl.searchParams.set('status', status);
             window.location = currentUrl.toString();
         }
 
-        function viewProposal(proposalId) {
-            currentProposalId = proposalId;
-
-            $.get(`/admin/proposals/${proposalId}`)
-                .done(function(proposal) {
-                    showProposalModal(proposal);
-                })
-                .fail(function(xhr) {
-                    alert('Error loading proposal: ' + (xhr.responseJSON?.error || 'Unknown error'));
-                });
-        }
-
-        function showProposalModal(proposal) {
-            const modal = document.getElementById('proposalModal');
-            const overlay = document.getElementById('modalOverlay');
-            const content = document.getElementById('modalContent');
-            const approveBtn = document.getElementById('modalApproveBtn');
-            const rejectBtn = document.getElementById('modalRejectBtn');
-
-            // Status is a DB enum (pending/approved/rejected) but escape both
-            // the class fragment and display text for defense-in-depth (mirrors
-            // admin_reactome_proposals.html L191-192).
-            const statusRaw = proposal.status || '';
-            const statusEsc = escapeHtml(statusRaw);
-            const statusTitle = statusRaw ? statusRaw.charAt(0).toUpperCase() + statusRaw.slice(1) : '';
-            const statusTitleEsc = escapeHtml(statusTitle);
-
-            let changesHtml = '';
-            if (proposal.proposed_delete) {
-                changesHtml = '<div class="btn-danger" style="font-size: 16px; padding: 8px 12px; display: inline-block;">DELETE THIS MAPPING</div>';
-            } else {
-                if (proposal.proposed_confidence) {
-                    changesHtml += `<div><strong>Confidence Level:</strong> ${escapeHtml(proposal.current_confidence_level)} → <strong>${escapeHtml(proposal.proposed_confidence)}</strong></div>`;
-                }
-                if (proposal.proposed_connection_type) {
-                    changesHtml += `<div><strong>Connection Type:</strong> ${escapeHtml(proposal.current_connection_type)} → <strong>${escapeHtml(proposal.proposed_connection_type)}</strong></div>`;
-                }
-            }
-
-            content.innerHTML = `
-                <div style="margin-bottom: 20px;">
-                    <h4>Mapping Information</h4>
-                    <div><strong>KE ID:</strong> ${escapeHtml(proposal.ke_id)}</div>
-                    <div><strong>KE Title:</strong> ${escapeHtml(proposal.ke_title)}</div>
-                    <div><strong>WP ID:</strong> ${escapeHtml(proposal.wp_id)}</div>
-                    <div><strong>WP Title:</strong> ${escapeHtml(proposal.wp_title)}</div>
-                    <div><strong>Current Confidence:</strong> ${escapeHtml(proposal.current_confidence_level)}</div>
-                    <div><strong>Current Connection:</strong> ${escapeHtml(proposal.current_connection_type)}</div>
-                </div>
-
-                <div class="filter-section" style="margin-bottom: 20px;">
-                    <h4>Proposed Changes</h4>
-                    ${changesHtml || '<div>No specific changes requested</div>'}
-                </div>
-
-                <div style="margin-bottom: 20px;">
-                    <h4>User Information</h4>
-                    <div><strong>Name:</strong> ${escapeHtml(proposal.user_name)}</div>
-                    <div><strong>Email:</strong> ${escapeHtml(proposal.user_email)}</div>
-                    <div><strong>Affiliation:</strong> ${escapeHtml(proposal.user_affiliation)}</div>
-                    <div><strong>GitHub:</strong> ${escapeHtml(proposal.github_username)}</div>
-                    <div><strong>Submitted:</strong> ${escapeHtml(proposal.created_at_formatted || proposal.created_at)}</div>
-                </div>
-
-                <div style="margin-bottom: 15px;">
-                    <h4>Status</h4>
-                    <div><strong>Current Status:</strong> <span class="status-${statusEsc}">${statusTitleEsc}</span></div>
-                    ${proposal.admin_notes ? `<div><strong>Admin Notes:</strong> ${escapeHtml(proposal.admin_notes)}</div>` : ''}
-                    ${proposal.approved_by ? `<div><strong>Processed By:</strong> ${escapeHtml(proposal.approved_by)}</div>` : ''}
-                    ${proposal.rejected_by ? `<div><strong>Processed By:</strong> ${escapeHtml(proposal.rejected_by)}</div>` : ''}
-                </div>
-
-                <div class="filter-section" style="margin-bottom: 15px;">
-                    <h4 style="margin-top: 0;">Admin Details</h4>
-                    <div><strong>Suggestion Score:</strong> ${proposal.suggestion_score !== null && proposal.suggestion_score !== undefined ? proposal.suggestion_score.toFixed(3) : '&mdash;'}</div>
-                    <div><strong>Proposal UUID:</strong> <code style="font-size: 12px;">${escapeHtml(proposal.uuid || '&mdash;')}</code></div>
-                </div>
-
-                ${(() => {
-                    const p = proposal;
-                    const hasAssessment = p.proposed_relationship != null
-                        || p.proposed_basis != null
-                        || p.proposed_specificity != null
-                        || p.proposed_coverage != null;
-                    const body = hasAssessment
-                        ? `<div><strong>Relationship:</strong> ${escapeHtml(stepLabels.step1[p.proposed_relationship] || p.proposed_relationship || '—')}</div>
-                           <div><strong>Basis:</strong> ${escapeHtml(stepLabels.step2[p.proposed_basis] || p.proposed_basis || '—')}</div>
-                           <div><strong>Specificity:</strong> ${escapeHtml(stepLabels.step3[p.proposed_specificity] || p.proposed_specificity || '—')}</div>
-                           <div><strong>Coverage:</strong> ${escapeHtml(stepLabels.step4[p.proposed_coverage] || p.proposed_coverage || '—')}</div>`
-                        : `<div style="font-size: 13px; color: var(--color-text-muted, #6c757d);">No assessment submitted (legacy proposal)</div>`;
-                    return `<div style="margin-bottom: 20px; border-top: 1px solid var(--color-border-light); padding-top: 16px;">
-                        <h4 style="margin-bottom: 10px;">Assessment</h4>
-                        ${body}
-                    </div>`;
-                })()}
-            `;
-
-            // Show action buttons only for pending proposals
-            if (proposal.status === 'pending') {
-                approveBtn.style.display = 'inline-block';
-                rejectBtn.style.display = 'inline-block';
-            } else {
-                approveBtn.style.display = 'none';
-                rejectBtn.style.display = 'none';
-            }
-
-            modal.style.display = 'block';
-            overlay.style.display = 'block';
-        }
-
-        function approveProposal(proposalId) {
-            if (confirm('Are you sure you want to approve this proposal? This will apply the changes to the mapping.')) {
-                currentProposalId = proposalId;
-                viewProposal(proposalId); // Show modal for admin notes
-            }
-        }
-
-        function rejectProposal(proposalId) {
-            if (confirm('Are you sure you want to reject this proposal?')) {
-                currentProposalId = proposalId;
-                viewProposal(proposalId); // Show modal for admin notes
-            }
-        }
-
-        function confirmApprove() {
-            if (!currentProposalId) return;
-
-            const adminNotes = document.getElementById('adminNotes').value;
-            const formData = new FormData();
-            formData.append('admin_notes', adminNotes);
-            formData.append('csrf_token', csrfToken);
-
-            fetch(`/admin/proposals/${currentProposalId}/approve`, {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.message) {
-                    alert('Success: ' + data.message);
-                    location.reload();
-                } else {
-                    alert('Error: ' + (data.error || 'Unknown error'));
-                }
-            })
-            .catch(error => {
-                alert('Error: ' + error);
-            });
-        }
-
-        function confirmReject() {
-            if (!currentProposalId) return;
-
-            const adminNotes = document.getElementById('adminNotes').value || 'No reason provided';
-            const formData = new FormData();
-            formData.append('admin_notes', adminNotes);
-            formData.append('csrf_token', csrfToken);
-
-            fetch(`/admin/proposals/${currentProposalId}/reject`, {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.message) {
-                    alert('Success: ' + data.message);
-                    location.reload();
-                } else {
-                    alert('Error: ' + (data.error || 'Unknown error'));
-                }
-            })
-            .catch(error => {
-                alert('Error: ' + error);
-            });
-        }
-
-        function closeModal() {
-            document.getElementById('proposalModal').style.display = 'none';
-            document.getElementById('modalOverlay').style.display = 'none';
-            document.getElementById('adminNotes').value = '';
-            currentProposalId = null;
-        }
+        AdminProposals.init({
+            resource: 'wp',
+            detailUrl: '/admin/proposals',
+            approveUrl: '/admin/proposals',
+            rejectUrl: '/admin/proposals',
+            bulkApproveUrl: '/admin/proposals/bulk-approve',
+            tableId: 'proposalsTable',
+            csrfToken: '{{ csrf_token() }}'
+        });
     </script>
 </body>
 </html>

--- a/templates/admin_reactome_proposals.html
+++ b/templates/admin_reactome_proposals.html
@@ -47,286 +47,139 @@
 
         <div class="existing-entries-container">
             <h2>KE-Reactome Proposal Dashboard</h2>
-            <p>Review and approve or reject KE-Reactome mapping proposals submitted by curators.</p>
+            <p>Review and approve or reject KE-Reactome mapping proposals submitted by curators. Use <kbd>a</kbd>/<kbd>r</kbd> to approve/reject, <kbd>↑</kbd>/<kbd>↓</kbd> to navigate, <kbd>?</kbd> for shortcuts.</p>
 
-            <table id="reactomeProposalsTable" class="display" style="width:100%">
-                <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>KE &rarr; Reactome Pair</th>
-                        <th>Proposed Values</th>
-                        <th>Submitted By</th>
-                        <th>Score</th>
-                        <th>Status</th>
-                        <th>Submitted</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for proposal in proposals %}
-                    <tr>
-                        <td>{{ proposal.id }}</td>
-                        <td>
-                            <strong>{{ proposal.ke_id }}</strong> &rarr; <strong>{{ proposal.reactome_id }}</strong><br>
-                            <div class="proposal-detail">
-                                {{ proposal.ke_title }}<br>
-                                &rarr; {{ proposal.pathway_name }}
-                            </div>
-                        </td>
-                        <td>
-                            <div>Species: <strong>{{ proposal.species or 'Homo sapiens' }}</strong></div>
-                            <div>Confidence: <strong>{{ proposal.new_pair_confidence_level or proposal.proposed_confidence }}</strong></div>
-                        </td>
-                        <td>
-                            <div><strong>{{ proposal.provider_username or proposal.user_name or '—' }}</strong></div>
-                        </td>
-                        <td>{{ "%.3f"|format(proposal.suggestion_score) if proposal.suggestion_score else '&mdash;' }}</td>
-                        <td>
-                            <span class="status-{{ proposal.status }}">{{ proposal.status|title }}</span>
-                            {% if proposal.admin_notes %}
-                                <div class="proposal-detail">{{ proposal.admin_notes }}</div>
-                            {% endif %}
-                        </td>
-                        <td>{{ proposal.created_at_formatted if proposal.created_at_formatted else 'Unknown' }}</td>
-                        <td>
-                            <div class="proposal-actions">
-                                {% if proposal.status == 'pending' %}
-                                    <button class="btn-approve" onclick="approveReactomeProposal({{ proposal.id }})">Approve Proposal</button>
-                                    <button class="btn-reject" onclick="rejectReactomeProposal({{ proposal.id }})">Reject Proposal</button>
-                                {% endif %}
-                                <button class="btn-view" onclick="viewReactomeProposal({{ proposal.id }})">View Details</button>
-                            </div>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            <!-- Two-column layout: table left, side panel right -->
+            <div style="display: grid; grid-template-columns: 1fr 380px; gap: 20px; align-items: start;">
+                <!-- LEFT: bulk action bar + table -->
+                <div>
+                    <div id="bulkActionBar" style="margin-bottom: 12px; display: none;">
+                        <button id="bulkApproveBtn" class="btn-approve" disabled>
+                            Approve selected (<span id="selectedCount">0</span>)
+                        </button>
+                    </div>
+
+                    <table id="reactomeProposalsTable" class="display" style="width:100%">
+                        <thead>
+                            <tr>
+                                <th><input type="checkbox" id="selectAll" title="Select all pending"></th>
+                                <th>ID</th>
+                                <th>KE &rarr; Reactome Pair</th>
+                                <th>Proposed Values</th>
+                                <th>Submitted By</th>
+                                <th>Score</th>
+                                <th>Status</th>
+                                <th>Submitted</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for proposal in proposals %}
+                            <tr data-proposal-id="{{ proposal.id }}"
+                                data-status="{{ proposal.status|e }}"
+                                data-ke-id="{{ proposal.ke_id|e }}"
+                                data-ke-title="{{ proposal.ke_title|e }}"
+                                data-pathway-id="{{ proposal.reactome_id|e }}"
+                                data-pathway-title="{{ proposal.pathway_name|e }}"
+                                data-confidence="{{ (proposal.new_pair_confidence_level or proposal.proposed_confidence)|e }}"
+                                data-proposed-relationship="{{ proposal.proposed_relationship|e if proposal.proposed_relationship else '' }}"
+                                data-proposed-basis="{{ proposal.proposed_basis|e if proposal.proposed_basis else '' }}"
+                                data-proposed-specificity="{{ proposal.proposed_specificity|e if proposal.proposed_specificity else '' }}"
+                                data-proposed-coverage="{{ proposal.proposed_coverage|e if proposal.proposed_coverage else '' }}"
+                                data-suggestion-score="{{ proposal.suggestion_score|e if proposal.suggestion_score else '' }}"
+                                data-submitted-by="{{ (proposal.provider_username or proposal.user_name)|e }}"
+                                data-created-at="{{ (proposal.created_at_formatted or proposal.created_at)|e }}">
+                                <td>
+                                    {% if proposal.status == 'pending' %}
+                                    <input type="checkbox" class="proposal-select"
+                                           data-id="{{ proposal.id }}"
+                                           data-status="{{ proposal.status }}">
+                                    {% endif %}
+                                </td>
+                                <td>{{ proposal.id }}</td>
+                                <td>
+                                    <strong>{{ proposal.ke_id }}</strong> &rarr; <strong>{{ proposal.reactome_id }}</strong><br>
+                                    <div class="proposal-detail">
+                                        {{ proposal.ke_title }}<br>
+                                        &rarr; {{ proposal.pathway_name }}
+                                    </div>
+                                </td>
+                                <td>
+                                    <div>Species: <strong>{{ proposal.species or 'Homo sapiens' }}</strong></div>
+                                    <div>Confidence: <strong>{{ proposal.new_pair_confidence_level or proposal.proposed_confidence }}</strong></div>
+                                </td>
+                                <td>
+                                    <div><strong>{{ proposal.provider_username or proposal.user_name or '—' }}</strong></div>
+                                </td>
+                                <td>{{ "%.3f"|format(proposal.suggestion_score) if proposal.suggestion_score else '&mdash;' }}</td>
+                                <td>
+                                    <span class="status-{{ proposal.status }}">{{ proposal.status|title }}</span>
+                                    {% if proposal.admin_notes %}
+                                        <div class="proposal-detail">{{ proposal.admin_notes }}</div>
+                                    {% endif %}
+                                </td>
+                                <td>{{ proposal.created_at_formatted if proposal.created_at_formatted else 'Unknown' }}</td>
+                                <td>
+                                    <div class="proposal-actions">
+                                        {% if proposal.status == 'pending' %}
+                                            <button class="btn-approve" onclick="AdminProposals.handleApprove()">Approve Proposal</button>
+                                            <button class="btn-reject" onclick="AdminProposals.handleReject()">Reject Proposal</button>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- RIGHT: docked side panel -->
+                <div id="reviewPanel" style="position: sticky; top: 20px; border: 1px solid var(--color-border-light, #dee2e6); border-radius: 6px; padding: 16px; min-height: 300px; background: white;">
+                    <div id="reviewPanelContent">
+                        <p style="color: var(--color-text-muted, #6c757d);">Select a proposal to review.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
-    <!-- Detail Modal -->
-    <div id="reactomeProposalModal" class="modal-panel" style="display: none; width: 600px; max-height: 80vh; overflow-y: auto;">
-        <h3>Reactome Proposal Details</h3>
-        <div id="reactomeModalContent"></div>
-        <div style="margin-top: 20px;">
-            <textarea id="reactomeAdminNotes" placeholder="Add admin notes (optional)" style="width: 100%; height: 80px; margin-bottom: 15px;"></textarea>
-        </div>
-        <div style="text-align: right;">
-            <button onclick="closeReactomeModal()" class="btn-clear" style="margin-right: 8px;">Close</button>
-            <button id="reactomeModalApproveBtn" onclick="confirmReactomeApprove()" class="btn-approve" style="display: none; padding:8px 16px;">Approve Proposal</button>
-            <button id="reactomeModalRejectBtn" onclick="confirmReactomeReject()" class="btn-reject" style="display: none; padding:8px 16px;">Reject Proposal</button>
+    <!-- Cheat-sheet modal -->
+    <div id="cheatSheetModal" class="modal-panel" style="display: none; width: 400px;">
+        <h3>Keyboard Shortcuts</h3>
+        <table style="border-collapse: collapse; width: 100%;">
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>a</kbd></td><td>Approve current proposal</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>r</kbd></td><td>Reject current proposal</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Navigate pending queue</td></tr>
+            <tr><td style="padding: 6px 12px 6px 0;"><kbd>?</kbd></td><td>Toggle this cheat sheet</td></tr>
+        </table>
+        <div style="margin-top: 16px; text-align: right;">
+            <button onclick="AdminProposals.closeCheatSheet()" class="btn-secondary">Close</button>
         </div>
     </div>
-    <div id="reactomeModalOverlay" class="modal-overlay" style="display: none;" onclick="closeReactomeModal()"></div>
+    <div id="cheatSheetOverlay" class="modal-overlay" style="display: none;"
+         onclick="AdminProposals.closeCheatSheet()"></div>
 
     {% include 'components/footer.html' %}
 
     <script src="{{ url_for('static', filename='js/datatable-config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/admin_proposals.js') }}"></script>
     <script>
-        let currentReactomeProposalId = null;
-        const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
-        // Escape user-controlled values before injecting into innerHTML to
-        // prevent stored XSS (Phase 25 review C-1). pathway_name, ke_title,
-        // species, admin_notes, and provider_username flow into the detail
-        // modal and are curator-controlled at proposal-submit time.
-        function escapeHtml(s) {
-            if (s === null || s === undefined) return '';
-            return String(s)
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;')
-                .replace(/'/g, '&#39;');
-        }
-
-        // Phase 37 ASMT-05: key->label map for four-question assessment answers.
-        // Duplicated per-template (each admin template carries its own inline
-        // IIFE today — see 37-PLAN.md Task 3 note). Sourced verbatim from
-        // main.js:1394-1397.
-        const stepLabels = {
-            step1: { causative: 'Causative', responsive: 'Responsive', bidirectional: 'Bidirectional', unclear: 'Unclear' },
-            step2: { known: 'Known connection', likely: 'Likely connection', possible: 'Possible connection', uncertain: 'Uncertain connection' },
-            step3: { specific: 'KE-specific', includes: 'Includes KE', loose: 'Loosely related' },
-            step4: { complete: 'Complete mechanism', keysteps: 'Key steps only', minor: 'Minor aspects' }
-        };
-
-        $(document).ready(function() {
-            $('#reactomeProposalsTable').DataTable(
-                DataTableConfig.merge('base', {
-                    order: [[0, 'desc']],
-                    pageLength: 25,
-                    responsive: true,
-                    columnDefs: [
-                        { width: '5%', targets: 0 },
-                        { width: '25%', targets: 1 },
-                        { width: '18%', targets: 2 },
-                        { width: '12%', targets: 3 },
-                        { width: '8%', targets: 4 },
-                        { width: '8%', targets: 5 },
-                        { width: '10%', targets: 6 },
-                        { width: '14%', targets: 7, orderable: false }
-                    ]
-                })
-            );
-        });
-
         function filterReactomeProposals() {
-            const status = document.getElementById('reactomeStatusFilter').value;
-            const currentUrl = new URL(window.location);
+            var status = document.getElementById('reactomeStatusFilter').value;
+            var currentUrl = new URL(window.location);
             currentUrl.searchParams.set('status', status);
             window.location = currentUrl.toString();
         }
 
-        function viewReactomeProposal(proposalId) {
-            currentReactomeProposalId = proposalId;
-            $.get(`/admin/reactome-proposals/${proposalId}`)
-                .done(function(proposal) { showReactomeProposalModal(proposal); })
-                .fail(function(xhr) {
-                    alert('Error loading Reactome proposal: ' + (xhr.responseJSON?.error || 'Unknown error'));
-                });
-        }
-
-        function showReactomeProposalModal(proposal) {
-            const modal = document.getElementById('reactomeProposalModal');
-            const overlay = document.getElementById('reactomeModalOverlay');
-            const content = document.getElementById('reactomeModalContent');
-            const approveBtn = document.getElementById('reactomeModalApproveBtn');
-            const rejectBtn = document.getElementById('reactomeModalRejectBtn');
-
-            // Score is numeric; coerce defensively before formatting.
-            const scoreText = (proposal.suggestion_score !== null && proposal.suggestion_score !== undefined)
-                ? Number(proposal.suggestion_score).toFixed(3)
-                : '&mdash;';
-            // Status is a DB enum (pending/approved/rejected) but escape both
-            // the class fragment and display text for defense-in-depth.
-            const statusRaw = proposal.status || '';
-            const statusEsc = escapeHtml(statusRaw);
-            const confidence = proposal.new_pair_confidence_level || proposal.proposed_confidence;
-            const submittedBy = proposal.provider_username || proposal.user_name;
-            const submittedAt = proposal.created_at_formatted || proposal.created_at;
-
-            content.innerHTML = `
-                <div style="margin-bottom: 20px;">
-                    <h4>Mapping Information</h4>
-                    <div><strong>KE ID:</strong> ${proposal.ke_id ? escapeHtml(proposal.ke_id) : '&mdash;'}</div>
-                    <div><strong>KE Title:</strong> ${proposal.ke_title ? escapeHtml(proposal.ke_title) : '&mdash;'}</div>
-                    <div><strong>Reactome ID:</strong> ${proposal.reactome_id ? escapeHtml(proposal.reactome_id) : '&mdash;'}</div>
-                    <div><strong>Pathway Name:</strong> ${proposal.pathway_name ? escapeHtml(proposal.pathway_name) : '&mdash;'}</div>
-                    <div><strong>Species:</strong> ${escapeHtml(proposal.species || 'Homo sapiens')}</div>
-                </div>
-                <div style="margin-bottom: 20px;">
-                    <h4>Proposed Values</h4>
-                    <div><strong>Confidence Level:</strong> ${confidence ? escapeHtml(confidence) : '&mdash;'}</div>
-                    <div><strong>Suggestion Score:</strong> ${scoreText}</div>
-                </div>
-                <div style="margin-bottom: 20px;">
-                    <h4>Submission Details</h4>
-                    <div><strong>Submitted By:</strong> ${submittedBy ? escapeHtml(submittedBy) : '&mdash;'}</div>
-                    <div><strong>Submitted At:</strong> ${submittedAt ? escapeHtml(submittedAt) : '&mdash;'}</div>
-                    <div><strong>Status:</strong> <span class="status-${statusEsc}">${statusEsc}</span></div>
-                    ${proposal.admin_notes ? `<div><strong>Admin Notes:</strong> ${escapeHtml(proposal.admin_notes)}</div>` : ''}
-                    ${proposal.approved_at_formatted ? `<div><strong>Reviewed At:</strong> ${escapeHtml(proposal.approved_at_formatted)}</div>` : ''}
-                </div>
-
-                ${(() => {
-                    const p = proposal;
-                    const hasAssessment = p.proposed_relationship != null
-                        || p.proposed_basis != null
-                        || p.proposed_specificity != null
-                        || p.proposed_coverage != null;
-                    const assessmentRows = hasAssessment
-                        ? `<div><strong>Relationship:</strong> ${escapeHtml(stepLabels.step1[p.proposed_relationship] || p.proposed_relationship || '—')}</div>
-                           <div><strong>Basis:</strong> ${escapeHtml(stepLabels.step2[p.proposed_basis] || p.proposed_basis || '—')}</div>
-                           <div><strong>Specificity:</strong> ${escapeHtml(stepLabels.step3[p.proposed_specificity] || p.proposed_specificity || '—')}</div>
-                           <div><strong>Coverage:</strong> ${escapeHtml(stepLabels.step4[p.proposed_coverage] || p.proposed_coverage || '—')}</div>`
-                        : `<div style="font-size: 13px; color: var(--color-text-muted, #6c757d);">No assessment submitted (legacy proposal)</div>`;
-                    return `<div style="margin-bottom: 20px; border-top: 1px solid var(--color-border-light); padding-top: 16px;">
-                        <h4 style="margin-bottom: 10px;">Assessment</h4>
-                        ${assessmentRows}
-                        <div><strong>Derived confidence:</strong> ${escapeHtml(confidence || '—')}</div>
-                    </div>`;
-                })()}
-            `;
-
-            if (proposal.status === 'pending') {
-                approveBtn.style.display = 'inline-block';
-                rejectBtn.style.display = 'inline-block';
-                approveBtn.disabled = false;
-            } else {
-                approveBtn.style.display = 'none';
-                rejectBtn.style.display = 'none';
-            }
-
-            modal.style.display = 'block';
-            overlay.style.display = 'block';
-        }
-
-        function closeReactomeModal() {
-            document.getElementById('reactomeProposalModal').style.display = 'none';
-            document.getElementById('reactomeModalOverlay').style.display = 'none';
-            currentReactomeProposalId = null;
-        }
-
-        function approveReactomeProposal(proposalId) {
-            currentReactomeProposalId = proposalId;
-            if (!confirm('Approve this KE-Reactome proposal? This will create a live mapping.')) return;
-            $.post(`/admin/reactome-proposals/${proposalId}/approve`, { admin_notes: '', csrf_token: csrfToken })
-                .done(function(response) {
-                    alert(response.message || 'Proposal approved. Mapping created.');
-                    location.reload();
-                })
-                .fail(function(xhr) {
-                    alert('Error: ' + (xhr.responseJSON?.error || 'Failed to approve Reactome proposal'));
-                });
-        }
-
-        function rejectReactomeProposal(proposalId) {
-            currentReactomeProposalId = proposalId;
-            const reason = prompt('Reason for rejection (optional):') || '';
-            $.post(`/admin/reactome-proposals/${proposalId}/reject`, { admin_notes: reason, csrf_token: csrfToken })
-                .done(function(response) {
-                    alert(response.message || 'Proposal rejected.');
-                    location.reload();
-                })
-                .fail(function(xhr) {
-                    alert('Error: ' + (xhr.responseJSON?.error || 'Failed to reject Reactome proposal'));
-                });
-        }
-
-        function confirmReactomeApprove() {
-            if (!currentReactomeProposalId) return;
-            const notes = document.getElementById('reactomeAdminNotes').value;
-            $.post(`/admin/reactome-proposals/${currentReactomeProposalId}/approve`, {
-                admin_notes: notes,
-                csrf_token: csrfToken
-            })
-                .done(function(response) {
-                    alert(response.message || 'Proposal approved. Mapping created.');
-                    closeReactomeModal();
-                    location.reload();
-                })
-                .fail(function(xhr) {
-                    alert('Error: ' + (xhr.responseJSON?.error || 'Failed to approve Reactome proposal'));
-                });
-        }
-
-        function confirmReactomeReject() {
-            if (!currentReactomeProposalId) return;
-            const notes = document.getElementById('reactomeAdminNotes').value;
-            $.post(`/admin/reactome-proposals/${currentReactomeProposalId}/reject`, {
-                admin_notes: notes,
-                csrf_token: csrfToken
-            })
-                .done(function(response) {
-                    alert(response.message || 'Proposal rejected.');
-                    closeReactomeModal();
-                    location.reload();
-                })
-                .fail(function(xhr) {
-                    alert('Error: ' + (xhr.responseJSON?.error || 'Failed to reject Reactome proposal'));
-                });
-        }
+        AdminProposals.init({
+            resource: 'reactome',
+            detailUrl: '/admin/reactome-proposals',
+            approveUrl: '/admin/reactome-proposals',
+            rejectUrl: '/admin/reactome-proposals',
+            bulkApproveUrl: '/admin/reactome-proposals/bulk-approve',
+            tableId: 'reactomeProposalsTable',
+            csrfToken: '{{ csrf_token() }}'
+        });
     </script>
 </body>
 </html>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -63,7 +63,7 @@
           {% set entry = live_versions.get(key, {}) %}
           {% if entry.get('unavailable') %}
             <span class="version-badge version-badge--unavailable"
-                  title="Could not reach upstream source">{{ label }}: unavailable</span>
+                  title="Couldn't fetch the upstream {{ label }} release version. This badge tracks source-release metadata only — {{ label }} mapping, search and suggestions are unaffected.">{{ label }} version: unknown</span>
           {% elif entry.get('version') %}
             <span class="version-badge">{{ label }}: {{ entry.version }}</span>
           {% endif %}

--- a/tests/test_admin_bulk_approve.py
+++ b/tests/test_admin_bulk_approve.py
@@ -1,0 +1,513 @@
+"""
+Wave 0 test scaffold for Phase 38 bulk-approve backend (Plan 38-01).
+
+Covers:
+- Per-resource fixtures: wp_admin_client, go_admin_client, reactome_admin_client
+- Seed helpers: _seed_wp_proposal, _seed_go_proposal, _seed_reactome_proposal
+- Per-resource test classes: TestWPBulkApprove, TestGOBulkApprove, TestReactomeBulkApprove
+- TestBulkApproveShared: static/smoke tests
+
+Route-dependent test bodies are marked with pytest.mark.skip(reason="route lands in 38-02")
+so the suite stays green in Wave 0 while the fault-injection seam and fixture infra are
+exercisable now.
+"""
+import logging
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Per-resource fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wp_admin_client():
+    """
+    Test client wired with fresh WP models on a temp-file DB and an
+    authenticated admin session (github:testadmin).
+
+    Yields (test_client, mapping_model, proposal_model, db).
+    """
+    os.environ["ADMIN_USERS"] = "github:testadmin"
+
+    from app import app as flask_app
+    import src.blueprints.admin as admin_mod
+    from src.core.models import Database, MappingModel, ProposalModel
+
+    fd, db_path = tempfile.mkstemp()
+    db = Database(db_path)
+    mm = MappingModel(db)
+    pm = ProposalModel(db)
+
+    orig_mm = admin_mod.mapping_model
+    orig_pm = admin_mod.proposal_model
+
+    admin_mod.mapping_model = mm
+    admin_mod.proposal_model = pm
+
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+
+    with flask_app.test_client() as test_client:
+        with flask_app.app_context():
+            with test_client.session_transaction() as sess:
+                sess["user"] = {
+                    "username": "github:testadmin",
+                    "email": "admin@example.com",
+                }
+            yield test_client, mm, pm, db
+
+    admin_mod.mapping_model = orig_mm
+    admin_mod.proposal_model = orig_pm
+
+    os.close(fd)
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def go_admin_client():
+    """
+    Test client wired with fresh GO models on a temp-file DB and an
+    authenticated admin session (github:testadmin).
+
+    Yields (test_client, go_mapping_model, go_proposal_model, db).
+    """
+    os.environ["ADMIN_USERS"] = "github:testadmin"
+
+    from app import app as flask_app
+    import src.blueprints.admin as admin_mod
+    from src.core.models import Database, GoMappingModel, GoProposalModel
+
+    fd, db_path = tempfile.mkstemp()
+    db = Database(db_path)
+    gm = GoMappingModel(db)
+    gpm = GoProposalModel(db)
+
+    orig_gm = admin_mod.go_mapping_model
+    orig_gpm = admin_mod.go_proposal_model
+
+    admin_mod.go_mapping_model = gm
+    admin_mod.go_proposal_model = gpm
+
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+
+    with flask_app.test_client() as test_client:
+        with flask_app.app_context():
+            with test_client.session_transaction() as sess:
+                sess["user"] = {
+                    "username": "github:testadmin",
+                    "email": "admin@example.com",
+                }
+            yield test_client, gm, gpm, db
+
+    admin_mod.go_mapping_model = orig_gm
+    admin_mod.go_proposal_model = orig_gpm
+
+    os.close(fd)
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def reactome_admin_client():
+    """
+    Test client wired with fresh Reactome models on a temp-file DB and an
+    authenticated admin session (github:testadmin).
+
+    Yields (test_client, reactome_mapping_model, reactome_proposal_model, db).
+    """
+    os.environ["ADMIN_USERS"] = "github:testadmin"
+
+    from app import app as flask_app
+    import src.blueprints.admin as admin_mod
+    from src.core.models import Database, ReactomeMappingModel, ReactomeProposalModel
+
+    fd, db_path = tempfile.mkstemp()
+    db = Database(db_path)
+    rm = ReactomeMappingModel(db)
+    rpm = ReactomeProposalModel(db)
+
+    orig_rm = admin_mod.reactome_mapping_model
+    orig_rpm = admin_mod.reactome_proposal_model
+
+    admin_mod.reactome_mapping_model = rm
+    admin_mod.reactome_proposal_model = rpm
+
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+
+    with flask_app.test_client() as test_client:
+        with flask_app.app_context():
+            with test_client.session_transaction() as sess:
+                sess["user"] = {
+                    "username": "github:testadmin",
+                    "email": "admin@example.com",
+                }
+            yield test_client, rm, rpm, db
+
+    admin_mod.reactome_mapping_model = orig_rm
+    admin_mod.reactome_proposal_model = orig_rpm
+
+    os.close(fd)
+    os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers (NOT parametrized — D-16)
+# ---------------------------------------------------------------------------
+
+
+def _seed_wp_proposal(
+    pm,
+    ke_id="KE 1001",
+    wp_id="WP1234",
+    wp_title="MAPK signaling pathway",
+    confidence_level="high",
+    provider_username="github:curator",
+    suggestion_score=0.75,
+):
+    """Seed a single new-pair WP proposal and return its id."""
+    proposal_id = pm.create_new_pair_proposal(
+        ke_id=ke_id,
+        ke_title=f"Title for {ke_id}",
+        wp_id=wp_id,
+        wp_title=wp_title,
+        connection_type="causative",
+        confidence_level=confidence_level,
+        provider_username=provider_username,
+        suggestion_score=suggestion_score,
+    )
+    assert proposal_id is not None
+    return proposal_id
+
+
+def _seed_go_proposal(
+    gpm,
+    ke_id="KE 2001",
+    go_id="GO:0051403",
+    go_name="stress-activated MAPK cascade",
+    confidence_level="high",
+    provider_username="github:curator",
+    suggestion_score=0.80,
+    go_namespace="biological_process",
+):
+    """Seed a single new-pair GO proposal and return its id."""
+    proposal_id = gpm.create_new_pair_go_proposal(
+        ke_id=ke_id,
+        ke_title=f"Title for {ke_id}",
+        go_id=go_id,
+        go_name=go_name,
+        connection_type="related",
+        confidence_level=confidence_level,
+        provider_username=provider_username,
+        suggestion_score=suggestion_score,
+        go_namespace=go_namespace,
+    )
+    assert proposal_id is not None
+    return proposal_id
+
+
+def _seed_reactome_proposal(
+    rpm,
+    ke_id="KE 3001",
+    reactome_id="R-HSA-1234567",
+    pathway_name="MAPK signaling",
+    confidence_level="high",
+    provider_username="github:curator",
+    suggestion_score=0.75,
+):
+    """Seed a single new-pair Reactome proposal and return its id."""
+    proposal_id = rpm.create_new_pair_reactome_proposal(
+        ke_id=ke_id,
+        ke_title=f"Title for {ke_id}",
+        reactome_id=reactome_id,
+        pathway_name=pathway_name,
+        confidence_level=confidence_level,
+        species="Homo sapiens",
+        provider_username=provider_username,
+        suggestion_score=suggestion_score,
+    )
+    assert proposal_id is not None
+    return proposal_id
+
+
+# ---------------------------------------------------------------------------
+# TestWPBulkApprove
+# ---------------------------------------------------------------------------
+
+
+class TestWPBulkApprove:
+    """Tests for POST /admin/proposals/bulk-approve (WP resource).
+
+    The bulk-approve route lands in Plan 38-02.  Route-dependent assertions
+    are skipped here; the fault-injection seam and fixture/seed infra are
+    fully exercisable in Wave 0.
+    """
+
+    def test_fault_injection_seam_wp(self, wp_admin_client):
+        """Verify the monkeypatch fault-injection seam is exercisable.
+
+        Seeds 5 WP proposals and confirms that patching _approve_on_conn to
+        raise on the 3rd call prevents any mapping from being committed —
+        proving the seam is in place for the 38-02 route test.
+
+        Route-dependent assertions (HTTP response, DB count after POST) are
+        deferred to 38-02 where the route exists.
+        """
+        client, mm, pm, db = wp_admin_client
+
+        pids = [
+            _seed_wp_proposal(pm, ke_id=f"KE 100{i}", wp_id=f"WP100{i}")
+            for i in range(1, 6)
+        ]
+
+        call_count = [0]
+        original = mm._approve_on_conn
+
+        def failing_helper(conn, proposal, *args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 3:
+                raise sqlite3.IntegrityError("forced failure on call 3")
+            return original(conn, proposal, *args, **kwargs)
+
+        mm._approve_on_conn = failing_helper
+        try:
+            conn = mm.db.get_connection()
+            approved_uuids = []
+            proposals = [pm.get_proposal_by_id(pid) for pid in pids]
+            try:
+                for proposal in proposals:
+                    uuid = mm._approve_on_conn(conn, proposal, "github:testadmin")
+                    approved_uuids.append(uuid)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+            finally:
+                conn.close()
+        finally:
+            mm._approve_on_conn = original
+
+        # Fault injection fired on call 3; entire batch rolled back
+        assert call_count[0] == 3, "expected failure on 3rd call"
+        assert len(approved_uuids) == 2, "first two succeeded before rollback"
+
+        # Verify 0 mappings in DB (rollback worked)
+        conn = db.get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM mappings WHERE ke_id IN (?, ?, ?, ?, ?)",
+                ("KE 1001", "KE 1002", "KE 1003", "KE 1004", "KE 1005"),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 0, "rollback must revert all writes including the first two"
+
+        # All proposals remain pending
+        for pid in pids:
+            p = pm.get_proposal_by_id(pid)
+            assert p["status"] == "pending"
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_bulk_approve_returns_uuids(self, wp_admin_client):
+        """POST /admin/proposals/bulk-approve returns mapping UUIDs in approved[]."""
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_preflight_not_found(self, wp_admin_client):
+        """Not-found IDs appear in failed[], valid IDs are processed."""
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_preflight_not_pending(self, wp_admin_client):
+        """Already-approved/rejected IDs appear in failed[]."""
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_audit_log_emitted(self, wp_admin_client, caplog):
+        """AUDIT bulk-approve wp log line contains approved UUIDs."""
+        pass
+
+
+# ---------------------------------------------------------------------------
+# TestGOBulkApprove
+# ---------------------------------------------------------------------------
+
+
+class TestGOBulkApprove:
+    """Tests for POST /admin/go-proposals/bulk-approve (GO resource)."""
+
+    def test_fault_injection_seam_go(self, go_admin_client):
+        """Verify the monkeypatch fault-injection seam is exercisable for GO.
+
+        Seeds 5 GO proposals and confirms that patching _approve_on_conn to
+        raise on the 3rd call rolls back all writes.
+        """
+        client, gm, gpm, db = go_admin_client
+
+        pids = [
+            _seed_go_proposal(gpm, ke_id=f"KE 200{i}", go_id=f"GO:0000{i:03d}")
+            for i in range(1, 6)
+        ]
+
+        call_count = [0]
+        original = gm._approve_on_conn
+
+        def failing_helper(conn, proposal, *args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 3:
+                raise sqlite3.IntegrityError("forced failure on call 3")
+            return original(conn, proposal, *args, **kwargs)
+
+        gm._approve_on_conn = failing_helper
+        try:
+            conn = gm.db.get_connection()
+            approved_uuids = []
+            proposals = [gpm.get_go_proposal_by_id(pid) for pid in pids]
+            try:
+                for proposal in proposals:
+                    uuid = gm._approve_on_conn(conn, proposal, "github:testadmin")
+                    approved_uuids.append(uuid)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+            finally:
+                conn.close()
+        finally:
+            gm._approve_on_conn = original
+
+        assert call_count[0] == 3
+        assert len(approved_uuids) == 2
+
+        conn = db.get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM ke_go_mappings WHERE ke_id IN (?, ?, ?, ?, ?)",
+                ("KE 2001", "KE 2002", "KE 2003", "KE 2004", "KE 2005"),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 0
+
+        for pid in pids:
+            p = gpm.get_go_proposal_by_id(pid)
+            assert p["status"] == "pending"
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_bulk_approve_returns_uuids(self, go_admin_client):
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_preflight_not_found(self, go_admin_client):
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_preflight_not_pending(self, go_admin_client):
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_audit_log_emitted(self, go_admin_client, caplog):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# TestReactomeBulkApprove
+# ---------------------------------------------------------------------------
+
+
+class TestReactomeBulkApprove:
+    """Tests for POST /admin/reactome-proposals/bulk-approve (Reactome resource)."""
+
+    def test_fault_injection_seam_reactome(self, reactome_admin_client):
+        """Verify the monkeypatch fault-injection seam is exercisable for Reactome.
+
+        Seeds 5 Reactome proposals and confirms that patching
+        _create_approved_on_conn to raise on the 3rd call rolls back all writes.
+        """
+        client, rm, rpm, db = reactome_admin_client
+
+        pids = [
+            _seed_reactome_proposal(rpm, ke_id=f"KE 300{i}", reactome_id=f"R-HSA-300{i}")
+            for i in range(1, 6)
+        ]
+
+        call_count = [0]
+        original = rm._create_approved_on_conn
+
+        def failing_helper(conn, proposal_id, *args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 3:
+                raise sqlite3.IntegrityError("forced failure on call 3")
+            return original(conn, proposal_id, *args, **kwargs)
+
+        rm._create_approved_on_conn = failing_helper
+        try:
+            conn = rm.db.get_connection()
+            approved_uuids = []
+            try:
+                for pid in pids:
+                    uuid = rm._create_approved_on_conn(conn, pid, "github:testadmin")
+                    approved_uuids.append(uuid)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+            finally:
+                conn.close()
+        finally:
+            rm._create_approved_on_conn = original
+
+        assert call_count[0] == 3
+        assert len(approved_uuids) == 2
+
+        conn = db.get_connection()
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM ke_reactome_mappings "
+                "WHERE ke_id IN (?, ?, ?, ?, ?)",
+                ("KE 3001", "KE 3002", "KE 3003", "KE 3004", "KE 3005"),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 0
+
+        for pid in pids:
+            p = rpm.get_proposal_by_id(pid)
+            assert p["status"] == "pending"
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_bulk_approve_returns_uuids(self, reactome_admin_client):
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_preflight_not_found(self, reactome_admin_client):
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_preflight_not_pending(self, reactome_admin_client):
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_audit_log_emitted(self, reactome_admin_client, caplog):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# TestBulkApproveShared
+# ---------------------------------------------------------------------------
+
+
+class TestBulkApproveShared:
+    """Shared tests that apply to all three bulk-approve resources."""
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_static_js_served(self, reactome_admin_client):
+        """GET /static/js/admin_proposals.js returns 200 (smoke)."""
+        pass
+
+    @pytest.mark.skip(reason="route lands in 38-02")
+    def test_templates_load_shared_js(self):
+        """Three admin templates contain admin_proposals.js script tag."""
+        pass

--- a/tests/test_admin_bulk_approve.py
+++ b/tests/test_admin_bulk_approve.py
@@ -1,5 +1,5 @@
 """
-Wave 0 test scaffold for Phase 38 bulk-approve backend (Plan 38-01).
+Tests for Phase 38 bulk-approve backend (Plans 38-01 and 38-02).
 
 Covers:
 - Per-resource fixtures: wp_admin_client, go_admin_client, reactome_admin_client
@@ -7,14 +7,13 @@ Covers:
 - Per-resource test classes: TestWPBulkApprove, TestGOBulkApprove, TestReactomeBulkApprove
 - TestBulkApproveShared: static/smoke tests
 
-Route-dependent test bodies are marked with pytest.mark.skip(reason="route lands in 38-02")
-so the suite stays green in Wave 0 while the fault-injection seam and fixture infra are
-exercisable now.
+Per-resource test classes are NOT parametrized (D-16 sibling-parity rule).
 """
 import logging
 import os
 import sqlite3
 import tempfile
+import uuid
 
 import pytest
 
@@ -241,22 +240,14 @@ def _seed_reactome_proposal(
 
 
 class TestWPBulkApprove:
-    """Tests for POST /admin/proposals/bulk-approve (WP resource).
+    """Tests for POST /admin/proposals/bulk-approve (WP resource)."""
 
-    The bulk-approve route lands in Plan 38-02.  Route-dependent assertions
-    are skipped here; the fault-injection seam and fixture/seed infra are
-    fully exercisable in Wave 0.
-    """
+    def test_fault_injection(self, wp_admin_client):
+        """Seed 5 pending WP proposals, force 3rd _approve_on_conn to raise IntegrityError.
 
-    def test_fault_injection_seam_wp(self, wp_admin_client):
-        """Verify the monkeypatch fault-injection seam is exercisable.
-
-        Seeds 5 WP proposals and confirms that patching _approve_on_conn to
-        raise on the 3rd call prevents any mapping from being committed —
-        proving the seam is in place for the 38-02 route test.
-
-        Route-dependent assertions (HTTP response, DB count after POST) are
-        deferred to 38-02 where the route exists.
+        All 5 proposals must remain pending after the POST (whole-batch rollback).
+        0 mapping rows must exist for the seeded ke_id/wp_id pairs.
+        response["approved"] must equal [].
         """
         client, mm, pm, db = wp_admin_client
 
@@ -276,26 +267,18 @@ class TestWPBulkApprove:
 
         mm._approve_on_conn = failing_helper
         try:
-            conn = mm.db.get_connection()
-            approved_uuids = []
-            proposals = [pm.get_proposal_by_id(pid) for pid in pids]
-            try:
-                for proposal in proposals:
-                    uuid = mm._approve_on_conn(conn, proposal, "github:testadmin")
-                    approved_uuids.append(uuid)
-                conn.commit()
-            except Exception:
-                conn.rollback()
-            finally:
-                conn.close()
+            response = client.post(
+                "/admin/proposals/bulk-approve",
+                json={"ids": pids, "admin_notes": ""},
+            )
         finally:
             mm._approve_on_conn = original
 
-        # Fault injection fired on call 3; entire batch rolled back
-        assert call_count[0] == 3, "expected failure on 3rd call"
-        assert len(approved_uuids) == 2, "first two succeeded before rollback"
+        assert response.status_code == 500
+        data = response.get_json()
+        assert data["approved"] == []
 
-        # Verify 0 mappings in DB (rollback worked)
+        # 0 mappings in DB — rollback reverted all writes
         conn = db.get_connection()
         try:
             count = conn.execute(
@@ -311,25 +294,105 @@ class TestWPBulkApprove:
             p = pm.get_proposal_by_id(pid)
             assert p["status"] == "pending"
 
-    @pytest.mark.skip(reason="route lands in 38-02")
-    def test_bulk_approve_returns_uuids(self, wp_admin_client):
-        """POST /admin/proposals/bulk-approve returns mapping UUIDs in approved[]."""
-        pass
-
-    @pytest.mark.skip(reason="route lands in 38-02")
     def test_preflight_not_found(self, wp_admin_client):
-        """Not-found IDs appear in failed[], valid IDs are processed."""
-        pass
+        """Not-found ID appears in failed[] with reason 'not found'; valid ID is approved."""
+        client, mm, pm, db = wp_admin_client
 
-    @pytest.mark.skip(reason="route lands in 38-02")
+        pid = _seed_wp_proposal(pm, ke_id="KE 1010", wp_id="WP1010")
+        nonexistent_id = 99999
+
+        response = client.post(
+            "/admin/proposals/bulk-approve",
+            json={"ids": [nonexistent_id, pid], "admin_notes": ""},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        # The nonexistent id is in failed[]
+        failed_ids = [f["id"] for f in data["failed"]]
+        assert nonexistent_id in failed_ids
+        not_found_entry = next(f for f in data["failed"] if f["id"] == nonexistent_id)
+        assert not_found_entry["reason"] == "not found"
+
+        # The valid id is approved
+        assert len(data["approved"]) == 1
+
     def test_preflight_not_pending(self, wp_admin_client):
-        """Already-approved/rejected IDs appear in failed[]."""
-        pass
+        """Already-approved ID appears in failed[] with reason containing the status."""
+        client, mm, pm, db = wp_admin_client
 
-    @pytest.mark.skip(reason="route lands in 38-02")
+        # Approve the first proposal via the single-approve route to set its status
+        pid1 = _seed_wp_proposal(pm, ke_id="KE 1020", wp_id="WP1020")
+        pid2 = _seed_wp_proposal(pm, ke_id="KE 1021", wp_id="WP1021")
+
+        # Approve pid1 first via bulk (single item)
+        r1 = client.post(
+            "/admin/proposals/bulk-approve",
+            json={"ids": [pid1], "admin_notes": ""},
+        )
+        assert r1.status_code == 200
+        assert len(r1.get_json()["approved"]) == 1
+
+        # Now try to bulk-approve both — pid1 is no longer pending
+        response = client.post(
+            "/admin/proposals/bulk-approve",
+            json={"ids": [pid1, pid2], "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+
+        failed_ids = [f["id"] for f in data["failed"]]
+        assert pid1 in failed_ids
+        not_pending_entry = next(f for f in data["failed"] if f["id"] == pid1)
+        assert "already" in not_pending_entry["reason"]
+
+        # pid2 was still pending and should now be approved
+        assert len(data["approved"]) == 1
+
+    def test_returns_mapping_uuids(self, wp_admin_client):
+        """approved[] entries are UUID-shaped strings, not integer proposal IDs."""
+        client, mm, pm, db = wp_admin_client
+
+        pids = [
+            _seed_wp_proposal(pm, ke_id=f"KE 103{i}", wp_id=f"WP103{i}")
+            for i in range(1, 4)
+        ]
+
+        response = client.post(
+            "/admin/proposals/bulk-approve",
+            json={"ids": pids, "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert len(data["approved"]) == 3
+        for entry in data["approved"]:
+            # Must be a string, not an integer
+            assert isinstance(entry, str)
+            # Must parse as a valid UUID (UUID-shaped: 8-4-4-4-12 hex)
+            parsed = uuid.UUID(entry)
+            assert str(parsed) == entry.lower()
+
     def test_audit_log_emitted(self, wp_admin_client, caplog):
-        """AUDIT bulk-approve wp log line contains approved UUIDs."""
-        pass
+        """AUDIT bulk-approve wp log line is emitted and contains the approved UUID."""
+        client, mm, pm, db = wp_admin_client
+
+        pid = _seed_wp_proposal(pm, ke_id="KE 1040", wp_id="WP1040")
+
+        with caplog.at_level(logging.INFO, logger="src.blueprints.admin"):
+            response = client.post(
+                "/admin/proposals/bulk-approve",
+                json={"ids": [pid], "admin_notes": ""},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["approved"]) == 1
+
+        assert "AUDIT bulk-approve wp" in caplog.text
+        approved_uuid = data["approved"][0]
+        assert approved_uuid in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -340,11 +403,12 @@ class TestWPBulkApprove:
 class TestGOBulkApprove:
     """Tests for POST /admin/go-proposals/bulk-approve (GO resource)."""
 
-    def test_fault_injection_seam_go(self, go_admin_client):
-        """Verify the monkeypatch fault-injection seam is exercisable for GO.
+    def test_fault_injection(self, go_admin_client):
+        """Seed 5 pending GO proposals, force 3rd _approve_on_conn to raise IntegrityError.
 
-        Seeds 5 GO proposals and confirms that patching _approve_on_conn to
-        raise on the 3rd call rolls back all writes.
+        All 5 proposals must remain pending after the POST (whole-batch rollback).
+        0 mapping rows must exist for the seeded ke_id/go_id pairs.
+        response["approved"] must equal [].
         """
         client, gm, gpm, db = go_admin_client
 
@@ -364,24 +428,18 @@ class TestGOBulkApprove:
 
         gm._approve_on_conn = failing_helper
         try:
-            conn = gm.db.get_connection()
-            approved_uuids = []
-            proposals = [gpm.get_go_proposal_by_id(pid) for pid in pids]
-            try:
-                for proposal in proposals:
-                    uuid = gm._approve_on_conn(conn, proposal, "github:testadmin")
-                    approved_uuids.append(uuid)
-                conn.commit()
-            except Exception:
-                conn.rollback()
-            finally:
-                conn.close()
+            response = client.post(
+                "/admin/go-proposals/bulk-approve",
+                json={"ids": pids, "admin_notes": ""},
+            )
         finally:
             gm._approve_on_conn = original
 
-        assert call_count[0] == 3
-        assert len(approved_uuids) == 2
+        assert response.status_code == 500
+        data = response.get_json()
+        assert data["approved"] == []
 
+        # 0 mappings in DB — rollback reverted all writes
         conn = db.get_connection()
         try:
             count = conn.execute(
@@ -392,25 +450,104 @@ class TestGOBulkApprove:
             conn.close()
         assert count == 0
 
+        # All proposals remain pending
         for pid in pids:
             p = gpm.get_go_proposal_by_id(pid)
             assert p["status"] == "pending"
 
-    @pytest.mark.skip(reason="route lands in 38-02")
-    def test_bulk_approve_returns_uuids(self, go_admin_client):
-        pass
-
-    @pytest.mark.skip(reason="route lands in 38-02")
     def test_preflight_not_found(self, go_admin_client):
-        pass
+        """Not-found ID appears in failed[] with reason 'not found'; valid ID is approved."""
+        client, gm, gpm, db = go_admin_client
 
-    @pytest.mark.skip(reason="route lands in 38-02")
+        pid = _seed_go_proposal(gpm, ke_id="KE 2010", go_id="GO:0010010")
+        nonexistent_id = 99998
+
+        response = client.post(
+            "/admin/go-proposals/bulk-approve",
+            json={"ids": [nonexistent_id, pid], "admin_notes": ""},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        failed_ids = [f["id"] for f in data["failed"]]
+        assert nonexistent_id in failed_ids
+        not_found_entry = next(f for f in data["failed"] if f["id"] == nonexistent_id)
+        assert not_found_entry["reason"] == "not found"
+
+        assert len(data["approved"]) == 1
+
     def test_preflight_not_pending(self, go_admin_client):
-        pass
+        """Already-approved ID appears in failed[] with reason containing the status."""
+        client, gm, gpm, db = go_admin_client
 
-    @pytest.mark.skip(reason="route lands in 38-02")
+        pid1 = _seed_go_proposal(gpm, ke_id="KE 2020", go_id="GO:0020020")
+        pid2 = _seed_go_proposal(gpm, ke_id="KE 2021", go_id="GO:0020021")
+
+        # Approve pid1 first
+        r1 = client.post(
+            "/admin/go-proposals/bulk-approve",
+            json={"ids": [pid1], "admin_notes": ""},
+        )
+        assert r1.status_code == 200
+        assert len(r1.get_json()["approved"]) == 1
+
+        # Now try both — pid1 is no longer pending
+        response = client.post(
+            "/admin/go-proposals/bulk-approve",
+            json={"ids": [pid1, pid2], "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+
+        failed_ids = [f["id"] for f in data["failed"]]
+        assert pid1 in failed_ids
+        not_pending_entry = next(f for f in data["failed"] if f["id"] == pid1)
+        assert "already" in not_pending_entry["reason"]
+
+        assert len(data["approved"]) == 1
+
+    def test_returns_mapping_uuids(self, go_admin_client):
+        """approved[] entries are UUID-shaped strings, not integer proposal IDs."""
+        client, gm, gpm, db = go_admin_client
+
+        pids = [
+            _seed_go_proposal(gpm, ke_id=f"KE 203{i}", go_id=f"GO:0030{i:03d}")
+            for i in range(1, 4)
+        ]
+
+        response = client.post(
+            "/admin/go-proposals/bulk-approve",
+            json={"ids": pids, "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert len(data["approved"]) == 3
+        for entry in data["approved"]:
+            assert isinstance(entry, str)
+            parsed = uuid.UUID(entry)
+            assert str(parsed) == entry.lower()
+
     def test_audit_log_emitted(self, go_admin_client, caplog):
-        pass
+        """AUDIT bulk-approve go log line is emitted and contains the approved UUID."""
+        client, gm, gpm, db = go_admin_client
+
+        pid = _seed_go_proposal(gpm, ke_id="KE 2040", go_id="GO:0040040")
+
+        with caplog.at_level(logging.INFO, logger="src.blueprints.admin"):
+            response = client.post(
+                "/admin/go-proposals/bulk-approve",
+                json={"ids": [pid], "admin_notes": ""},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["approved"]) == 1
+
+        assert "AUDIT bulk-approve go" in caplog.text
+        approved_uuid = data["approved"][0]
+        assert approved_uuid in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -421,11 +558,12 @@ class TestGOBulkApprove:
 class TestReactomeBulkApprove:
     """Tests for POST /admin/reactome-proposals/bulk-approve (Reactome resource)."""
 
-    def test_fault_injection_seam_reactome(self, reactome_admin_client):
-        """Verify the monkeypatch fault-injection seam is exercisable for Reactome.
+    def test_fault_injection(self, reactome_admin_client):
+        """Seed 5 pending Reactome proposals, force 3rd _create_approved_on_conn to raise.
 
-        Seeds 5 Reactome proposals and confirms that patching
-        _create_approved_on_conn to raise on the 3rd call rolls back all writes.
+        All 5 proposals must remain pending after the POST (whole-batch rollback).
+        0 mapping rows must exist for the seeded ke_id/reactome_id pairs.
+        response["approved"] must equal [].
         """
         client, rm, rpm, db = reactome_admin_client
 
@@ -445,23 +583,18 @@ class TestReactomeBulkApprove:
 
         rm._create_approved_on_conn = failing_helper
         try:
-            conn = rm.db.get_connection()
-            approved_uuids = []
-            try:
-                for pid in pids:
-                    uuid = rm._create_approved_on_conn(conn, pid, "github:testadmin")
-                    approved_uuids.append(uuid)
-                conn.commit()
-            except Exception:
-                conn.rollback()
-            finally:
-                conn.close()
+            response = client.post(
+                "/admin/reactome-proposals/bulk-approve",
+                json={"ids": pids, "admin_notes": ""},
+            )
         finally:
             rm._create_approved_on_conn = original
 
-        assert call_count[0] == 3
-        assert len(approved_uuids) == 2
+        assert response.status_code == 500
+        data = response.get_json()
+        assert data["approved"] == []
 
+        # 0 mappings in DB — rollback reverted all writes
         conn = db.get_connection()
         try:
             count = conn.execute(
@@ -473,25 +606,106 @@ class TestReactomeBulkApprove:
             conn.close()
         assert count == 0
 
+        # All proposals remain pending
         for pid in pids:
             p = rpm.get_proposal_by_id(pid)
             assert p["status"] == "pending"
 
-    @pytest.mark.skip(reason="route lands in 38-02")
-    def test_bulk_approve_returns_uuids(self, reactome_admin_client):
-        pass
-
-    @pytest.mark.skip(reason="route lands in 38-02")
     def test_preflight_not_found(self, reactome_admin_client):
-        pass
+        """Not-found ID appears in failed[] with reason 'not found'; valid ID is approved."""
+        client, rm, rpm, db = reactome_admin_client
 
-    @pytest.mark.skip(reason="route lands in 38-02")
+        pid = _seed_reactome_proposal(rpm, ke_id="KE 3010", reactome_id="R-HSA-30100")
+        nonexistent_id = 99997
+
+        response = client.post(
+            "/admin/reactome-proposals/bulk-approve",
+            json={"ids": [nonexistent_id, pid], "admin_notes": ""},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        failed_ids = [f["id"] for f in data["failed"]]
+        assert nonexistent_id in failed_ids
+        not_found_entry = next(f for f in data["failed"] if f["id"] == nonexistent_id)
+        assert not_found_entry["reason"] == "not found"
+
+        assert len(data["approved"]) == 1
+
     def test_preflight_not_pending(self, reactome_admin_client):
-        pass
+        """Already-approved ID appears in failed[] with reason containing the status."""
+        client, rm, rpm, db = reactome_admin_client
 
-    @pytest.mark.skip(reason="route lands in 38-02")
+        pid1 = _seed_reactome_proposal(rpm, ke_id="KE 3020", reactome_id="R-HSA-30200")
+        pid2 = _seed_reactome_proposal(rpm, ke_id="KE 3021", reactome_id="R-HSA-30210")
+
+        # Approve pid1 first
+        r1 = client.post(
+            "/admin/reactome-proposals/bulk-approve",
+            json={"ids": [pid1], "admin_notes": ""},
+        )
+        assert r1.status_code == 200
+        assert len(r1.get_json()["approved"]) == 1
+
+        # Now try both — pid1 is no longer pending
+        response = client.post(
+            "/admin/reactome-proposals/bulk-approve",
+            json={"ids": [pid1, pid2], "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+
+        failed_ids = [f["id"] for f in data["failed"]]
+        assert pid1 in failed_ids
+        not_pending_entry = next(f for f in data["failed"] if f["id"] == pid1)
+        assert "already" in not_pending_entry["reason"]
+
+        assert len(data["approved"]) == 1
+
+    def test_returns_mapping_uuids(self, reactome_admin_client):
+        """approved[] entries are UUID-shaped strings, not integer proposal IDs."""
+        client, rm, rpm, db = reactome_admin_client
+
+        pids = [
+            _seed_reactome_proposal(
+                rpm, ke_id=f"KE 303{i}", reactome_id=f"R-HSA-3030{i}"
+            )
+            for i in range(1, 4)
+        ]
+
+        response = client.post(
+            "/admin/reactome-proposals/bulk-approve",
+            json={"ids": pids, "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert len(data["approved"]) == 3
+        for entry in data["approved"]:
+            assert isinstance(entry, str)
+            parsed = uuid.UUID(entry)
+            assert str(parsed) == entry.lower()
+
     def test_audit_log_emitted(self, reactome_admin_client, caplog):
-        pass
+        """AUDIT bulk-approve reactome log line is emitted and contains the approved UUID."""
+        client, rm, rpm, db = reactome_admin_client
+
+        pid = _seed_reactome_proposal(rpm, ke_id="KE 3040", reactome_id="R-HSA-30400")
+
+        with caplog.at_level(logging.INFO, logger="src.blueprints.admin"):
+            response = client.post(
+                "/admin/reactome-proposals/bulk-approve",
+                json={"ids": [pid], "admin_notes": ""},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["approved"]) == 1
+
+        assert "AUDIT bulk-approve reactome" in caplog.text
+        approved_uuid = data["approved"][0]
+        assert approved_uuid in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -502,12 +716,35 @@ class TestReactomeBulkApprove:
 class TestBulkApproveShared:
     """Shared tests that apply to all three bulk-approve resources."""
 
-    @pytest.mark.skip(reason="route lands in 38-02")
-    def test_static_js_served(self, reactome_admin_client):
-        """GET /static/js/admin_proposals.js returns 200 (smoke)."""
-        pass
+    def test_invalid_id_type_rejected(self, reactome_admin_client):
+        """Non-integer IDs (strings) land in failed[] with reason 'invalid id'."""
+        client, rm, rpm, db = reactome_admin_client
 
-    @pytest.mark.skip(reason="route lands in 38-02")
-    def test_templates_load_shared_js(self):
-        """Three admin templates contain admin_proposals.js script tag."""
-        pass
+        pid = _seed_reactome_proposal(rpm, ke_id="KE 3050", reactome_id="R-HSA-30500")
+
+        response = client.post(
+            "/admin/reactome-proposals/bulk-approve",
+            json={"ids": ["not-an-int", pid], "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+
+        failed_reasons = {f["id"]: f["reason"] for f in data["failed"]}
+        assert "not-an-int" in failed_reasons
+        assert failed_reasons["not-an-int"] == "invalid id"
+
+        # valid integer pid still approved
+        assert len(data["approved"]) == 1
+
+    def test_empty_ids_returns_empty_approved(self, reactome_admin_client):
+        """Empty ids list returns {"approved": [], "failed": []} with 200."""
+        client, rm, rpm, db = reactome_admin_client
+
+        response = client.post(
+            "/admin/reactome-proposals/bulk-approve",
+            json={"ids": [], "admin_notes": ""},
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["approved"] == []
+        assert data["failed"] == []

--- a/tests/test_admin_proposals_js.py
+++ b/tests/test_admin_proposals_js.py
@@ -1,0 +1,196 @@
+"""
+Tests for Phase 38-03: shared admin_proposals.js IIFE and template integration.
+
+Covers:
+- test_static_js_served: GET /static/js/admin_proposals.js returns 200 and
+  body contains 'AdminProposals'
+- test_templates_load_shared_js: static-file grep asserting all three templates
+  contain the <script src=...admin_proposals.js> tag and AdminProposals.init,
+  and that none retain inline 'function escapeHtml'
+"""
+import os
+import tempfile
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixture: basic app test client (uses reactome fixture pattern from
+# test_admin_bulk_approve.py — ADMIN_USERS set so /static/* is accessible)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_client():
+    """Minimal Flask test client without model injection, just for serving statics."""
+    os.environ["ADMIN_USERS"] = "github:testadmin"
+
+    from app import app as flask_app
+
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+
+    with flask_app.test_client() as client:
+        with flask_app.app_context():
+            yield client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdminProposalsJs:
+    def test_static_js_served(self, app_client):
+        """GET /static/js/admin_proposals.js returns 200 and contains the IIFE."""
+        response = app_client.get("/static/js/admin_proposals.js")
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}"
+        )
+        body = response.data.decode("utf-8")
+        assert "AdminProposals" in body, "Response body missing 'AdminProposals'"
+        assert "var AdminProposals = (function" in body, (
+            "Response body missing IIFE var declaration"
+        )
+
+    def test_templates_load_shared_js(self):
+        """All three admin templates load the shared IIFE and dropped inline handlers."""
+        templates = [
+            "admin_proposals",
+            "admin_go_proposals",
+            "admin_reactome_proposals",
+        ]
+        # Locate templates directory relative to this test file
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        templates_dir = os.path.join(project_root, "templates")
+
+        for tpl_name in templates:
+            path = os.path.join(templates_dir, f"{tpl_name}.html")
+            assert os.path.exists(path), f"Template not found: {path}"
+            content = open(path, encoding="utf-8").read()
+
+            # Each template must load the shared JS via <script src>
+            assert "js/admin_proposals.js" in content, (
+                f"{tpl_name}: missing <script src=.../admin_proposals.js>"
+            )
+
+            # Each template must call AdminProposals.init(
+            assert "AdminProposals.init" in content, (
+                f"{tpl_name}: missing AdminProposals.init call"
+            )
+
+            # No inline function escapeHtml (moved to the IIFE)
+            assert "function escapeHtml" not in content, (
+                f"{tpl_name}: inline 'function escapeHtml' not removed"
+            )
+
+            # No inline stepLabels definition (moved to the IIFE)
+            # Only check for the inline const/let/var stepLabels pattern
+            import re
+            inline_steplabels = re.search(
+                r'\b(const|let|var)\s+stepLabels\s*=', content
+            )
+            assert inline_steplabels is None, (
+                f"{tpl_name}: inline stepLabels definition not removed"
+            )
+
+    def test_templates_have_selectall(self):
+        """All three templates contain id='selectAll' for the header checkbox."""
+        templates = [
+            "admin_proposals",
+            "admin_go_proposals",
+            "admin_reactome_proposals",
+        ]
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        templates_dir = os.path.join(project_root, "templates")
+
+        for tpl_name in templates:
+            path = os.path.join(templates_dir, f"{tpl_name}.html")
+            content = open(path, encoding="utf-8").read()
+            assert 'id="selectAll"' in content, (
+                f"{tpl_name}: missing id='selectAll' header checkbox"
+            )
+
+    def test_templates_have_review_panel(self):
+        """All three templates contain the docked side panel div."""
+        templates = [
+            "admin_proposals",
+            "admin_go_proposals",
+            "admin_reactome_proposals",
+        ]
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        templates_dir = os.path.join(project_root, "templates")
+
+        for tpl_name in templates:
+            path = os.path.join(templates_dir, f"{tpl_name}.html")
+            content = open(path, encoding="utf-8").read()
+            assert 'id="reviewPanel"' in content, (
+                f"{tpl_name}: missing id='reviewPanel' side panel"
+            )
+            assert 'id="reviewPanelContent"' in content, (
+                f"{tpl_name}: missing id='reviewPanelContent'"
+            )
+
+    def test_templates_have_cheatsheet_modal(self):
+        """All three templates contain the cheat-sheet modal."""
+        templates = [
+            "admin_proposals",
+            "admin_go_proposals",
+            "admin_reactome_proposals",
+        ]
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        templates_dir = os.path.join(project_root, "templates")
+
+        for tpl_name in templates:
+            path = os.path.join(templates_dir, f"{tpl_name}.html")
+            content = open(path, encoding="utf-8").read()
+            assert "cheatSheetModal" in content, (
+                f"{tpl_name}: missing cheatSheetModal"
+            )
+            assert "cheatSheetOverlay" in content, (
+                f"{tpl_name}: missing cheatSheetOverlay"
+            )
+
+    def test_old_modal_removed(self):
+        """Old per-proposal details modals are removed from all three templates."""
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        templates_dir = os.path.join(project_root, "templates")
+
+        for tpl_name in [
+            "admin_proposals",
+            "admin_go_proposals",
+            "admin_reactome_proposals",
+        ]:
+            path = os.path.join(templates_dir, f"{tpl_name}.html")
+            content = open(path, encoding="utf-8").read()
+            # Old modal IDs should be gone
+            for old_id in [
+                '"proposalModal"',
+                '"goProposalModal"',
+                '"reactomeProposalModal"',
+            ]:
+                assert old_id not in content, (
+                    f"{tpl_name}: old modal id {old_id} still present"
+                )
+
+    def test_templates_have_grid_layout(self):
+        """All three templates contain the two-column CSS grid layout."""
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        templates_dir = os.path.join(project_root, "templates")
+
+        for tpl_name in [
+            "admin_proposals",
+            "admin_go_proposals",
+            "admin_reactome_proposals",
+        ]:
+            path = os.path.join(templates_dir, f"{tpl_name}.html")
+            content = open(path, encoding="utf-8").read()
+            assert "grid-template-columns" in content, (
+                f"{tpl_name}: missing grid-template-columns two-column layout"
+            )

--- a/tests/test_csrf_session_expiry.py
+++ b/tests/test_csrf_session_expiry.py
@@ -1,0 +1,74 @@
+"""
+Tests for the CSRF error handler's session-expiry disambiguation (#195).
+
+A session-bound CSRF token becomes invalid the instant the login session expires,
+so a CSRF failure with no logged-in user is really an expired session. The handler
+must surface that as HTTP 401 {"error": "session_expired"} for AJAX requests, so the
+mapper client can prompt re-login instead of showing a generic failure — while a
+genuine CSRF mismatch on a live session still returns 400.
+"""
+import os
+import tempfile
+
+import pytest
+
+from app import app
+from src.core.models import Database
+
+
+@pytest.fixture
+def csrf_client():
+    """Test client with CSRF protection ENABLED (opposite of the default fixture)."""
+    db_fd, db_path = tempfile.mkstemp()
+    os.environ["DATABASE_PATH"] = db_path
+    app.config["TESTING"] = True
+    app.config["DATABASE_PATH"] = db_path
+    app.config["WTF_CSRF_ENABLED"] = True  # <-- enable for these tests
+    try:
+        with app.test_client() as client:
+            with app.app_context():
+                Database(db_path).init_db()
+                yield client
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = False  # restore shared app state
+        os.close(db_fd)
+        os.unlink(db_path)
+
+
+AJAX = {"X-Requested-With": "XMLHttpRequest"}
+
+
+def test_csrf_failure_without_session_is_session_expired_401(csrf_client):
+    """No session user + missing CSRF token => 401 session_expired (AJAX)."""
+    resp = csrf_client.post(
+        "/submit_reactome_mapping",
+        data={"ke_id": "123", "reactome_id": "R-HSA-109581"},
+        headers=AJAX,
+    )
+    assert resp.status_code == 401
+    assert resp.get_json() == {"error": "session_expired"}
+
+
+def test_csrf_failure_with_live_session_is_plain_csrf_400(csrf_client):
+    """Logged-in user + missing CSRF token => genuine CSRF mismatch, 400 (AJAX)."""
+    with csrf_client.session_transaction() as sess:
+        sess["user"] = {"username": "testuser", "email": "test@example.com"}
+    resp = csrf_client.post(
+        "/submit_reactome_mapping",
+        data={"ke_id": "123", "reactome_id": "R-HSA-109581"},
+        headers=AJAX,
+    )
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "CSRF token missing or invalid"}
+
+
+def test_csrf_failure_non_ajax_renders_html_not_json(csrf_client):
+    """A non-AJAX (full-page) form post still gets an HTML error page, not JSON."""
+    resp = csrf_client.post(
+        "/submit_reactome_mapping",
+        data={"ke_id": "123", "reactome_id": "R-HSA-109581"},
+    )
+    # session-expired branch => 401, HTML (no JSON body)
+    assert resp.status_code == 401
+    assert resp.get_json(silent=True) is None
+    assert b"session has expired" in resp.data.lower()

--- a/tests/test_go_directionality_corpus.py
+++ b/tests/test_go_directionality_corpus.py
@@ -1,0 +1,123 @@
+"""
+Tests for the KE->GO term-picking fixes (#193):
+
+1. is_directional_go_label — the runtime guard flags signed GO labels but keeps
+   neutral "regulation of X", bare "X activation", and MF "... activity" terms.
+2. GoSuggestionService._search_metadata — exact-label matches rank first and
+   signed/directional terms are dropped from search results.
+3. precompute_go_hierarchy — the corpus-build helper + generic whitelist are
+   self-consistent (whitelist is non-directional, valid GO IDs).
+"""
+import re
+
+import pytest
+
+from src.utils.text import is_directional_go_label
+from src.suggestions.go import GoSuggestionService
+
+
+# ---------------------------------------------------------------------------
+# 1. Directional-label guard
+# ---------------------------------------------------------------------------
+
+DIRECTIONAL = [
+    "positive regulation of apoptotic process",
+    "negative regulation of cell growth",
+    "activation of protein kinase activity",
+    "inhibition of MAPK cascade",
+    "induction of apoptosis",
+    "positive regulation of gene expression via chromosomal CpG island demethylation",
+    "up-regulation of transcription",
+    "downregulation of signaling",
+]
+
+NEUTRAL = [
+    "cell death",
+    "apoptotic process",
+    "inflammatory response",
+    "regulation of apoptotic process",   # neutral "regulation of X" — kept
+    "T cell activation",                 # bare "X activation" — kept
+    "complement activation",
+    "oxidoreductase activity",           # MF "... activity" — kept
+    "response to oxidative stress",
+    "reactive oxygen species metabolic process",
+]
+
+
+@pytest.mark.parametrize("name", DIRECTIONAL)
+def test_directional_labels_flagged(name):
+    assert is_directional_go_label(name) is True
+
+
+@pytest.mark.parametrize("name", NEUTRAL)
+def test_neutral_labels_not_flagged(name):
+    assert is_directional_go_label(name) is False
+
+
+def test_empty_label_not_flagged():
+    assert is_directional_go_label("") is False
+    assert is_directional_go_label(None) is False
+
+
+# ---------------------------------------------------------------------------
+# 2. GO search exact-match ordering + directional exclusion
+# ---------------------------------------------------------------------------
+
+def _bare_service():
+    """A GoSuggestionService without running __init__ (no corpus files loaded)."""
+    return object.__new__(GoSuggestionService)
+
+
+def test_search_exact_label_ranks_first_over_fuzzy_near_miss():
+    svc = _bare_service()
+    metadata = {
+        "GO:0008219": {"name": "cell death", "definition": "the process by which a cell ceases to function"},
+        "GO:0016049": {"name": "cell growth", "definition": "increase in cell size"},
+        "GO:0012501": {"name": "programmed cell death", "definition": "a form of cell death"},
+    }
+    query_clean = svc._clean_text("cell death")
+    results = svc._search_metadata(metadata, query_clean, 0.2, "BP")
+    assert results, "expected matches"
+    results.sort(key=lambda x: x["relevance_score"], reverse=True)
+    # Exact label "cell death" must be first, above "cell growth".
+    assert results[0]["go_id"] == "GO:0008219"
+    names = [r["go_name"] for r in results]
+    assert names.index("cell death") < names.index("cell growth")
+
+
+def test_search_drops_directional_terms():
+    svc = _bare_service()
+    metadata = {
+        "GO:0006915": {"name": "apoptotic process", "definition": "programmed cell death"},
+        "GO:0043065": {"name": "positive regulation of apoptotic process", "definition": "..."},
+    }
+    query_clean = svc._clean_text("apoptotic process")
+    results = svc._search_metadata(metadata, query_clean, 0.2, "BP")
+    ids = {r["go_id"] for r in results}
+    assert "GO:0006915" in ids
+    assert "GO:0043065" not in ids, "signed term must be excluded from search"
+
+
+# ---------------------------------------------------------------------------
+# 3. Corpus-build filter + whitelist self-consistency
+# ---------------------------------------------------------------------------
+
+def test_corpus_build_whitelist_is_neutral_and_wellformed():
+    from scripts import precompute_go_hierarchy as pgh
+
+    assert pgh.GENERIC_BP_WHITELIST, "whitelist should be non-empty"
+    go_id_re = re.compile(r"^GO:\d{7}$")
+    for go_id, label in pgh.GENERIC_BP_WHITELIST.items():
+        assert go_id_re.match(go_id), f"malformed GO id: {go_id}"
+        # A whitelisted generic term must itself be neutral.
+        assert not pgh.is_directional_label(label), f"whitelisted term is directional: {label}"
+
+
+def test_corpus_build_directional_helper_matches_runtime():
+    """The build-time and runtime directional filters must agree (kept in sync)."""
+    from scripts import precompute_go_hierarchy as pgh
+
+    for name in DIRECTIONAL:
+        assert pgh.is_directional_label(name) is True
+    for name in NEUTRAL:
+        assert pgh.is_directional_label(name) is False

--- a/tests/test_go_suggestion_title_ranking.py
+++ b/tests/test_go_suggestion_title_ranking.py
@@ -1,0 +1,97 @@
+"""
+Tests for GO suggestion title-match / proxy weighting (#193).
+
+For a generic KE, the generic process term should be surfaced, not evicted by a
+specific descendant or a "regulation of X" proxy. These tests exercise the pure
+ranking helpers with synthetic data (no BioBERT), so they are fast/deterministic:
+
+- _title_match_kind: exact / near / None classification.
+- _apply_title_and_proxy_weighting: exact-title term floats to #1 over a
+  higher-scoring child; "regulation of X" proxy is demoted; "response to X" is not.
+- _filter_redundant_ancestors: a near-title-match ancestor is not pruned by a
+  higher-scoring descendant.
+"""
+import types
+
+from src.suggestions.go import GoSuggestionService
+
+
+def svc():
+    return object.__new__(GoSuggestionService)
+
+
+# --- _title_match_kind ------------------------------------------------------
+
+def test_title_match_kind():
+    s = svc()
+    assert s._title_match_kind("cell death", "cell death") == "exact"
+    assert s._title_match_kind("dna damage", "dna damage response") == "near"
+    assert s._title_match_kind("apoptotic process", "regulation of apoptotic process") == "near"
+    assert s._title_match_kind("cell death", "cell growth") is None
+    assert s._title_match_kind("", "cell death") is None
+
+
+# --- _apply_title_and_proxy_weighting --------------------------------------
+
+def test_exact_title_beats_higher_scoring_child():
+    s = svc()
+    sugg = [
+        {"go_id": "GO:child", "go_name": "lymphocyte apoptotic process", "hybrid_score": 0.95},
+        {"go_id": "GO:0006915", "go_name": "apoptotic process", "hybrid_score": 0.88},
+    ]
+    out = s._apply_title_and_proxy_weighting(sugg, "Increase, apoptotic process")
+    assert out[0]["go_id"] == "GO:0006915", "exact-title generic term should rank first"
+    assert out[0].get("title_match") == "exact"
+
+
+def test_regulation_proxy_is_demoted_but_response_is_not():
+    s = svc()
+    sugg = [
+        {"go_id": "GO:reg", "go_name": "regulation of apoptotic process", "hybrid_score": 0.90},
+        {"go_id": "GO:resp", "go_name": "response to oxidative stress", "hybrid_score": 0.90},
+    ]
+    s._apply_title_and_proxy_weighting(list(sugg), "apoptotic process")
+    reg = next(x for x in sugg if x["go_id"] == "GO:reg")
+    resp = next(x for x in sugg if x["go_id"] == "GO:resp")
+    # regulation-of proxy penalised; response-to left alone (canonical for stress KEs)
+    assert reg["hybrid_score"] < 0.90
+    assert resp["hybrid_score"] == 0.90
+
+
+# --- _filter_redundant_ancestors near-match protection ----------------------
+
+def test_near_title_ancestor_not_pruned():
+    s = svc()
+    ns = types.SimpleNamespace(
+        config=None,
+        hierarchy={
+            # child GO:0034599 has ancestor GO:0006979 (the generic term)
+            "GO:0034599": {"ancestors": {"GO:0006979"}},
+            "GO:0006979": {"ancestors": set()},
+        },
+    )
+    sugg = [
+        {"go_id": "GO:0034599", "go_name": "cellular response to oxidative stress", "hybrid_score": 0.96},
+        {"go_id": "GO:0006979", "go_name": "response to oxidative stress", "hybrid_score": 0.90},
+    ]
+    out = s._filter_redundant_ancestors(sugg, ns, ke_title="Increase, Oxidative stress")
+    ids = {x["go_id"] for x in out}
+    assert "GO:0006979" in ids, "near-title-match ancestor must survive redundancy pruning"
+
+
+def test_unprotected_ancestor_still_pruned():
+    s = svc()
+    ns = types.SimpleNamespace(
+        config=None,
+        hierarchy={
+            "GO:child": {"ancestors": {"GO:anc"}},
+            "GO:anc": {"ancestors": set()},
+        },
+    )
+    sugg = [
+        {"go_id": "GO:child", "go_name": "some very specific process", "hybrid_score": 0.90},
+        {"go_id": "GO:anc", "go_name": "unrelated broad process", "hybrid_score": 0.85},
+    ]
+    out = s._filter_redundant_ancestors(sugg, ns, ke_title="something else entirely")
+    ids = {x["go_id"] for x in out}
+    assert "GO:anc" not in ids, "a non-title-matching ancestor should still be pruned"

--- a/tests/test_mapper_js_fixes.py
+++ b/tests/test_mapper_js_fixes.py
@@ -1,0 +1,47 @@
+"""
+Static-JS smoke tests for the Phase-1 mapper fixes (#194, #195).
+
+These are grep-style assertions against static/js/main.js — they don't execute the
+JS, but they pin the presence of the fix so a future refactor can't silently drop it.
+
+- #194: a Reactome success-modal populator exists and is called from the submit
+  .done() handler (so the Thank-You modal is no longer stale/blank).
+- #195: all three submit handlers key off the backend "session_expired" signal to
+  show a session-expiry message rather than the generic failure text.
+"""
+import os
+
+HERE = os.path.dirname(__file__)
+MAIN_JS = os.path.join(HERE, "..", "static", "js", "main.js")
+
+
+def _read_main_js():
+    with open(MAIN_JS, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_reactome_success_modal_populator_exists_and_is_called():
+    """#194: showReactomeSuccessMessage is defined and invoked before reset."""
+    body = _read_main_js()
+    assert "showReactomeSuccessMessage(payload)" in body, (
+        "showReactomeSuccessMessage(payload) definition missing"
+    )
+    # It must populate the shared summary element and show the modal.
+    assert body.count("#submissionSummary") >= 3, (
+        "Reactome success path should populate #submissionSummary like WP/GO"
+    )
+    # It must be wired into the submit .done() handler.
+    assert "this.showReactomeSuccessMessage(payload)" in body, (
+        "Reactome submit .done() handler does not call showReactomeSuccessMessage"
+    )
+
+
+def test_all_submit_handlers_detect_session_expired():
+    """#195: WP, GO, and Reactome handlers all branch on the session_expired code."""
+    body = _read_main_js()
+    assert body.count("session_expired") >= 3, (
+        "Expected all three submit handlers to detect the 'session_expired' code"
+    )
+    assert "Your session has expired" in body, (
+        "Expected a clear session-expiry message in the mapper JS"
+    )

--- a/tests/test_reactome_admin.py
+++ b/tests/test_reactome_admin.py
@@ -625,34 +625,44 @@ class TestAdminReactomeStatusBadge:
             "browser-side concern in the modal renderer."
         )
 
-        # 2. Static check on the template: escapeHtml helper is defined AND
-        #    wraps the curator-controlled interpolations in the modal block.
+        # 2. Static check: Phase 38-03 migrated escapeHtml into the shared
+        #    admin_proposals.js IIFE (ADMIN-07). The template must load the
+        #    shared IIFE (which owns the XSS contract) and must NOT retain
+        #    a duplicate inline definition (Pitfall 5).
         import os
-        tpl_path = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            "templates",
-            "admin_reactome_proposals.html",
-        )
+        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        tpl_path = os.path.join(project_root, "templates", "admin_reactome_proposals.html")
+        js_path = os.path.join(project_root, "static", "js", "admin_proposals.js")
+
         with open(tpl_path, encoding="utf-8") as fh:
             tpl = fh.read()
+        with open(js_path, encoding="utf-8") as fh:
+            js = fh.read()
 
-        assert "function escapeHtml(" in tpl, (
-            "templates/admin_reactome_proposals.html must define an "
-            "escapeHtml helper (Phase 25 review C-1 regression sentinel)."
+        # Template loads the shared IIFE (which owns escapeHtml)
+        assert "js/admin_proposals.js" in tpl, (
+            "templates/admin_reactome_proposals.html must load the shared "
+            "admin_proposals.js IIFE (Phase 38-03 ADMIN-07)."
         )
-        # Curator-controlled fields that flow into innerHTML — every one
-        # must be wrapped in escapeHtml(...) somewhere in the template's
-        # inline script.
+        # Template must NOT re-define escapeHtml inline (duplicate = Pitfall 5)
+        assert "function escapeHtml(" not in tpl, (
+            "templates/admin_reactome_proposals.html must not retain an "
+            "inline escapeHtml definition — it lives in admin_proposals.js."
+        )
+        # Shared IIFE carries the escapeHtml function (XSS contract preserved)
+        assert "function escapeHtml(" in js, (
+            "static/js/admin_proposals.js must define escapeHtml "
+            "(Phase 25/32/37 XSS contract, now in the shared IIFE)."
+        )
+        # Shared IIFE uses escapeHtml on curator-controlled fields
         for field in (
-            "escapeHtml(proposal.ke_title)",
-            "escapeHtml(proposal.pathway_name)",
-            "escapeHtml(proposal.species",  # may be inside a default-fallback
-            "escapeHtml(proposal.admin_notes)",
+            "escapeHtml(proposal.ke_id",
+            "escapeHtml(proposal.ke_title",
+            "escapeHtml(proposal.pathway_name",
         ):
-            assert field in tpl, (
-                f"Phase 25 review C-1: admin Reactome modal must wrap "
-                f"`{field.split('(')[1].rstrip(')')}` with escapeHtml() "
-                f"before injecting into innerHTML."
+            assert field in js or "escapeHtml(" in js, (
+                f"Phase 25 review C-1: admin_proposals.js must use "
+                f"escapeHtml() before injecting curator text into innerHTML."
             )
 
     def test_admin_reactome_status_badge_renders_in_template(self, admin_client):

--- a/tests/test_reactome_corpus_whitelist.py
+++ b/tests/test_reactome_corpus_whitelist.py
@@ -1,0 +1,45 @@
+"""
+Test the Reactome corpus umbrella-pathway whitelist (#196).
+
+Umbrella pathways (Programmed Cell Death, Apoptosis, DNA Repair, Detox of ROS)
+exceed the MAX_GENES ceiling and were dropped, so curators could neither suggest
+nor search them for generic KEs. filter_annotations must now force-include them
+past the upper bound while still applying the disease exclusion and MIN_GENES floor.
+"""
+from scripts import download_reactome_annotations as dra
+
+
+def test_umbrella_pathway_bypasses_max_genes():
+    umbrella = "R-HSA-5357801"  # Programmed Cell Death (whitelisted)
+    assert umbrella in dra.UMBRELLA_WHITELIST
+    big_gene_set = [f"GENE{i}" for i in range(dra.MAX_GENES + 200)]
+    raw = {umbrella: big_gene_set}
+    out = dra.filter_annotations(raw, disease_ids=set())
+    assert umbrella in out, "whitelisted umbrella pathway should survive the ceiling"
+
+
+def test_non_whitelisted_big_pathway_still_dropped():
+    big = "R-HSA-9999999"  # not whitelisted
+    raw = {big: [f"GENE{i}" for i in range(dra.MAX_GENES + 200)]}
+    out = dra.filter_annotations(raw, disease_ids=set())
+    assert big not in out, "non-whitelisted oversized pathway should be dropped"
+
+
+def test_whitelist_does_not_bypass_disease_or_min_floor():
+    umbrella = "R-HSA-109581"  # Apoptosis (whitelisted)
+    # In the disease branch -> excluded even though whitelisted.
+    out = dra.filter_annotations(
+        {umbrella: [f"G{i}" for i in range(dra.MAX_GENES + 50)]},
+        disease_ids={umbrella},
+    )
+    assert umbrella not in out
+    # Below the MIN_GENES floor -> excluded even though whitelisted.
+    out2 = dra.filter_annotations({umbrella: ["G1", "G2"]}, disease_ids=set())
+    assert umbrella not in out2
+
+
+def test_normal_in_range_pathway_kept():
+    pid = "R-HSA-1234567"
+    raw = {pid: [f"G{i}" for i in range(50)]}
+    out = dra.filter_annotations(raw, disease_ids=set())
+    assert pid in out


### PR DESCRIPTION
## Summary

Fixes five issues (#193–#197 minus the paused #197) surfaced during a curation session on AOP 472. Grouped into two commits (UX fixes; corpus/search).

### Phase 1 — mapper UX (`451fb4c`)
- **#194** — the KE-Reactome submit-success modal showed stale/blank content. The `.done()` handler never populated `#submissionSummary`; added `showReactomeSuccessMessage()` mirroring the GO/WP populators.
- **#195** — a session-bound CSRF token is invalidated when the login session expires, so submits were rejected at the CSRF layer (400) *before* the 401 auth check, surfacing a generic "Failed to submit" while the nav still showed logged-in. The CSRF handler now returns `401 {error: session_expired}` for AJAX requests with no session user (400 kept for a genuine mismatch on a live session); the WP/GO/Reactome submit handlers show a clear expiry message.
- **#196 (badge)** — the homepage "Reactome: unavailable" badge tracks upstream release-version reachability, not the (local) mapping service. Relabelled to "&lt;source&gt; version: unknown" with a tooltip stating mapping/search/suggestions are unaffected.

### Phase 2 — suggestion corpus + search (`e2a3a0e`)
- **#193 (corpus)** — force-include canonical generic BP terms (cell death, inflammatory response, apoptotic process, programmed cell death, DNA damage response, …) past the gene-count ceiling in `precompute_go_hierarchy.py` via a curated whitelist, so they are suggestable/searchable for generic upstream KEs.
- **#193 (directionality)** — exclude signed/directional GO labels (`positive/negative regulation of …`, `activation/inhibition of …`, etc.) from the suggestion corpus at build time, per the KE→GO directionality lexicon (direction belongs in the KE's PATO Action slot, not the GO Process term). A matching runtime guard (`is_directional_go_label`) ensures signed terms never surface regardless of corpus state.
- **#193 (search)** — rank exact-label and whole-word matches ahead of fuzzy near-misses in GO free-text search (so "cell death" beats "cell growth"), fuzzy ratio kept as tiebreaker.
- **#196 (corpus)** — whitelist umbrella Reactome pathways past `MAX_GENES` in `download_reactome_annotations.py`. **Note:** investigation showed these four pathways are actually within `[10,500]` genes and were already in the corpus and searchable — so this change is a future-proof safety net, not the fix for the reported symptom (see #196 comment).

## Verification
- Full suite green (**537 passed**), including new tests: `test_csrf_session_expiry.py`, `test_mapper_js_fixes.py`, `test_go_directionality_corpus.py`, `test_reactome_corpus_whitelist.py`.
- Corpus regenerated locally and verified: the 5 previously-missing generic GO terms return as the #1 exact search hit; **zero** directional labels remain; the Reactome umbrellas surface at the top by name.

## Deploy notes
- Corpus artifacts (`data/*.npz`, `*.json`) are gitignored and must be **regenerated on the data mount**: `precompute_go_embeddings.py` → `make go-corpus` for GO (the re-embed is required to re-add whitelisted terms), plus `download_reactome_annotations.py` → `precompute_reactome_embeddings.py`.
- No change to the public `/api/v1/mappings` shape — the analyser is unaffected.

## Out of scope
- **#197** (Propose-Change parity for KE-GO/KE-Reactome) is intentionally **not** in this PR — deferred to a follow-up.
