### PR TITLE
Consolidate /get_data_versions onto SourceVersionService; drop dead version JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`/get_data_versions` consolidated onto `SourceVersionService`.** The route carried its own SPARQL against AOP-Wiki and WikiPathways, duplicating what `src/services/source_versions.py` already did for the footer badges. Having two implementations is what let one of them drift until it was silently dead (#204). The route now delegates: ~134 lines of hand-rolled query and error handling become ~48, coverage goes from two resources to **four** (GO and Reactome were never reported by this endpoint), it inherits the service's 24-hour cache instead of hitting upstream on every request, and every resource is always present in the response with an explicit `unavailable` flag rather than being dropped on failure. The URL and its public availability are unchanged. A guard test asserts the route never reintroduces its own `requests.post`.
+- **Removed dead version-rendering JavaScript.** `loadDataVersions` and `displayVersionInfo` in `static/js/main.js` (45 lines) rendered into a `#version-info` element that does not exist in any template, so the function returned early on every page load. Deleted along with its call site; the footer badges are rendered server-side from the same service.
+
 ### Fixed
 
 - **WikiPathways version showed as "unknown" on the live site.** WikiPathways moved its `void:Dataset` IRIs from `http://` to `https://`, and `capture_wikipathways` filtered with `STRSTARTS(STR(?dataset), "http://data.wikipathways.org/")`. The query kept returning HTTP 200 with **zero bindings**, so nothing errored and nothing logged — the failure surfaced only as a permanently "unknown" badge in the footer while Reactome and AOP-Wiki resolved normally. The filter now matches either scheme (`^https?://data\.wikipathways\.org/`) and the badge reads `2026-07-10`, the current release. A guard test asserts the query never pins a scheme again, because a scheme-pinned filter fails silently — no behavioural test against a mocked 200 response can catch it, only inspecting the query can. Two further tests cover an https IRI end-to-end and the `/smiles` and `/citedin` dataset suffixes that share each release alongside `/rdf/`.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ tests/                  # Pytest test suite
 | `/get_pathway_options` | GET | Fetch pathway options | SPARQL |
 | `/get_aop_options` | GET | Fetch AOP options | SPARQL |
 | `/get_aop_kes/<aop_id>` | GET | Fetch Key Events for a specific AOP | SPARQL |
-| `/get_data_versions` | GET | Fetch data source version info | SPARQL |
+| `/get_data_versions` | GET | Upstream release versions for all four source resources (WikiPathways, GO, Reactome, AOP-Wiki) | `SourceVersionService` (24 h cache) |
 | `/suggest_pathways/<ke_id>` | GET | Pathway suggestions for a Key Event | SPARQL |
 | `/search_pathways` | GET | Full-text pathway search with fuzzy matching | SPARQL |
 | `/ke_genes/<ke_id>` | GET | Genes associated with a Key Event | SPARQL |

--- a/src/blueprints/api.py
+++ b/src/blueprints/api.py
@@ -28,6 +28,7 @@ from src.core.schemas import (
     validate_request_data,
 )
 from src.core.config_loader import ConfigLoader
+from src.services import source_versions
 from src.utils.text import sanitize_log
 
 logger = logging.getLogger(__name__)
@@ -475,137 +476,48 @@ def get_pathway_options():
 @api_bp.route("/get_data_versions", methods=["GET"])
 @sparql_rate_limit
 def get_data_versions():
-    """Fetch version information from AOP-Wiki and WikiPathways SPARQL endpoints."""
+    """Report upstream release versions for the four source resources.
+
+    Delegates to :mod:`src.services.source_versions`, which is the single place
+    upstream releases are resolved (and is what the footer badges already use).
+
+    This route previously issued its own SPARQL against AOP-Wiki and
+    WikiPathways. That duplicate implementation drifted: it sent
+    ``Accept: application/json``, which both endpoints answer with HTTP 406, and
+    its handler only branched on ``status_code == 200`` — so a failure produced
+    an empty object with a 200 status and no log line (#204). Delegating removes
+    the second copy, picks up the 24 h cache, and extends coverage from two
+    resources to four (GO and Reactome were never reported here).
+
+    Response shape is unchanged in spirit but now consistent per resource::
+
+        {"wikipathways": {"source": "WikiPathways", "version": "2026-07-10",
+                          "unavailable": false}, ...}
+    """
+    labels = {
+        "wikipathways": "WikiPathways",
+        "gene_ontology": "Gene Ontology",
+        "reactome": "Reactome",
+        "aopwiki": "AOP-Wiki",
+    }
+
     try:
-        versions = {}
-        
-        # Get AOP-Wiki version info
-        try:
-            aop_query = """
-            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX dc: <http://purl.org/dc/elements/1.1/>
-            PREFIX dcterms: <http://purl.org/dc/terms/>
-            
-            SELECT DISTINCT ?version ?date ?comment
-            WHERE {
-                ?dataset a <http://rdfs.org/ns/void#Dataset> .
-                OPTIONAL { ?dataset dcterms:hasVersion ?version }
-                OPTIONAL { ?dataset dcterms:created ?date }
-                OPTIONAL { ?dataset rdfs:comment ?comment }
-            } LIMIT 1
-            """
-            
-            aop_endpoint = "https://aopwiki.rdf.bigcat-bioinformatics.org/sparql"
-            # Accept must be application/sparql-results+json. Both SPARQL
-            # endpoints answer application/json with HTTP 406, which the
-            # status check below then dropped silently (see #204).
-            aop_response = requests.post(
-                aop_endpoint,
-                data={"query": aop_query},
-                headers={"Accept": "application/sparql-results+json"},
-                timeout=10
-            )
-
-            if aop_response.status_code != 200:
-                raise RuntimeError(
-                    f"SPARQL endpoint returned HTTP {aop_response.status_code}"
-                )
-
-            if aop_response.status_code == 200:
-                aop_data = aop_response.json()
-                if aop_data.get("results", {}).get("bindings"):
-                    result = aop_data["results"]["bindings"][0]
-                    versions["aop_wiki"] = {
-                        "source": "AOP-Wiki RDF",
-                        "version": result.get("version", {}).get("value", "Unknown"),
-                        "date": result.get("date", {}).get("value", "Unknown"),
-                        "comment": result.get("comment", {}).get("value", ""),
-                        "endpoint": aop_endpoint
-                    }
-                else:
-                    versions["aop_wiki"] = {
-                        "source": "AOP-Wiki RDF",
-                        "version": "Available",
-                        "date": "Unknown",
-                        "comment": "SPARQL endpoint accessible",
-                        "endpoint": aop_endpoint
-                    }
-                    
-        except Exception as e:
-            logger.warning("Could not fetch AOP-Wiki version: %s", e)
-            versions["aop_wiki"] = {
-                "source": "AOP-Wiki RDF",
-                "version": "Unknown",
-                "date": "Unknown",
-                "comment": f"Error: {str(e)}",
-                "endpoint": "https://aopwiki.rdf.bigcat-bioinformatics.org/sparql"
-            }
-        
-        # Get WikiPathways version info
-        try:
-            wp_query = """
-            PREFIX void: <http://rdfs.org/ns/void#>
-            PREFIX dcterms: <http://purl.org/dc/terms/>
-            PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            
-            SELECT DISTINCT ?version ?date ?title
-            WHERE {
-                ?dataset a void:Dataset .
-                OPTIONAL { ?dataset dcterms:hasVersion ?version }
-                OPTIONAL { ?dataset dcterms:created ?date }
-                OPTIONAL { ?dataset dcterms:title ?title }
-            } LIMIT 1
-            """
-            
-            wp_endpoint = "https://sparql.wikipathways.org/sparql"
-            # See the AOP-Wiki call above — application/json yields HTTP 406.
-            wp_response = requests.post(
-                wp_endpoint,
-                data={"query": wp_query},
-                headers={"Accept": "application/sparql-results+json"},
-                timeout=10
-            )
-
-            if wp_response.status_code != 200:
-                raise RuntimeError(
-                    f"SPARQL endpoint returned HTTP {wp_response.status_code}"
-                )
-
-            if wp_response.status_code == 200:
-                wp_data = wp_response.json()
-                if wp_data.get("results", {}).get("bindings"):
-                    result = wp_data["results"]["bindings"][0]
-                    versions["wikipathways"] = {
-                        "source": "WikiPathways",
-                        "version": result.get("version", {}).get("value", "Current"),
-                        "date": result.get("date", {}).get("value", "Unknown"),
-                        "comment": result.get("title", {}).get("value", ""),
-                        "endpoint": wp_endpoint
-                    }
-                else:
-                    versions["wikipathways"] = {
-                        "source": "WikiPathways",
-                        "version": "Current",
-                        "date": "Unknown",
-                        "comment": "SPARQL endpoint accessible",
-                        "endpoint": wp_endpoint
-                    }
-                    
-        except Exception as e:
-            logger.warning("Could not fetch WikiPathways version: %s", e)
-            versions["wikipathways"] = {
-                "source": "WikiPathways",
-                "version": "Unknown",
-                "date": "Unknown", 
-                "comment": f"Error: {str(e)}",
-                "endpoint": "https://sparql.wikipathways.org/sparql"
-            }
-        
-        return jsonify(versions), 200
-        
+        snapshot = source_versions.snapshot()
     except Exception as e:
+        # snapshot() is documented never to raise; treat a breach as a real error
+        # rather than silently returning an empty body as the old code did.
         logger.error("Error fetching data versions: %s", e)
         return jsonify({"error": "Failed to load data version information"}), 500
+
+    versions = {
+        key: {
+            "source": label,
+            "version": snapshot.get(key, {}).get("version", "unavailable"),
+            "unavailable": snapshot.get(key, {}).get("unavailable", True),
+        }
+        for key, label in labels.items()
+    }
+    return jsonify(versions), 200
 
 
 @api_bp.route("/submit_proposal", methods=["POST"])

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -507,7 +507,6 @@ class KEWPApp {
         }
 
         this.loadDropdownOptions();
-        this.loadDataVersions();
 
         // Initialize form validation
 
@@ -1874,51 +1873,6 @@ class KEWPApp {
 
     hidePathwayPreview() {
         $("#pathway-preview").remove();
-    }
-
-    loadDataVersions() {
-        // Only load version info if we're on a page that has the version info element
-        if ($("#version-info").length === 0) {
-            return;
-        }
-        
-        $.getJSON("/get_data_versions")
-            .done((data) => {
-                // Version data loaded successfully
-                this.displayVersionInfo(data);
-            })
-            .fail((xhr, status, error) => {
-                console.warn("Failed to load version information:", error);
-                $("#version-info").html('<span class="text-muted">Version information unavailable</span>');
-            });
-    }
-
-    displayVersionInfo(versions) {
-        let versionHtml = '';
-        
-        if (versions.aop_wiki) {
-            versionHtml += `
-                <div style="margin-bottom: 3px;">
-                    <strong>AOP-Wiki:</strong> ${versions.aop_wiki.version}
-                    ${versions.aop_wiki.date !== 'Unknown' ? ` (${versions.aop_wiki.date})` : ''}
-                </div>
-            `;
-        }
-        
-        if (versions.wikipathways) {
-            versionHtml += `
-                <div style="margin-bottom: 3px;">
-                    <strong>WikiPathways:</strong> ${versions.wikipathways.version}
-                    ${versions.wikipathways.date !== 'Unknown' ? ` (${versions.wikipathways.date})` : ''}
-                </div>
-            `;
-        }
-        
-        if (versionHtml) {
-            $("#version-info").html(versionHtml);
-        } else {
-            $("#version-info").html('<span class="text-muted">Version information not available</span>');
-        }
     }
 
     populatePathwayDropdowns() {

--- a/tests/test_get_data_versions_204.py
+++ b/tests/test_get_data_versions_204.py
@@ -1,102 +1,128 @@
 """
-`/get_data_versions` returned an empty object in production (#204).
+`/get_data_versions` — consolidated onto SourceVersionService (#204).
 
-Two defects compounded:
+History: the route issued its own SPARQL against AOP-Wiki and WikiPathways,
+duplicating what `src/services/source_versions.py` already did for the footer
+badges. That duplicate drifted and broke silently in two ways at once —
 
-1. The route sent ``Accept: application/json``. Both the AOP-Wiki and
-   WikiPathways SPARQL endpoints answer that with **HTTP 406 Not Acceptable** —
-   they serve ``application/sparql-results+json``. Verified against both live
-   endpoints.
-2. The response handling was ``if status_code == 200: <set key>`` with no
-   ``else``. A non-200 therefore set no key and raised nothing, so the route
-   returned ``{}`` with a 200 status and no log line. The frontend
-   (`static/js/main.js`) silently rendered nothing.
+1. It sent ``Accept: application/json``. Both SPARQL endpoints answer that with
+   **HTTP 406**; they serve ``application/sparql-results+json``.
+2. Its handler was ``if status_code == 200:`` with no ``else``, so a non-200 set
+   no key and raised nothing. The route returned ``{}`` with a 200 status and no
+   log line, making a total upstream failure look identical to "no data".
 
-The combination meant a total outage of this endpoint looked identical to
-"no data yet". These tests pin the header and the non-silence.
+The route now delegates to `source_versions.snapshot()`. These tests pin the
+properties that made the old version fail invisibly: every resource is always
+represented, failures are labelled rather than dropped, and no second copy of
+the upstream fetch logic creeps back in.
 """
 
 import pytest
 
+RESOURCES = ["wikipathways", "gene_ontology", "reactome", "aopwiki"]
 
-def _versions_source():
+
+@pytest.fixture
+def stub_snapshot(monkeypatch):
+    """Replace SourceVersionService.snapshot with a controllable stub."""
+
+    def _install(payload):
+        from src.blueprints import api
+
+        monkeypatch.setattr(api.source_versions, "snapshot", lambda: payload)
+
+    return _install
+
+
+def test_reports_all_four_resources(client, stub_snapshot):
+    """Coverage went from two resources to four; GO and Reactome were never here."""
+    stub_snapshot(
+        {
+            "wikipathways": {"version": "2026-07-10", "unavailable": False},
+            "gene_ontology": {"version": "2026-06-15", "unavailable": False},
+            "reactome": {"version": "v97", "unavailable": False},
+            "aopwiki": {"version": "2026-07-17", "unavailable": False},
+        }
+    )
+
+    body = client.get("/get_data_versions").get_json()
+
+    assert sorted(body) == sorted(RESOURCES)
+    assert body["wikipathways"]["version"] == "2026-07-10"
+    assert body["reactome"]["version"] == "v97"
+    assert body["wikipathways"]["unavailable"] is False
+    assert body["wikipathways"]["source"] == "WikiPathways"
+
+
+def test_failed_resource_is_labelled_not_dropped(client, stub_snapshot):
+    """The core regression: a failure must stay visible in the payload.
+
+    Previously an upstream failure removed the key entirely, so a caller could
+    not tell "fetch failed" from "resource not covered".
+    """
+    stub_snapshot(
+        {
+            "wikipathways": {"version": "unavailable", "unavailable": True},
+            "gene_ontology": {"version": "2026-06-15", "unavailable": False},
+            "reactome": {"version": "v97", "unavailable": False},
+            "aopwiki": {"version": "2026-07-17", "unavailable": False},
+        }
+    )
+
+    body = client.get("/get_data_versions").get_json()
+
+    assert "wikipathways" in body, "failed resource was dropped from the payload"
+    assert body["wikipathways"]["unavailable"] is True
+    assert body["gene_ontology"]["unavailable"] is False
+
+
+def test_empty_snapshot_still_lists_every_resource(client, stub_snapshot):
+    """Even a total service failure must not return `{}` with a 200."""
+    stub_snapshot({})
+
+    resp = client.get("/get_data_versions")
+    body = resp.get_json()
+
+    assert resp.status_code == 200
+    assert sorted(body) == sorted(RESOURCES)
+    assert all(body[r]["unavailable"] is True for r in RESOURCES)
+
+
+def test_snapshot_raising_returns_500_not_empty_body(client, monkeypatch):
+    """snapshot() is documented never to raise; a breach is a real error.
+
+    The old code's failure mode was a 200 with an empty body. If the service
+    contract is ever violated we want a 500, not silence.
+    """
+    from src.blueprints import api
+
+    def boom():
+        raise RuntimeError("contract violated")
+
+    monkeypatch.setattr(api.source_versions, "snapshot", boom)
+
+    resp = client.get("/get_data_versions")
+
+    assert resp.status_code == 500
+    assert "error" in resp.get_json()
+
+
+def test_route_does_not_reimplement_upstream_fetches():
+    """Guard against a second copy of the SPARQL logic returning.
+
+    The duplication is what allowed the two implementations to drift apart
+    until one of them was silently dead.
+    """
     import inspect
 
     from src.blueprints import api
 
-    return inspect.getsource(api.get_data_versions)
+    source = inspect.getsource(api.get_data_versions)
 
-
-def test_requests_sparql_results_json_not_plain_json():
-    """application/json gets a 406 from both endpoints."""
-    source = _versions_source()
-
-    assert "application/sparql-results+json" in source, (
-        "SPARQL endpoints require Accept: application/sparql-results+json"
+    assert "requests.post" not in source, (
+        "route must delegate to source_versions, not issue its own HTTP calls"
     )
-    assert '"Accept": "application/json"' not in source, (
-        "Accept: application/json returns HTTP 406 from both AOP-Wiki and "
-        "WikiPathways; it must not be reintroduced"
-    )
-
-
-def test_non_200_is_not_swallowed():
-    """A failed upstream call must not silently vanish from the response."""
-    source = _versions_source()
-
-    assert "status_code != 200" in source, (
-        "route must branch on non-200 explicitly; the original code only "
-        "handled == 200, so a 406 produced a key-less, log-less empty result"
-    )
-
-
-@pytest.mark.parametrize("resource", ["aop_wiki", "wikipathways"])
-def test_upstream_failure_still_reports_the_resource(monkeypatch, client, resource):
-    """Every resource appears in the payload even when its fetch fails.
-
-    The point of the fix is that a caller can distinguish "fetch failed" from
-    "resource not covered". Before, both looked like an absent key.
-    """
-    import requests as _requests
-
-    from src.blueprints import api
-
-    class _Resp:
-        status_code = 406
-        text = "Not Acceptable"
-
-        def json(self):  # pragma: no cover - should not be reached on 406
-            raise ValueError("no json on a 406")
-
-    monkeypatch.setattr(api.requests, "post", lambda *a, **kw: _Resp())
-
-    resp = client.get("/get_data_versions")
-
-    assert resp.status_code == 200
-    body = resp.get_json()
-    assert resource in body, (
-        f"{resource} missing entirely from the payload on upstream failure — "
-        "this is the silent-drop bug"
-    )
-    # And it must be marked as failed rather than looking like real data.
-    assert body[resource].get("version") in ("Unknown", "unavailable", None) or (
-        "Error" in str(body[resource].get("comment", ""))
-    )
-
-
-def test_all_resources_present_on_success(monkeypatch, client):
-    """A healthy fetch reports both resources."""
-    from src.blueprints import api
-
-    class _Resp:
-        status_code = 200
-
-        def json(self):
-            return {"results": {"bindings": [{}]}}
-
-    monkeypatch.setattr(api.requests, "post", lambda *a, **kw: _Resp())
-
-    body = client.get("/get_data_versions").get_json()
-
-    assert "aop_wiki" in body
-    assert "wikipathways" in body
+    assert "sparql" not in source.lower() or "SPARQL" in inspect.getdoc(
+        api.get_data_versions
+    ), "route should no longer build SPARQL queries itself"
+    assert "source_versions.snapshot" in source


### PR DESCRIPTION
Follow-up to #204, which fixed the endpoint but noted it was both duplicated and dead.

## Why consolidate rather than delete

The route is public and listed in the README endpoint table, so deleting the URL risks breaking an unknown external caller for no real gain. Delegating keeps the URL working while removing the thing that actually caused the bug: **two independent implementations of the same upstream fetch**, one of which drifted until it was silently broken.

## What changed

`/get_data_versions` now calls `source_versions.snapshot()` — the same service the footer badges already use.

| | before | after |
|---|---|---|
| implementation | ~134 lines of hand-rolled SPARQL + error handling | ~48 lines delegating |
| resources covered | 2 (AOP-Wiki, WikiPathways) | **4** (+ GO, Reactome) |
| upstream calls | every request | 24 h cache |
| on failure | key dropped, `{}` returned with a 200 | resource present with `unavailable: true` |

Live output from the consolidated route:

```json
{
  "wikipathways":  {"source": "WikiPathways",   "version": "2026-07-10", "unavailable": false},
  "gene_ontology": {"source": "Gene Ontology",  "version": "2026-01-23", "unavailable": false},
  "reactome":      {"source": "Reactome",       "version": "v97",        "unavailable": false},
  "aopwiki":       {"source": "AOP-Wiki",       "version": "2026-07-17", "unavailable": false}
}
```

The URL, method and public availability are unchanged.

## Dead JavaScript removed

`loadDataVersions` and `displayVersionInfo` in `static/js/main.js` (45 lines) rendered into a `#version-info` element that exists in **no** template — the function returned early on every page load. Removed along with its call site. The footer badges are rendered server-side from the same service, so nothing user-facing is affected.

## Tests

Rewritten around the properties that let the original fail invisibly, rather than around the implementation:

- every resource is present in the payload, including on failure
- a failed resource is *labelled* `unavailable`, not dropped
- an empty snapshot still lists all four rather than returning `{}`
- if `snapshot()` ever violates its never-raises contract, the route returns 500 rather than a silent empty body
- a guard test asserts the route never reintroduces `requests.post` — the duplication is the root cause, so it's worth pinning

602 tests pass. Verified against the real service locally: all four resources resolve, and the footer badges are unaffected.