### PR TITLE
Record Zenodo release 2026-07-21; correct the EACCES root cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Zenodo release `2026-07-21`** — [10.5281/zenodo.21472670](https://doi.org/10.5281/zenodo.21472670), the second canonical version on the concept timeline. Counts: WikiPathways 125 (79 High / 44 Medium / 2 Low), GO 11 (4/7/0), Reactome 6 (2/4/0) — GO and Reactome roughly doubled since the 2026-05-14 deposit. CC0, same v3 structure (three per-resource ZIPs with GMT-by-confidence + Turtle, plus a top-level README). Published with the repo rename already in place, so the deposit description and bundled README carry the `molAOP-builder` URL.
+
+### Security
+
+- **Zenodo API token migrated from an environment variable to a Docker secret** on the production service. `zenodo_api_token_v2` is mounted at `/run/secrets/zenodo_api_token` and `ZENODO_API_TOKEN` was removed from the service spec in the same update, so the publishing credential is no longer readable via `docker service inspect`. Completes #191, whose original trigger was the token revoked by Zenodo's 2026-05-21 session incident.
+
+### Fixed
+
+- **Corrected the documented root cause of the `zenodo_meta.json` EACCES fallback** (#191). `CLAUDE.md` and `docs/RELEASES.md` attributed it to a container-uid/host-owner mismatch on the data directory and prescribed rebuilding the image with `APP_UID`/`APP_GID` build args. That diagnosis was wrong and the prescribed fix could not have worked: the container already runs as uid 1000, and the data directory is world-writable with setgid gid 1000, so creating new files there succeeds. The actual blocker is **per-file group ownership** — pre-existing files carry gid `1003` while the container is gid `1000`, so permission resolution falls through to `other` = `r--` and an in-place overwrite fails. The documented remedy is now to delete and recreate the file from inside the container, which makes it inherit gid 1000 from the setgid directory and stay writable. Nine corpus artifacts on the mount carry the same gid and will hit the identical failure on any in-place rewrite; both docs now say so, with a one-liner to list them.
+
 ### Changed
 
 - **Repository renamed `KE-WP-mapping` → `molAOP-builder`.** The old name dated from when the tool mapped Key Events to WikiPathways only; it now covers three target resources (WikiPathways, GO BP/MF, Reactome) plus curation review, a versioned public API, exports and DOI'd releases. The new name matches the deployed service, the container image (`ghcr.io/marvinm2/molaop-builder`), and the sister repository `molAOP-analyser`. GitHub permanently redirects the old web and clone URLs, and the workflow hardcodes `IMAGE_NAME: marvinm2/molaop-builder`, so the published image, the swarm deployment and the public API are all unaffected. The GitHub description (still the January 2025 placeholder), homepage URL and topics were set at the same time. All in-repo references updated — including the two in `src/exporters/zenodo_assembly.py` that are embedded into the Zenodo deposit README and description, and one in the GMT export header, which had to land before the next Zenodo release so the new DOI does not ship pointing at the old URL. `docs/archive/` is intentionally left as-is.

--- a/data/zenodo_meta.json
+++ b/data/zenodo_meta.json
@@ -1,12 +1,27 @@
 {
-  "deposition_id": 20184796,
-  "doi": "10.5281/zenodo.20184796",
+  "deposition_id": 21472670,
+  "doi": "10.5281/zenodo.21472670",
   "concept_doi": "10.5281/zenodo.20184643",
-  "published_at": "2026-05-14",
-  "version": "2026-05-14",
+  "published_at": "2026-07-21",
+  "version": "2026-07-21",
   "counts": {
-    "wp":       {"All": 125, "High": 79, "Medium": 44, "Low": 2},
-    "go":       {"All": 7,   "High": 2,  "Medium": 5,  "Low": 0},
-    "reactome": {"All": 2,   "High": 1,  "Medium": 1,  "Low": 0}
+    "wp": {
+      "All": 125,
+      "High": 79,
+      "Medium": 44,
+      "Low": 2
+    },
+    "go": {
+      "All": 11,
+      "High": 4,
+      "Medium": 7,
+      "Low": 0
+    },
+    "reactome": {
+      "All": 6,
+      "High": 2,
+      "Medium": 4,
+      "Low": 0
+    }
   }
 }

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -90,17 +90,48 @@ flip it on:
 
 These are tracked under GitHub [issue #158](https://github.com/marvinm2/molAOP-builder/issues/158):
 
-- **`data/zenodo_meta.json` write may fall back to `/tmp/`** if the container uid
-  doesn't match the host owner of the gluster mount. The `Dockerfile` now accepts
-  `APP_UID` / `APP_GID` build args (default `1000`) so a rebuild aligned with the
-  host owner clears the original EACCES. Both the release script and the admin
-  `publish_zenodo` route share `persist_meta_with_fallback`: a successful Zenodo
-  deposit never appears to fail; on a write block the payload lands at
-  `/tmp/zenodo_meta_pending.json` (loud log, response includes `meta_path_fallback`).
-  Operator then `scp`s it back into git. Confirm the host owner with
-  `ssh tgx1 stat -c '%u %g' /mnt/gluster/docker/molaop-builder/data` and rebuild
-  with `docker build --build-arg APP_UID=<uid> --build-arg APP_GID=<gid> ...` if
-  it isn't 1000:1000.
+- **`data/zenodo_meta.json` write may fall back to `/tmp/`.** Both the release script
+  and the admin `publish_zenodo` route share `persist_meta_with_fallback`, so a
+  successful Zenodo deposit never appears to fail; on a write block the payload lands
+  at `/tmp/zenodo_meta_pending.json` (loud log, response includes
+  `meta_path_fallback`) and the operator restores it.
+
+  **Root cause is per-file group ownership, not the container uid.** Observed on the
+  2026-07-21 release:
+
+  ```
+  drwxrwsrwx  70055468 1000   data/                 <- world-writable, setgid, gid 1000
+  -rw-rw-r--  70055468 1003   data/zenodo_meta.json <- gid 1003
+  uid=1000(appuser) gid=1000(appuser)               <- container user
+  ```
+
+  The *directory* is fine — the container can create new files in it. The blocked
+  write is on the *existing file*, which carries group `1003` while the container is
+  gid `1000`, so permission resolution falls through to `other` = `r--`. Rebuilding
+  the image with different `APP_UID` / `APP_GID` build args does **not** help, because
+  the container uid is already 1000; the file simply belongs to a group it is not in.
+
+  Fix by deleting and recreating the file from inside the container, so it inherits
+  gid 1000 from the setgid directory and stays writable thereafter:
+
+  ```bash
+  ssh tgx1 'cp /mnt/gluster/docker/molaop-builder/data/zenodo_meta.json /tmp/zenodo_meta.stale.bak'
+  ssh tgx1 'C=$(docker ps -qf name=molaop-builder); docker exec $C sh -c \
+      "rm -f /app/data/zenodo_meta.json && cp /tmp/zenodo_meta_pending.json /app/data/zenodo_meta.json"'
+  ssh tgx1 'ls -ln /mnt/gluster/docker/molaop-builder/data/zenodo_meta.json'   # expect 1000 1000
+  ```
+
+  The app picks the new file up without a restart. Then `scp` it back into git as in
+  step 2 above.
+
+  **The same trap applies to nine other files on the mount** — `go.obo`,
+  `goa_human.gaf.gz`, `ke_embeddings.npz`, `ke_metadata.json`, `pathway_metadata.json`,
+  `pathway_embeddings.npz`, `pathway_title_embeddings.npz`, `go_bp_gene_annotations.json`,
+  `ke_aop_membership.json` — all group `1003`. They are readable, so nothing breaks in
+  normal operation, but any in-place rewrite hits the identical EACCES. This is why the
+  corpus-regeneration procedure says to `rm -f` the artifacts first and let the
+  container recreate them. Check with:
+  `ssh tgx1 "ls -ln /mnt/gluster/docker/molaop-builder/data | awk '\$4==1003'"`.
 - **`rdflib` ISO-8601 warnings** are resolved. The DB startup migration
   (`_migrate_iso8601_datetime_backfill`) normalises legacy `"YYYY-MM-DD HH:MM:SS"`
   rows to ISO-8601 across the three mapping tables, and the RDF exporter applies


### PR DESCRIPTION
Follow-up to #191, which is now closed.

## Release

New Zenodo version [10.5281/zenodo.21472670](https://doi.org/10.5281/zenodo.21472670), `2026-07-21`, CC0. Counts: WikiPathways 125 (79/44/2), GO 11 (4/7/0), Reactome 6 (2/4/0) — GO and Reactome roughly doubled since the 2026-05-14 deposit.

Verified the deposit has the correct v3 structure (three per-resource ZIPs + README, no inherited-file contamination) and that both its description and bundled README carry the `molAOP-builder` URL. Sequencing the rename (#201) before the release is what made that work.

The API token is now a Docker secret (`zenodo_api_token_v2` → `/run/secrets/zenodo_api_token`) with `ZENODO_API_TOKEN` removed from the service spec in the same update, so the credential is no longer exposed to `docker service inspect`.

## The documented EACCES cause was wrong

The publish succeeded but the meta write fell back to `/tmp/zenodo_meta_pending.json`, so the app kept advertising the May deposit until restored by hand.

`CLAUDE.md` and `docs/RELEASES.md` blamed a container-uid/host-owner mismatch on the data directory and prescribed rebuilding with `APP_UID`/`APP_GID` build args. **That fix could not have worked** — the container already runs as uid 1000, and the directory is world-writable with setgid gid 1000, so creating new files there succeeds:

```
drwxrwsrwx  70055468 1000   data/                 <- fine
-rw-rw-r--  70055468 1003   data/zenodo_meta.json <- the actual problem
uid=1000(appuser) gid=1000(appuser)
```

The blocked write is on the *existing file*: group `1003` against a gid `1000` container means permission falls through to `other` = `r--`. The file simply belongs to a group the container is not in, which no image rebuild changes.

Both docs now give the working remedy — delete and recreate from inside the container so the file inherits gid 1000 from the setgid directory — and flag that **nine corpus artifacts on the mount carry the same gid** and will fail identically on any in-place rewrite. That is the same trap the corpus-regeneration procedure already works around with `rm -f`; it just was not connected to this failure before.

## Verification

Deposit confirmed against the Zenodo API (structure, licence, counts, repo URL). Both concept and version DOIs render on `/downloads` and in the site footer. The restored meta file is now `1000:1000`, so the next publish overwrites it normally rather than falling back again.