### PR TITLE
Add GET /api/v1/aops and refresh the AOP membership snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,13 @@ data/*.json
 !data/zenodo_meta.json
 # Keep upstream source-versions manifest (small, ships with the snapshot)
 !data/source_versions.json
+# Keep the KE->AOP membership snapshot. It backs ke_aop_context on every mapping
+# record and the whole of /api/v1/aops, so an untracked copy meant the API's AOP
+# knowledge lived only on whichever machine last ran the precompute script - and
+# it went 4 months without a refresh because nothing surfaced its age.
+# NOTE: production reads this from the /app/data bind mount, which shadows the
+# image, so committing a refresh here does NOT deploy it. Copy it to the mount.
+!data/ke_aop_membership.json
 
 # GO source data (large, re-downloadable)
 data/go.obo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`GET /api/v1/aops` — the AOP list the Analyser's picker needs.** Until now nothing in the public API answered "which AOPs does this instance have mappings for?". A consumer had to page every mapping record, read `ke_aop_context`, and invert it — which yields AOP IDs but no titles, no total KE counts, and no per-resource breakdown. The Analyser did exactly this and fell back to AOP-Wiki SPARQL for the rest, so its AOP dropdown was never actually Builder-driven (molAOP-analyser#3).
+
+  The endpoint returns one row per AOP with `aop_title`, `ke_count`, `mapped_ke_count`, and a per-resource split (`wikipathways_ke_count` / `go_ke_count` / `reactome_ke_count`), sorted by mapped coverage so the best-covered AOPs come first. `?mapped_only=true` drops AOPs no curator has touched, `?q=` filters over ID and title, and pagination and `?format=csv` match the other v1 collections. Missing the membership snapshot degrades to an empty list rather than a 500, since that file is mounted at runtime rather than shipped in the image.
+
+- **Refreshed `data/ke_aop_membership.json`.** The snapshot behind `ke_aop_context` — and now behind `/api/v1/aops` — was generated on **10 March 2026** and had not been regenerated since, so every consumer of `ke_aop_context` was reading four-month-old AOP-Wiki membership. Re-running `scripts/precompute_ke_aop_membership.py` adds **125 KE-AOP memberships across 11 AOPs that were previously invisible** (1,567 → 1,599 KEs; 3,623 → 3,719 memberships) and loses none. Concretely: AOP 625 went from 15 KEs to 18, AOP 628 from 14 to 16, and AOP 638 appeared for the first time with 11 — it had been absent from the API's AOP context entirely.
+
 - **Zenodo release `2026-07-21`** — [10.5281/zenodo.21472670](https://doi.org/10.5281/zenodo.21472670), the second canonical version on the concept timeline. Counts: WikiPathways 125 (79 High / 44 Medium / 2 Low), GO 11 (4/7/0), Reactome 6 (2/4/0) — GO and Reactome roughly doubled since the 2026-05-14 deposit. CC0, same v3 structure (three per-resource ZIPs with GMT-by-confidence + Turtle, plus a top-level README). Published with the repo rename already in place, so the deposit description and bundled README carry the `molAOP-builder` URL.
 
 ### Security

--- a/data/ke_aop_membership.json
+++ b/data/ke_aop_membership.json
@@ -1,0 +1,18076 @@
+{
+  "KE 142": [
+    {
+      "aop_id": "AOP 1",
+      "aop_title": "Uncharacterized liver damage leading to hepatocellular carcinoma"
+    }
+  ],
+  "KE 294": [
+    {
+      "aop_id": "AOP 1",
+      "aop_title": "Uncharacterized liver damage leading to hepatocellular carcinoma"
+    },
+    {
+      "aop_id": "AOP 33",
+      "aop_title": "Kidney toxicity induced by activation of 5HT2C"
+    }
+  ],
+  "KE 334": [
+    {
+      "aop_id": "AOP 1",
+      "aop_title": "Uncharacterized liver damage leading to hepatocellular carcinoma"
+    }
+  ],
+  "KE 57": [
+    {
+      "aop_id": "AOP 1",
+      "aop_title": "Uncharacterized liver damage leading to hepatocellular carcinoma"
+    }
+  ],
+  "KE 613": [
+    {
+      "aop_id": "AOP 10",
+      "aop_title": "Binding to the picrotoxin site of ionotropic GABA receptors leading to epileptic seizures in adult brain"
+    }
+  ],
+  "KE 616": [
+    {
+      "aop_id": "AOP 10",
+      "aop_title": "Binding to the picrotoxin site of ionotropic GABA receptors leading to epileptic seizures in adult brain"
+    }
+  ],
+  "KE 64": [
+    {
+      "aop_id": "AOP 10",
+      "aop_title": "Binding to the picrotoxin site of ionotropic GABA receptors leading to epileptic seizures in adult brain"
+    }
+  ],
+  "KE 667": [
+    {
+      "aop_id": "AOP 10",
+      "aop_title": "Binding to the picrotoxin site of ionotropic GABA receptors leading to epileptic seizures in adult brain"
+    }
+  ],
+  "KE 669": [
+    {
+      "aop_id": "AOP 10",
+      "aop_title": "Binding to the picrotoxin site of ionotropic GABA receptors leading to epileptic seizures in adult brain"
+    }
+  ],
+  "KE 682": [
+    {
+      "aop_id": "AOP 10",
+      "aop_title": "Binding to the picrotoxin site of ionotropic GABA receptors leading to epileptic seizures in adult brain"
+    }
+  ],
+  "KE 360": [
+    {
+      "aop_id": "AOP 100",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of female spawning behavior"
+    },
+    {
+      "aop_id": "AOP 101",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of pheromone release"
+    },
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    },
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    },
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 155",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced posterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 156",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 157",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced posterior swim bladder inflation "
+    },
+    {
+      "aop_id": "AOP 158",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 16",
+      "aop_title": "Acetylcholinesterase inhibition leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 216",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 218",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased locomotor activity"
+    },
+    {
+      "aop_id": "AOP 219",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased sexual behavior"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 238",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 289",
+      "aop_title": "Inhibition of 5α-reductase leading to impaired fecundity in female fish"
+    },
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 292",
+      "aop_title": "Inhibition of tyrosinase leads to decreased population in fish"
+    },
+    {
+      "aop_id": "AOP 297",
+      "aop_title": "Inhibition of retinaldehyde dehydrogenase leads to population decline"
+    },
+    {
+      "aop_id": "AOP 299",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 30",
+      "aop_title": "Estrogen receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 311",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 312",
+      "aop_title": "Acetylcholinesterase Inhibition leading to Acute Mortality via Impaired Coordination & Movement​"
+    },
+    {
+      "aop_id": "AOP 323",
+      "aop_title": "PPARalpha Agonism Leading to Decreased Viable Offspring via Decreased 11-Ketotestosterone"
+    },
+    {
+      "aop_id": "AOP 334",
+      "aop_title": "Glucocorticoid Receptor Agonism Leading to Impaired Fin Regeneration"
+    },
+    {
+      "aop_id": "AOP 336",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (1)"
+    },
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 338",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (3)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    },
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    },
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    },
+    {
+      "aop_id": "AOP 346",
+      "aop_title": "Aromatase inhibition leads to male-biased sex ratio via impacts on gonad differentiation"
+    },
+    {
+      "aop_id": "AOP 348",
+      "aop_title": "Inhibition of 11β-Hydroxysteroid Dehydrogenase leading to decreased population trajectory "
+    },
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    },
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    },
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    },
+    {
+      "aop_id": "AOP 376",
+      "aop_title": "Androgen receptor agonism leading to male-biased sex ratio"
+    },
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 388",
+      "aop_title": "Deposition of ionising energy  leading to population decline via programmed cell death"
+    },
+    {
+      "aop_id": "AOP 389",
+      "aop_title": " Oxygen-evolving complex damage leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    },
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    },
+    {
+      "aop_id": "AOP 536",
+      "aop_title": "Estrogen receptor agonism leading to reduced survival and population growth due to renal failure"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    },
+    {
+      "aop_id": "AOP 567",
+      "aop_title": "Binding to plastoquinone B site leading to decreased population growth rate via photosystem II inhibition"
+    },
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 608",
+      "aop_title": "Thyroid Hormone Excess Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 63",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 671": [
+    {
+      "aop_id": "AOP 100",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of female spawning behavior"
+    },
+    {
+      "aop_id": "AOP 101",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of pheromone release"
+    }
+  ],
+  "KE 672": [
+    {
+      "aop_id": "AOP 100",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of female spawning behavior"
+    }
+  ],
+  "KE 673": [
+    {
+      "aop_id": "AOP 100",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of female spawning behavior"
+    }
+  ],
+  "KE 674": [
+    {
+      "aop_id": "AOP 100",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of female spawning behavior"
+    },
+    {
+      "aop_id": "AOP 101",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of pheromone release"
+    }
+  ],
+  "KE 675": [
+    {
+      "aop_id": "AOP 100",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of female spawning behavior"
+    },
+    {
+      "aop_id": "AOP 101",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of pheromone release"
+    },
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    },
+    {
+      "aop_id": "AOP 63",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction"
+    }
+  ],
+  "KE 79": [
+    {
+      "aop_id": "AOP 100",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of female spawning behavior"
+    },
+    {
+      "aop_id": "AOP 101",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of pheromone release"
+    },
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    },
+    {
+      "aop_id": "AOP 28",
+      "aop_title": "Cyclooxygenase inhibition leading reproductive failure"
+    },
+    {
+      "aop_id": "AOP 63",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction"
+    }
+  ],
+  "KE 678": [
+    {
+      "aop_id": "AOP 101",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of pheromone release"
+    }
+  ],
+  "KE 681": [
+    {
+      "aop_id": "AOP 101",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via inhibition of pheromone release"
+    }
+  ],
+  "KE 687": [
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    }
+  ],
+  "KE 689": [
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    }
+  ],
+  "KE 690": [
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    }
+  ],
+  "KE 691": [
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    }
+  ],
+  "KE 692": [
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    }
+  ],
+  "KE 693": [
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    },
+    {
+      "aop_id": "AOP 558",
+      "aop_title": "Phosphodiesterase inhibition leading to heart failure"
+    }
+  ],
+  "KE 694": [
+    {
+      "aop_id": "AOP 102",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with meiotic prophase I /metaphase I transition"
+    }
+  ],
+  "KE 695": [
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    }
+  ],
+  "KE 696": [
+    {
+      "aop_id": "AOP 103",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction via interference with spindle assembly checkpoint"
+    }
+  ],
+  "KE 351": [
+    {
+      "aop_id": "AOP 104",
+      "aop_title": "Altered ion channel activity leading impaired heart function"
+    },
+    {
+      "aop_id": "AOP 113",
+      "aop_title": "Glutamate-gated chloride channel activation leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 155",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced posterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 156",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 157",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced posterior swim bladder inflation "
+    },
+    {
+      "aop_id": "AOP 158",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 16",
+      "aop_title": "Acetylcholinesterase inhibition leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 160",
+      "aop_title": "Ionotropic gamma-aminobutyric acid receptor activation mediated neurotransmission inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 161",
+      "aop_title": "Glutamate-gated chloride channel activation leading to neurotransmission inhibition associated mortality"
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 186",
+      "aop_title": "unknown MIE leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 312",
+      "aop_title": "Acetylcholinesterase Inhibition leading to Acute Mortality via Impaired Coordination & Movement​"
+    },
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    },
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    },
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    },
+    {
+      "aop_id": "AOP 413",
+      "aop_title": "Oxidation and antagonism of reduced glutathione leading to mortality via acute renal failure"
+    },
+    {
+      "aop_id": "AOP 450",
+      "aop_title": " Inhibition of AChE and activation of CYP2E1 leading to sensory axonal peripheral neuropathy and mortality"
+    },
+    {
+      "aop_id": "AOP 536",
+      "aop_title": "Estrogen receptor agonism leading to reduced survival and population growth due to renal failure"
+    },
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 608",
+      "aop_title": "Thyroid Hormone Excess Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 96",
+      "aop_title": "Axonal sodium channel modulation leading to acute mortality"
+    }
+  ],
+  "KE 697": [
+    {
+      "aop_id": "AOP 104",
+      "aop_title": "Altered ion channel activity leading impaired heart function"
+    }
+  ],
+  "KE 698": [
+    {
+      "aop_id": "AOP 104",
+      "aop_title": "Altered ion channel activity leading impaired heart function"
+    },
+    {
+      "aop_id": "AOP 552",
+      "aop_title": "Inhibiton of L-Type Calcium Channels leading to heart failure via QT interval prolongation and Torsades de Pointes (TdP)"
+    },
+    {
+      "aop_id": "AOP 553",
+      "aop_title": "Inhibition of Voltage-gated sodium channels (Na⁺ channels)  leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 559",
+      "aop_title": "Inhibition of acetylcholinesterase (AChE) leading to arrhythmias"
+    }
+  ],
+  "KE 699": [
+    {
+      "aop_id": "AOP 104",
+      "aop_title": "Altered ion channel activity leading impaired heart function"
+    }
+  ],
+  "KE 708": [
+    {
+      "aop_id": "AOP 105",
+      "aop_title": "Alpha2u-microglobulin cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat)"
+    }
+  ],
+  "KE 709": [
+    {
+      "aop_id": "AOP 105",
+      "aop_title": "Alpha2u-microglobulin cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat)"
+    },
+    {
+      "aop_id": "AOP 256",
+      "aop_title": "Inhibition of mitochondrial DNA polymerase gamma leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 257",
+      "aop_title": "Receptor mediated endocytosis and lysosomal overload leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 258",
+      "aop_title": "Renal protein alkylation leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 437",
+      "aop_title": "Inhibition of mitochondrial electron transport chain (ETC) complexes leading to kidney toxicity"
+    }
+  ],
+  "KE 710": [
+    {
+      "aop_id": "AOP 105",
+      "aop_title": "Alpha2u-microglobulin cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat)"
+    },
+    {
+      "aop_id": "AOP 116",
+      "aop_title": "Cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat) "
+    }
+  ],
+  "KE 713": [
+    {
+      "aop_id": "AOP 105",
+      "aop_title": "Alpha2u-microglobulin cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat)"
+    },
+    {
+      "aop_id": "AOP 116",
+      "aop_title": "Cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat) "
+    }
+  ],
+  "KE 714": [
+    {
+      "aop_id": "AOP 105",
+      "aop_title": "Alpha2u-microglobulin cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat)"
+    }
+  ],
+  "KE 767": [
+    {
+      "aop_id": "AOP 105",
+      "aop_title": "Alpha2u-microglobulin cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat)"
+    }
+  ],
+  "KE 718": [
+    {
+      "aop_id": "AOP 106",
+      "aop_title": "Chemical binding to tubulin in oocytes leading to aneuploid offspring"
+    }
+  ],
+  "KE 720": [
+    {
+      "aop_id": "AOP 106",
+      "aop_title": "Chemical binding to tubulin in oocytes leading to aneuploid offspring"
+    }
+  ],
+  "KE 721": [
+    {
+      "aop_id": "AOP 106",
+      "aop_title": "Chemical binding to tubulin in oocytes leading to aneuploid offspring"
+    }
+  ],
+  "KE 723": [
+    {
+      "aop_id": "AOP 106",
+      "aop_title": "Chemical binding to tubulin in oocytes leading to aneuploid offspring"
+    }
+  ],
+  "KE 728": [
+    {
+      "aop_id": "AOP 106",
+      "aop_title": "Chemical binding to tubulin in oocytes leading to aneuploid offspring"
+    }
+  ],
+  "KE 752": [
+    {
+      "aop_id": "AOP 106",
+      "aop_title": "Chemical binding to tubulin in oocytes leading to aneuploid offspring"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 435",
+      "aop_title": "Deposition of ionising energy leads to population decline via pollen abnormal"
+    }
+  ],
+  "KE 1214": [
+    {
+      "aop_id": "AOP 107",
+      "aop_title": "Constitutive androstane receptor activation leading to hepatocellular adenomas and carcinomas in the mouse and the rat"
+    }
+  ],
+  "KE 715": [
+    {
+      "aop_id": "AOP 107",
+      "aop_title": "Constitutive androstane receptor activation leading to hepatocellular adenomas and carcinomas in the mouse and the rat"
+    }
+  ],
+  "KE 716": [
+    {
+      "aop_id": "AOP 107",
+      "aop_title": "Constitutive androstane receptor activation leading to hepatocellular adenomas and carcinomas in the mouse and the rat"
+    },
+    {
+      "aop_id": "AOP 117",
+      "aop_title": "Androgen receptor activation leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 37",
+      "aop_title": "PPARα activation leading to hepatocellular adenomas and carcinomas in rodents"
+    }
+  ],
+  "KE 719": [
+    {
+      "aop_id": "AOP 107",
+      "aop_title": "Constitutive androstane receptor activation leading to hepatocellular adenomas and carcinomas in the mouse and the rat"
+    },
+    {
+      "aop_id": "AOP 108",
+      "aop_title": "Inhibition of pyruvate dehydrogenase kinase leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 117",
+      "aop_title": "Androgen receptor activation leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 118",
+      "aop_title": "Chronic cytotoxicity leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 37",
+      "aop_title": "PPARα activation leading to hepatocellular adenomas and carcinomas in rodents"
+    }
+  ],
+  "KE 774": [
+    {
+      "aop_id": "AOP 107",
+      "aop_title": "Constitutive androstane receptor activation leading to hepatocellular adenomas and carcinomas in the mouse and the rat"
+    },
+    {
+      "aop_id": "AOP 117",
+      "aop_title": "Androgen receptor activation leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 118",
+      "aop_title": "Chronic cytotoxicity leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 209": [
+    {
+      "aop_id": "AOP 108",
+      "aop_title": "Inhibition of pyruvate dehydrogenase kinase leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    },
+    {
+      "aop_id": "AOP 210",
+      "aop_title": "Activation of c-Jun N-terminal kinase (JNK) and Forkhead box O (FOXO) and reduction of WNT pathways leading to reproductive failure: Integrated multi-OMICS approach for AOP building"
+    },
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    }
+  ],
+  "KE 724": [
+    {
+      "aop_id": "AOP 108",
+      "aop_title": "Inhibition of pyruvate dehydrogenase kinase leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 726": [
+    {
+      "aop_id": "AOP 108",
+      "aop_title": "Inhibition of pyruvate dehydrogenase kinase leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 768": [
+    {
+      "aop_id": "AOP 108",
+      "aop_title": "Inhibition of pyruvate dehydrogenase kinase leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 136",
+      "aop_title": "Intracellular Acidification Induced Olfactory Epithelial Injury Leading to Site of Contact Nasal Tumors"
+    },
+    {
+      "aop_id": "AOP 284",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress leads to chronic kidney disease"
+    }
+  ],
+  "KE 769": [
+    {
+      "aop_id": "AOP 108",
+      "aop_title": "Inhibition of pyruvate dehydrogenase kinase leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 733": [
+    {
+      "aop_id": "AOP 109",
+      "aop_title": "Cytotoxicity leading to bronchioloalveolar adenomas and carcinomas (in mouse)"
+    }
+  ],
+  "KE 734": [
+    {
+      "aop_id": "AOP 109",
+      "aop_title": "Cytotoxicity leading to bronchioloalveolar adenomas and carcinomas (in mouse)"
+    }
+  ],
+  "KE 735": [
+    {
+      "aop_id": "AOP 109",
+      "aop_title": "Cytotoxicity leading to bronchioloalveolar adenomas and carcinomas (in mouse)"
+    }
+  ],
+  "KE 736": [
+    {
+      "aop_id": "AOP 109",
+      "aop_title": "Cytotoxicity leading to bronchioloalveolar adenomas and carcinomas (in mouse)"
+    }
+  ],
+  "KE 770": [
+    {
+      "aop_id": "AOP 109",
+      "aop_title": "Cytotoxicity leading to bronchioloalveolar adenomas and carcinomas (in mouse)"
+    }
+  ],
+  "KE 245": [
+    {
+      "aop_id": "AOP 11",
+      "aop_title": "Percellome Toxicogenomics Approach for AOP Building: Case study on Pentachlorophenol"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 1023": [
+    {
+      "aop_id": "AOP 110",
+      "aop_title": "Inhibition of iodide pump activity leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 119",
+      "aop_title": "Inhibition of thyroid peroxidase leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 162",
+      "aop_title": "Enhanced hepatic clearance of thyroid hormones leading to thyroid follicular cell adenomas and carcinomas in the rat and mouse"
+    },
+    {
+      "aop_id": "AOP 190",
+      "aop_title": "Type II iodothyronine deiodinase (DIO2) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 277": [
+    {
+      "aop_id": "AOP 110",
+      "aop_title": "Inhibition of iodide pump activity leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 119",
+      "aop_title": "Inhibition of thyroid peroxidase leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    },
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 175",
+      "aop_title": "Thyroperoxidase inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 176",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 188",
+      "aop_title": "Iodotyrosine deiodinase (IYD) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 192",
+      "aop_title": "Pendrin inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 193",
+      "aop_title": "Dual oxidase (DUOX) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 271",
+      "aop_title": "Inhibition of thyroid peroxidase leading to impaired fertility in fish"
+    },
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    },
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    },
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 457",
+      "aop_title": "Succinate dehydrogenase inhibition leading to increased insulin resistance through reduction in circulating thyroxine"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 65",
+      "aop_title": "XX Inhibition of Sodium Iodide Symporter and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 281": [
+    {
+      "aop_id": "AOP 110",
+      "aop_title": "Inhibition of iodide pump activity leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 119",
+      "aop_title": "Inhibition of thyroid peroxidase leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    },
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 162",
+      "aop_title": "Enhanced hepatic clearance of thyroid hormones leading to thyroid follicular cell adenomas and carcinomas in the rat and mouse"
+    },
+    {
+      "aop_id": "AOP 175",
+      "aop_title": "Thyroperoxidase inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 176",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 188",
+      "aop_title": "Iodotyrosine deiodinase (IYD) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 192",
+      "aop_title": "Pendrin inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 193",
+      "aop_title": "Dual oxidase (DUOX) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 194",
+      "aop_title": "Hepatic nuclear receptor activation leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    },
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    },
+    {
+      "aop_id": "AOP 366",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein transthyretin (TTR) leading to altered amphibian metamorphosis "
+    },
+    {
+      "aop_id": "AOP 367",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein thyroid binding globulin (TBG) leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 457",
+      "aop_title": "Succinate dehydrogenase inhibition leading to increased insulin resistance through reduction in circulating thyroxine"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 65",
+      "aop_title": "XX Inhibition of Sodium Iodide Symporter and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 424": [
+    {
+      "aop_id": "AOP 110",
+      "aop_title": "Inhibition of iodide pump activity leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 176",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 65",
+      "aop_title": "XX Inhibition of Sodium Iodide Symporter and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 739": [
+    {
+      "aop_id": "AOP 110",
+      "aop_title": "Inhibition of iodide pump activity leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 119",
+      "aop_title": "Inhibition of thyroid peroxidase leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 162",
+      "aop_title": "Enhanced hepatic clearance of thyroid hormones leading to thyroid follicular cell adenomas and carcinomas in the rat and mouse"
+    }
+  ],
+  "KE 740": [
+    {
+      "aop_id": "AOP 110",
+      "aop_title": "Inhibition of iodide pump activity leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 119",
+      "aop_title": "Inhibition of thyroid peroxidase leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 162",
+      "aop_title": "Enhanced hepatic clearance of thyroid hormones leading to thyroid follicular cell adenomas and carcinomas in the rat and mouse"
+    }
+  ],
+  "KE 741": [
+    {
+      "aop_id": "AOP 110",
+      "aop_title": "Inhibition of iodide pump activity leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 119",
+      "aop_title": "Inhibition of thyroid peroxidase leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 162",
+      "aop_title": "Enhanced hepatic clearance of thyroid hormones leading to thyroid follicular cell adenomas and carcinomas in the rat and mouse"
+    }
+  ],
+  "KE 1614": [
+    {
+      "aop_id": "AOP 111",
+      "aop_title": "Decrease in androgen receptor activity leading to Leydig cell tumors (in rat)"
+    },
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    },
+    {
+      "aop_id": "AOP 305",
+      "aop_title": "5α-reductase inhibition leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 306",
+      "aop_title": "Androgen receptor (AR) antagonism leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 307",
+      "aop_title": "Decreased testosterone synthesis leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 344",
+      "aop_title": "Androgen receptor (AR) antagonism leading to nipple retention (NR) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 345",
+      "aop_title": "Androgen receptor (AR) antagonism leading to decreased fertility in females"
+    },
+    {
+      "aop_id": "AOP 372",
+      "aop_title": "Androgen receptor antagonism leading to testicular cancer "
+    },
+    {
+      "aop_id": "AOP 477",
+      "aop_title": "Androgen receptor (AR) antagonism leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 570",
+      "aop_title": "Decreased testosterone synthesis leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 571",
+      "aop_title": "5α-reductase inhibition leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 575",
+      "aop_title": "Decreased testosterone synthesis leading to increased nipple retention (NR) in male (rodent) offspring"
+    },
+    {
+      "aop_id": "AOP 576",
+      "aop_title": "5α-reductase inhibition leading to increased nipple retention (NR) in male (rodent) offspring"
+    }
+  ],
+  "KE 743": [
+    {
+      "aop_id": "AOP 111",
+      "aop_title": "Decrease in androgen receptor activity leading to Leydig cell tumors (in rat)"
+    }
+  ],
+  "KE 744": [
+    {
+      "aop_id": "AOP 111",
+      "aop_title": "Decrease in androgen receptor activity leading to Leydig cell tumors (in rat)"
+    },
+    {
+      "aop_id": "AOP 120",
+      "aop_title": "Inhibition of 5α-reductase leading to Leydig cell tumors (in rat)"
+    }
+  ],
+  "KE 745": [
+    {
+      "aop_id": "AOP 111",
+      "aop_title": "Decrease in androgen receptor activity leading to Leydig cell tumors (in rat)"
+    },
+    {
+      "aop_id": "AOP 120",
+      "aop_title": "Inhibition of 5α-reductase leading to Leydig cell tumors (in rat)"
+    }
+  ],
+  "KE 754": [
+    {
+      "aop_id": "AOP 111",
+      "aop_title": "Decrease in androgen receptor activity leading to Leydig cell tumors (in rat)"
+    }
+  ],
+  "KE 111": [
+    {
+      "aop_id": "AOP 112",
+      "aop_title": "Increased dopaminergic activity leading to endometrial adenocarcinomas (in Wistar rat)"
+    },
+    {
+      "aop_id": "AOP 167",
+      "aop_title": "Early-life estrogen receptor agonism leading to endometrial adenosquamous carcinoma via promotion of sine oculis homeobox 1 progenitor cells"
+    },
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 52",
+      "aop_title": "ER agonism leading to skewed sex ratios due to altered sexual differentiation in males"
+    },
+    {
+      "aop_id": "AOP 53",
+      "aop_title": "ER agonism leading to reduced survival due to renal failure"
+    },
+    {
+      "aop_id": "AOP 536",
+      "aop_title": "Estrogen receptor agonism leading to reduced survival and population growth due to renal failure"
+    },
+    {
+      "aop_id": "AOP 537",
+      "aop_title": "Estrogen receptor agonism leads to reduced fecundity via increased vitellogenin in the liver"
+    }
+  ],
+  "KE 746": [
+    {
+      "aop_id": "AOP 112",
+      "aop_title": "Increased dopaminergic activity leading to endometrial adenocarcinomas (in Wistar rat)"
+    },
+    {
+      "aop_id": "AOP 611",
+      "aop_title": "Behavioral abnormalities due to increased expression of dopamine transporter and receptor-related genes"
+    }
+  ],
+  "KE 747": [
+    {
+      "aop_id": "AOP 112",
+      "aop_title": "Increased dopaminergic activity leading to endometrial adenocarcinomas (in Wistar rat)"
+    }
+  ],
+  "KE 749": [
+    {
+      "aop_id": "AOP 112",
+      "aop_title": "Increased dopaminergic activity leading to endometrial adenocarcinomas (in Wistar rat)"
+    }
+  ],
+  "KE 772": [
+    {
+      "aop_id": "AOP 112",
+      "aop_title": "Increased dopaminergic activity leading to endometrial adenocarcinomas (in Wistar rat)"
+    },
+    {
+      "aop_id": "AOP 167",
+      "aop_title": "Early-life estrogen receptor agonism leading to endometrial adenosquamous carcinoma via promotion of sine oculis homeobox 1 progenitor cells"
+    },
+    {
+      "aop_id": "AOP 503",
+      "aop_title": "Activation of uterine estrogen receptor-alfa leading to endometrial adenocarcinoma, via epigenetic modulation"
+    }
+  ],
+  "KE 773": [
+    {
+      "aop_id": "AOP 112",
+      "aop_title": "Increased dopaminergic activity leading to endometrial adenocarcinomas (in Wistar rat)"
+    }
+  ],
+  "KE 760": [
+    {
+      "aop_id": "AOP 113",
+      "aop_title": "Glutamate-gated chloride channel activation leading to acute mortality"
+    }
+  ],
+  "KE 761": [
+    {
+      "aop_id": "AOP 113",
+      "aop_title": "Glutamate-gated chloride channel activation leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 160",
+      "aop_title": "Ionotropic gamma-aminobutyric acid receptor activation mediated neurotransmission inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 161",
+      "aop_title": "Glutamate-gated chloride channel activation leading to neurotransmission inhibition associated mortality"
+    }
+  ],
+  "KE 763": [
+    {
+      "aop_id": "AOP 113",
+      "aop_title": "Glutamate-gated chloride channel activation leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 233",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 235",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via K Channel Opening"
+    }
+  ],
+  "KE 764": [
+    {
+      "aop_id": "AOP 113",
+      "aop_title": "Glutamate-gated chloride channel activation leading to acute mortality"
+    }
+  ],
+  "KE 765": [
+    {
+      "aop_id": "AOP 113",
+      "aop_title": "Glutamate-gated chloride channel activation leading to acute mortality"
+    }
+  ],
+  "KE 766": [
+    {
+      "aop_id": "AOP 114",
+      "aop_title": "HPPD inhibition leading to corneal papillomas and carcinomas (in rat)"
+    }
+  ],
+  "KE 775": [
+    {
+      "aop_id": "AOP 114",
+      "aop_title": "HPPD inhibition leading to corneal papillomas and carcinomas (in rat)"
+    }
+  ],
+  "KE 776": [
+    {
+      "aop_id": "AOP 114",
+      "aop_title": "HPPD inhibition leading to corneal papillomas and carcinomas (in rat)"
+    }
+  ],
+  "KE 777": [
+    {
+      "aop_id": "AOP 114",
+      "aop_title": "HPPD inhibition leading to corneal papillomas and carcinomas (in rat)"
+    }
+  ],
+  "KE 778": [
+    {
+      "aop_id": "AOP 114",
+      "aop_title": "HPPD inhibition leading to corneal papillomas and carcinomas (in rat)"
+    }
+  ],
+  "KE 779": [
+    {
+      "aop_id": "AOP 114",
+      "aop_title": "HPPD inhibition leading to corneal papillomas and carcinomas (in rat)"
+    },
+    {
+      "aop_id": "AOP 115",
+      "aop_title": "Epithelial cytotoxicity leading to forestomach tumors (in mouse and rat)"
+    }
+  ],
+  "KE 149": [
+    {
+      "aop_id": "AOP 115",
+      "aop_title": "Epithelial cytotoxicity leading to forestomach tumors (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 206",
+      "aop_title": "Peroxisome proliferator-activated receptors γ inactivation leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    },
+    {
+      "aop_id": "AOP 280",
+      "aop_title": "α-diketone-induced bronchiolitis obliterans"
+    },
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 505",
+      "aop_title": "Reactive Oxygen Species (ROS) formation leads to cancer via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 544",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via increased inflammation"
+    },
+    {
+      "aop_id": "AOP 577",
+      "aop_title": "AhR activation leading to endometriosis"
+    }
+  ],
+  "KE 780": [
+    {
+      "aop_id": "AOP 115",
+      "aop_title": "Epithelial cytotoxicity leading to forestomach tumors (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    }
+  ],
+  "KE 781": [
+    {
+      "aop_id": "AOP 115",
+      "aop_title": "Epithelial cytotoxicity leading to forestomach tumors (in mouse and rat)"
+    }
+  ],
+  "KE 782": [
+    {
+      "aop_id": "AOP 115",
+      "aop_title": "Epithelial cytotoxicity leading to forestomach tumors (in mouse and rat)"
+    }
+  ],
+  "KE 783": [
+    {
+      "aop_id": "AOP 116",
+      "aop_title": "Cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat) "
+    }
+  ],
+  "KE 784": [
+    {
+      "aop_id": "AOP 116",
+      "aop_title": "Cytotoxicity leading to renal tubular adenomas and carcinomas (in male rat) "
+    }
+  ],
+  "KE 25": [
+    {
+      "aop_id": "AOP 117",
+      "aop_title": "Androgen receptor activation leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 376",
+      "aop_title": "Androgen receptor agonism leading to male-biased sex ratio"
+    },
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 547",
+      "aop_title": "Androgen receptor agonism leading to long anogenital distance in female offspring"
+    }
+  ],
+  "KE 786": [
+    {
+      "aop_id": "AOP 118",
+      "aop_title": "Chronic cytotoxicity leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 787": [
+    {
+      "aop_id": "AOP 118",
+      "aop_title": "Chronic cytotoxicity leading to hepatocellular adenomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 279": [
+    {
+      "aop_id": "AOP 119",
+      "aop_title": "Inhibition of thyroid peroxidase leading to follicular cell adenomas and carcinomas (in rat and mouse)"
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 175",
+      "aop_title": "Thyroperoxidase inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 271",
+      "aop_title": "Inhibition of thyroid peroxidase leading to impaired fertility in fish"
+    },
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    },
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    },
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    }
+  ],
+  "KE 188": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 3",
+      "aop_title": "Inhibition of the mitochondrial complex I of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 374",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on brain cells (neuronal and non-neuronal) leads to neuroinflammation resulting in encephalitis"
+    },
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    },
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    },
+    {
+      "aop_id": "AOP 636",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human amyotrophic lateral sclerosis (ALS)"
+    }
+  ],
+  "KE 195": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    },
+    {
+      "aop_id": "AOP 522",
+      "aop_title": "Estrogen antagonism leading to increased risk of autism-like behavior"
+    }
+  ],
+  "KE 201": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    }
+  ],
+  "KE 341": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    },
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    },
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    },
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    },
+    {
+      "aop_id": "AOP 499",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via disrupted neurotransmitter release"
+    },
+    {
+      "aop_id": "AOP 500",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via ROS and apoptosis"
+    },
+    {
+      "aop_id": "AOP 520",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 533",
+      "aop_title": "Retinoic acid receptor antagonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    },
+    {
+      "aop_id": "AOP 77",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony death/failure 1"
+    },
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    },
+    {
+      "aop_id": "AOP 88",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure via abnormal role change within caste"
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    },
+    {
+      "aop_id": "AOP 99",
+      "aop_title": "Histamine (H2) receptor antagonism leading to reduced survival"
+    }
+  ],
+  "KE 352": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 374",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on brain cells (neuronal and non-neuronal) leads to neuroinflammation resulting in encephalitis"
+    },
+    {
+      "aop_id": "AOP 450",
+      "aop_title": " Inhibition of AChE and activation of CYP2E1 leading to sensory axonal peripheral neuropathy and mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    },
+    {
+      "aop_id": "AOP 500",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via ROS and apoptosis"
+    }
+  ],
+  "KE 381": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    },
+    {
+      "aop_id": "AOP 375",
+      "aop_title": "test AOP"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 52": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    }
+  ],
+  "KE 55": [
+    {
+      "aop_id": "AOP 12",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development leads to neurodegeneration with impairment in learning and memory in aging"
+    },
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    },
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 264",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via ATP depletion associated cell death"
+    },
+    {
+      "aop_id": "AOP 265",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via increased cytosolic calcium"
+    },
+    {
+      "aop_id": "AOP 266",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via decreased Na-K ATPase activity"
+    },
+    {
+      "aop_id": "AOP 268",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via mitochondrial swelling"
+    },
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 325",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell death"
+    },
+    {
+      "aop_id": "AOP 331",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 333",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 38",
+      "aop_title": "Protein Alkylation leading to Liver Fibrosis"
+    },
+    {
+      "aop_id": "AOP 479",
+      "aop_title": "Mitochondrial complexes inhibition leading to left ventricular function decrease via increased myocardial oxidative stress"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    },
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    },
+    {
+      "aop_id": "AOP 494",
+      "aop_title": "AhR activation leading to liver fibrosis "
+    },
+    {
+      "aop_id": "AOP 530",
+      "aop_title": "Endocytotic lysosomal uptake leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 596",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 599",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 1617": [
+    {
+      "aop_id": "AOP 120",
+      "aop_title": "Inhibition of 5α-reductase leading to Leydig cell tumors (in rat)"
+    },
+    {
+      "aop_id": "AOP 289",
+      "aop_title": "Inhibition of 5α-reductase leading to impaired fecundity in female fish"
+    },
+    {
+      "aop_id": "AOP 305",
+      "aop_title": "5α-reductase inhibition leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 571",
+      "aop_title": "5α-reductase inhibition leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 576",
+      "aop_title": "5α-reductase inhibition leading to increased nipple retention (NR) in male (rodent) offspring"
+    }
+  ],
+  "KE 1690": [
+    {
+      "aop_id": "AOP 120",
+      "aop_title": "Inhibition of 5α-reductase leading to Leydig cell tumors (in rat)"
+    },
+    {
+      "aop_id": "AOP 124",
+      "aop_title": "HMG-CoA reductase inhibition leading to decreased fertility"
+    },
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    },
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    },
+    {
+      "aop_id": "AOP 307",
+      "aop_title": "Decreased testosterone synthesis leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    },
+    {
+      "aop_id": "AOP 526",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Impaired, Spermatogenesis"
+    },
+    {
+      "aop_id": "AOP 570",
+      "aop_title": "Decreased testosterone synthesis leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 575",
+      "aop_title": "Decreased testosterone synthesis leading to increased nipple retention (NR) in male (rodent) offspring"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 64",
+      "aop_title": "Glucocorticoid Receptor (GR) Mediated Adult Leydig Cell Dysfunction Leading to Decreased Male Fertility"
+    }
+  ],
+  "KE 791": [
+    {
+      "aop_id": "AOP 120",
+      "aop_title": "Inhibition of 5α-reductase leading to Leydig cell tumors (in rat)"
+    }
+  ],
+  "KE 793": [
+    {
+      "aop_id": "AOP 121",
+      "aop_title": "Urinary bladder calculi leading to urothelial papillomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 794": [
+    {
+      "aop_id": "AOP 121",
+      "aop_title": "Urinary bladder calculi leading to urothelial papillomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 795": [
+    {
+      "aop_id": "AOP 121",
+      "aop_title": "Urinary bladder calculi leading to urothelial papillomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 335",
+      "aop_title": "AOP for urothelial carcinogenesis due to chemical cytotoxicity by mitochondrial impairment "
+    }
+  ],
+  "KE 796": [
+    {
+      "aop_id": "AOP 121",
+      "aop_title": "Urinary bladder calculi leading to urothelial papillomas and carcinomas (in mouse and rat)"
+    },
+    {
+      "aop_id": "AOP 335",
+      "aop_title": "AOP for urothelial carcinogenesis due to chemical cytotoxicity by mitochondrial impairment "
+    }
+  ],
+  "KE 797": [
+    {
+      "aop_id": "AOP 121",
+      "aop_title": "Urinary bladder calculi leading to urothelial papillomas and carcinomas (in mouse and rat)"
+    }
+  ],
+  "KE 219": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    },
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 271",
+      "aop_title": "Inhibition of thyroid peroxidase leading to impaired fertility in fish"
+    },
+    {
+      "aop_id": "AOP 289",
+      "aop_title": "Inhibition of 5α-reductase leading to impaired fecundity in female fish"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    },
+    {
+      "aop_id": "AOP 7",
+      "aop_title": "Aromatase (Cyp19a1) reduction leading to impaired fertility in adult female"
+    }
+  ],
+  "KE 221": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 271",
+      "aop_title": "Inhibition of thyroid peroxidase leading to impaired fertility in fish"
+    },
+    {
+      "aop_id": "AOP 289",
+      "aop_title": "Inhibition of 5α-reductase leading to impaired fecundity in female fish"
+    },
+    {
+      "aop_id": "AOP 30",
+      "aop_title": "Estrogen receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    }
+  ],
+  "KE 285": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 30",
+      "aop_title": "Estrogen receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    }
+  ],
+  "KE 3": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    },
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 7",
+      "aop_title": "Aromatase (Cyp19a1) reduction leading to impaired fertility in adult female"
+    }
+  ],
+  "KE 309": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 30",
+      "aop_title": "Estrogen receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    }
+  ],
+  "KE 78": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    },
+    {
+      "aop_id": "AOP 216",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    },
+    {
+      "aop_id": "AOP 238",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 271",
+      "aop_title": "Inhibition of thyroid peroxidase leading to impaired fertility in fish"
+    },
+    {
+      "aop_id": "AOP 289",
+      "aop_title": "Inhibition of 5α-reductase leading to impaired fecundity in female fish"
+    },
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 299",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 30",
+      "aop_title": "Estrogen receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 311",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 537",
+      "aop_title": "Estrogen receptor agonism leads to reduced fecundity via increased vitellogenin in the liver"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    }
+  ],
+  "KE 798": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 546",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer through hypoxic-like mechanisms"
+    }
+  ],
+  "KE 799": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    }
+  ],
+  "KE 800": [
+    {
+      "aop_id": "AOP 122",
+      "aop_title": "Prolyl hydroxylase inhibition leading to reproductive dysfunction via increased HIF1 heterodimer formation"
+    },
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    }
+  ],
+  "KE 801": [
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    }
+  ],
+  "KE 802": [
+    {
+      "aop_id": "AOP 123",
+      "aop_title": "Unknown MIE leading to reproductive dysfunction via increased HIF-1alpha transcription"
+    }
+  ],
+  "KE 330": [
+    {
+      "aop_id": "AOP 124",
+      "aop_title": "HMG-CoA reductase inhibition leading to decreased fertility"
+    }
+  ],
+  "KE 804": [
+    {
+      "aop_id": "AOP 124",
+      "aop_title": "HMG-CoA reductase inhibition leading to decreased fertility"
+    }
+  ],
+  "KE 805": [
+    {
+      "aop_id": "AOP 124",
+      "aop_title": "HMG-CoA reductase inhibition leading to decreased fertility"
+    }
+  ],
+  "KE 807": [
+    {
+      "aop_id": "AOP 124",
+      "aop_title": "HMG-CoA reductase inhibition leading to decreased fertility"
+    },
+    {
+      "aop_id": "AOP 323",
+      "aop_title": "PPARalpha Agonism Leading to Decreased Viable Offspring via Decreased 11-Ketotestosterone"
+    }
+  ],
+  "KE 809": [
+    {
+      "aop_id": "AOP 124",
+      "aop_title": "HMG-CoA reductase inhibition leading to decreased fertility"
+    }
+  ],
+  "KE 527": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 529": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 530": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 566",
+      "aop_title": "Decreased, GnRH pulsatility/release leading to estradiol availability, increased via impaired ovulation"
+    },
+    {
+      "aop_id": "AOP 609",
+      "aop_title": "Activation, estrogen receptor alpha leads to prolonged estrus cycle via decreased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 531": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 512",
+      "aop_title": "Reduced availability of GnRH leading to uterine adenocarcinoma via increased estrogen availability at target organ level "
+    },
+    {
+      "aop_id": "AOP 566",
+      "aop_title": "Decreased, GnRH pulsatility/release leading to estradiol availability, increased via impaired ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 532": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 533": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 534": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 535": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 536": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    },
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 848": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    }
+  ],
+  "KE 849": [
+    {
+      "aop_id": "AOP 126",
+      "aop_title": "Alpha-noradrenergic antagonism leads to reduced fecundity via delayed ovulation"
+    }
+  ],
+  "KE 813": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 814": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    },
+    {
+      "aop_id": "AOP 256",
+      "aop_title": "Inhibition of mitochondrial DNA polymerase gamma leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 257",
+      "aop_title": "Receptor mediated endocytosis and lysosomal overload leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 258",
+      "aop_title": "Renal protein alkylation leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 437",
+      "aop_title": "Inhibition of mitochondrial electron transport chain (ETC) complexes leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    }
+  ],
+  "KE 818": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 819": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 820": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 821": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 823": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 824": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 825": [
+    {
+      "aop_id": "AOP 128",
+      "aop_title": "Kidney dysfunction by decreased thyroid hormone"
+    }
+  ],
+  "KE 382": [
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    }
+  ],
+  "KE 383": [
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    }
+  ],
+  "KE 385": [
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    },
+    {
+      "aop_id": "AOP 533",
+      "aop_title": "Retinoic acid receptor antagonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 386": [
+    {
+      "aop_id": "AOP 13",
+      "aop_title": "Chronic binding of antagonist to N-methyl-D-aspartate receptors (NMDARs) during brain development induces impairment of learning and memory abilities"
+    },
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 405",
+      "aop_title": "Organo-Phosphate Chemicals induced inhibition of AChE  leading to impaired cognitive function"
+    },
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    },
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    },
+    {
+      "aop_id": "AOP 501",
+      "aop_title": "Excessive iron accumulation leading to neurological disorders"
+    },
+    {
+      "aop_id": "AOP 522",
+      "aop_title": "Estrogen antagonism leading to increased risk of autism-like behavior"
+    },
+    {
+      "aop_id": "AOP 533",
+      "aop_title": "Retinoic acid receptor antagonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    },
+    {
+      "aop_id": "AOP 636",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human amyotrophic lateral sclerosis (ALS)"
+    },
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    }
+  ],
+  "KE 177": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    },
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 178",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to mitochondrial dysfunction and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 205",
+      "aop_title": "AOP from chemical insult to cell death"
+    },
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    },
+    {
+      "aop_id": "AOP 256",
+      "aop_title": "Inhibition of mitochondrial DNA polymerase gamma leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 258",
+      "aop_title": "Renal protein alkylation leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 3",
+      "aop_title": "Inhibition of the mitochondrial complex I of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 335",
+      "aop_title": "AOP for urothelial carcinogenesis due to chemical cytotoxicity by mitochondrial impairment "
+    },
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 423",
+      "aop_title": " Toxicological mechanisms of hepatocyte apoptosis through the PARP1 dependent cell death pathway "
+    },
+    {
+      "aop_id": "AOP 437",
+      "aop_title": "Inhibition of mitochondrial electron transport chain (ETC) complexes leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 479",
+      "aop_title": "Mitochondrial complexes inhibition leading to left ventricular function decrease via increased myocardial oxidative stress"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    },
+    {
+      "aop_id": "AOP 480",
+      "aop_title": "Mitochondrial complexes inhibition leading to heart failure via decreased ATP production"
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    },
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    },
+    {
+      "aop_id": "AOP 500",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via ROS and apoptosis"
+    },
+    {
+      "aop_id": "AOP 509",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating apoptosis signal pathway and mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    },
+    {
+      "aop_id": "AOP 530",
+      "aop_title": "Endocytotic lysosomal uptake leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 587",
+      "aop_title": "Inhibition of the mitochondrial complex III of nigro-striatal neurons leads to parkinsonian motor deficits "
+    },
+    {
+      "aop_id": "AOP 588",
+      "aop_title": "Inhibition of the mitochondrial complex II of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 589",
+      "aop_title": "Inhibition of the mitochondrial complex IV of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 636",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human amyotrophic lateral sclerosis (ALS)"
+    },
+    {
+      "aop_id": "AOP 77",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony death/failure 1"
+    },
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 79",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to impaired hive thermoregulation and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    }
+  ],
+  "KE 828": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 829": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 831": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    },
+    {
+      "aop_id": "AOP 257",
+      "aop_title": "Receptor mediated endocytosis and lysosomal overload leading to kidney toxicity"
+    }
+  ],
+  "KE 833": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 835": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 836": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 837": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 838": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 839": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 840": [
+    {
+      "aop_id": "AOP 130",
+      "aop_title": "Phospholipase A2 (LPLA2) inhibitors leading to hepatotoxicity"
+    }
+  ],
+  "KE 18": [
+    {
+      "aop_id": "AOP 131",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to uroporphyria"
+    },
+    {
+      "aop_id": "AOP 150",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via reduced VEGF"
+    },
+    {
+      "aop_id": "AOP 151",
+      "aop_title": "AhR activation leading to preeclampsia"
+    },
+    {
+      "aop_id": "AOP 21",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via increased COX-2"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 414",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through TGF-β dependent fibrosis toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 415",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 416",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 417",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 418",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 419",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through P53 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 420",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through sustained NRF2 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    },
+    {
+      "aop_id": "AOP 455",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 456",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced cardiovascular toxicity"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 494",
+      "aop_title": "AhR activation leading to liver fibrosis "
+    },
+    {
+      "aop_id": "AOP 563",
+      "aop_title": "Aryl hydrocarbon Receptor (AHR) activation causes Premature Ovarian Insufficiency via Bax mediated apoptosis"
+    },
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 577",
+      "aop_title": "AhR activation leading to endometriosis"
+    },
+    {
+      "aop_id": "AOP 578",
+      "aop_title": "AhR activation leading to cancer progression via immunosuppression"
+    }
+  ],
+  "KE 369": [
+    {
+      "aop_id": "AOP 131",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to uroporphyria"
+    }
+  ],
+  "KE 844": [
+    {
+      "aop_id": "AOP 131",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to uroporphyria"
+    }
+  ],
+  "KE 845": [
+    {
+      "aop_id": "AOP 131",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to uroporphyria"
+    }
+  ],
+  "KE 846": [
+    {
+      "aop_id": "AOP 131",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to uroporphyria"
+    }
+  ],
+  "KE 850": [
+    {
+      "aop_id": "AOP 131",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to uroporphyria"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 280": [
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    },
+    {
+      "aop_id": "AOP 65",
+      "aop_title": "XX Inhibition of Sodium Iodide Symporter and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 402": [
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 300",
+      "aop_title": "Thyroid Receptor Antagonism and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 405",
+      "aop_title": "Organo-Phosphate Chemicals induced inhibition of AChE  leading to impaired cognitive function"
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 442",
+      "aop_title": "Binding to voltage gate sodium channels during development leads to cognitive impairment"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 485",
+      "aop_title": "Thyroid hormone antagonism leading to impaired oligodendrocyte maturation during development and subsequent decreased cognition"
+    },
+    {
+      "aop_id": "AOP 486",
+      "aop_title": "Binding to the extracellular protein laminin leading to decreased cognitive function"
+    },
+    {
+      "aop_id": "AOP 487",
+      "aop_title": "Unknown MIE altering cholesterol metabolism leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 488",
+      "aop_title": "Increased reactive oxygen species production leading to decreased cognitive function"
+    },
+    {
+      "aop_id": "AOP 489",
+      "aop_title": "Inhibition of voltage-gated sodium channels leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 581",
+      "aop_title": "Glucocorticoid receptor (GR) activation during development leads to cognitive function (COG) decrease"
+    },
+    {
+      "aop_id": "AOP 65",
+      "aop_title": "XX Inhibition of Sodium Iodide Symporter and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 425": [
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 176",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 188",
+      "aop_title": "Iodotyrosine deiodinase (IYD) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    }
+  ],
+  "KE 756": [
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 300",
+      "aop_title": "Thyroid Receptor Antagonism and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 757": [
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 300",
+      "aop_title": "Thyroid Receptor Antagonism and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 442",
+      "aop_title": "Binding to voltage gate sodium channels during development leads to cognitive impairment"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 758": [
+    {
+      "aop_id": "AOP 134",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 300",
+      "aop_title": "Thyroid Receptor Antagonism and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 42",
+      "aop_title": "Inhibition of Thyroperoxidase and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 442",
+      "aop_title": "Binding to voltage gate sodium channels during development leads to cognitive impairment"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 867": [
+    {
+      "aop_id": "AOP 136",
+      "aop_title": "Intracellular Acidification Induced Olfactory Epithelial Injury Leading to Site of Contact Nasal Tumors"
+    }
+  ],
+  "KE 868": [
+    {
+      "aop_id": "AOP 136",
+      "aop_title": "Intracellular Acidification Induced Olfactory Epithelial Injury Leading to Site of Contact Nasal Tumors"
+    }
+  ],
+  "KE 869": [
+    {
+      "aop_id": "AOP 136",
+      "aop_title": "Intracellular Acidification Induced Olfactory Epithelial Injury Leading to Site of Contact Nasal Tumors"
+    }
+  ],
+  "KE 870": [
+    {
+      "aop_id": "AOP 136",
+      "aop_title": "Intracellular Acidification Induced Olfactory Epithelial Injury Leading to Site of Contact Nasal Tumors"
+    },
+    {
+      "aop_id": "AOP 272",
+      "aop_title": "Deposition of energy leading to lung cancer"
+    },
+    {
+      "aop_id": "AOP 303",
+      "aop_title": "Frustrated phagocytosis-induced lung cancer"
+    },
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    },
+    {
+      "aop_id": "AOP 420",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through sustained NRF2 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 872": [
+    {
+      "aop_id": "AOP 136",
+      "aop_title": "Intracellular Acidification Induced Olfactory Epithelial Injury Leading to Site of Contact Nasal Tumors"
+    }
+  ],
+  "KE 876": [
+    {
+      "aop_id": "AOP 136",
+      "aop_title": "Intracellular Acidification Induced Olfactory Epithelial Injury Leading to Site of Contact Nasal Tumors"
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    }
+  ],
+  "KE 1096": [
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    }
+  ],
+  "KE 1097": [
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 186",
+      "aop_title": "unknown MIE leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    }
+  ],
+  "KE 1098": [
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 186",
+      "aop_title": "unknown MIE leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 551",
+      "aop_title": "Increased Muscarinic M2 Receptor leading to Arrhythmia"
+    }
+  ],
+  "KE 1102": [
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    }
+  ],
+  "KE 1106": [
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 186",
+      "aop_title": "unknown MIE leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 551",
+      "aop_title": "Increased Muscarinic M2 Receptor leading to Arrhythmia"
+    },
+    {
+      "aop_id": "AOP 554",
+      "aop_title": "β-adrenergic receptor agonists leading to arrhythmias."
+    },
+    {
+      "aop_id": "AOP 559",
+      "aop_title": "Inhibition of acetylcholinesterase (AChE) leading to arrhythmias"
+    },
+    {
+      "aop_id": "AOP 560",
+      "aop_title": "Inhibition of Funny current (If) leading to Arrhythmias"
+    },
+    {
+      "aop_id": "AOP 562",
+      "aop_title": "HCN Channel Inhibition leading to Arrhythmias"
+    }
+  ],
+  "KE 1392": [
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 171",
+      "aop_title": "Chronic cytotoxicity of the serous membrane leading to pleural/peritoneal mesotheliomas in the rat."
+    },
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 186",
+      "aop_title": "unknown MIE leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 220",
+      "aop_title": "Cyp2E1 Activation Leading to Liver Cancer"
+    },
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    },
+    {
+      "aop_id": "AOP 260",
+      "aop_title": "CYP2E1 activation and formation of protein adducts leading to neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 284",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress leads to chronic kidney disease"
+    },
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 325",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell death"
+    },
+    {
+      "aop_id": "AOP 326",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 331",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 332",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 333",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 411",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function "
+    },
+    {
+      "aop_id": "AOP 424",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function via CFTR dysfunction"
+    },
+    {
+      "aop_id": "AOP 425",
+      "aop_title": "Oxidative Stress Leading to Decreased Lung Function via Decreased FOXJ1"
+    },
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    },
+    {
+      "aop_id": "AOP 437",
+      "aop_title": "Inhibition of mitochondrial electron transport chain (ETC) complexes leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 450",
+      "aop_title": " Inhibition of AChE and activation of CYP2E1 leading to sensory axonal peripheral neuropathy and mortality"
+    },
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    },
+    {
+      "aop_id": "AOP 457",
+      "aop_title": "Succinate dehydrogenase inhibition leading to increased insulin resistance through reduction in circulating thyroxine"
+    },
+    {
+      "aop_id": "AOP 459",
+      "aop_title": "AhR activation in the thyroid leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 462",
+      "aop_title": "Activation of reactive oxygen species leading the atherosclerosis"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 479",
+      "aop_title": "Mitochondrial complexes inhibition leading to left ventricular function decrease via increased myocardial oxidative stress"
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    },
+    {
+      "aop_id": "AOP 482",
+      "aop_title": "Deposition of energy leading to occurrence of bone loss"
+    },
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    },
+    {
+      "aop_id": "AOP 488",
+      "aop_title": "Increased reactive oxygen species production leading to decreased cognitive function"
+    },
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    },
+    {
+      "aop_id": "AOP 501",
+      "aop_title": "Excessive iron accumulation leading to neurological disorders"
+    },
+    {
+      "aop_id": "AOP 505",
+      "aop_title": "Reactive Oxygen Species (ROS) formation leads to cancer via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 507",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 509",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating apoptosis signal pathway and mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    },
+    {
+      "aop_id": "AOP 521",
+      "aop_title": "Essential element imbalance leads to reproductive failure via oxidative stress"
+    },
+    {
+      "aop_id": "AOP 534",
+      "aop_title": "Succinate dehydrogenase (SDH) inhibition leads to oxidative stress"
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    },
+    {
+      "aop_id": "AOP 538",
+      "aop_title": "Adverse outcome pathway of PFAS-induced vascular disrupting effects  via activating oxidative stress related pathways "
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 596",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 598",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 599",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 600",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell growth"
+    },
+    {
+      "aop_id": "AOP 601",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    },
+    {
+      "aop_id": "AOP 603",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 608",
+      "aop_title": "Thyroid Hormone Excess Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    },
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    },
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 877": [
+    {
+      "aop_id": "AOP 138",
+      "aop_title": "Organic anion transporter (OAT1) inhibition leading to renal failure and mortality"
+    }
+  ],
+  "KE 155": [
+    {
+      "aop_id": "AOP 139",
+      "aop_title": "Alkylation of DNA leading to cancer 1"
+    },
+    {
+      "aop_id": "AOP 141",
+      "aop_title": "Alkylation of DNA leading to cancer 2"
+    },
+    {
+      "aop_id": "AOP 15",
+      "aop_title": "Alkylation of DNA in male pre-meiotic germ cells leading to heritable mutations"
+    },
+    {
+      "aop_id": "AOP 272",
+      "aop_title": "Deposition of energy leading to lung cancer"
+    },
+    {
+      "aop_id": "AOP 296",
+      "aop_title": "Oxidative DNA damage leading to chromosomal aberrations and mutations"
+    },
+    {
+      "aop_id": "AOP 322",
+      "aop_title": "Alkylation of DNA leading to decreased sperm count"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 325",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell death"
+    },
+    {
+      "aop_id": "AOP 397",
+      "aop_title": "Bulky DNA adducts leading to mutations"
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    },
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    },
+    {
+      "aop_id": "AOP 644",
+      "aop_title": "Bulky DNA adducts leading to chromosomal aberrations and mutations"
+    }
+  ],
+  "KE 185": [
+    {
+      "aop_id": "AOP 139",
+      "aop_title": "Alkylation of DNA leading to cancer 1"
+    },
+    {
+      "aop_id": "AOP 141",
+      "aop_title": "Alkylation of DNA leading to cancer 2"
+    },
+    {
+      "aop_id": "AOP 15",
+      "aop_title": "Alkylation of DNA in male pre-meiotic germ cells leading to heritable mutations"
+    },
+    {
+      "aop_id": "AOP 272",
+      "aop_title": "Deposition of energy leading to lung cancer"
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 296",
+      "aop_title": "Oxidative DNA damage leading to chromosomal aberrations and mutations"
+    },
+    {
+      "aop_id": "AOP 397",
+      "aop_title": "Bulky DNA adducts leading to mutations"
+    },
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 644",
+      "aop_title": "Bulky DNA adducts leading to chromosomal aberrations and mutations"
+    }
+  ],
+  "KE 885": [
+    {
+      "aop_id": "AOP 139",
+      "aop_title": "Alkylation of DNA leading to cancer 1"
+    },
+    {
+      "aop_id": "AOP 141",
+      "aop_title": "Alkylation of DNA leading to cancer 2"
+    },
+    {
+      "aop_id": "AOP 474",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer by promoting EMT"
+    },
+    {
+      "aop_id": "AOP 505",
+      "aop_title": "Reactive Oxygen Species (ROS) formation leads to cancer via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 513",
+      "aop_title": "Reactive Oxygen (ROS) formation leads to cancer via Peroxisome proliferation-activated receptor (PPAR) pathway"
+    },
+    {
+      "aop_id": "AOP 546",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer through hypoxic-like mechanisms"
+    }
+  ],
+  "KE 97": [
+    {
+      "aop_id": "AOP 139",
+      "aop_title": "Alkylation of DNA leading to cancer 1"
+    },
+    {
+      "aop_id": "AOP 141",
+      "aop_title": "Alkylation of DNA leading to cancer 2"
+    },
+    {
+      "aop_id": "AOP 15",
+      "aop_title": "Alkylation of DNA in male pre-meiotic germ cells leading to heritable mutations"
+    },
+    {
+      "aop_id": "AOP 322",
+      "aop_title": "Alkylation of DNA leading to decreased sperm count"
+    }
+  ],
+  "KE 122": [
+    {
+      "aop_id": "AOP 14",
+      "aop_title": "Glucocorticoid Receptor Activation Leading to Increased Disease Susceptibility"
+    },
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 318",
+      "aop_title": "Glucocorticoid Receptor activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 334",
+      "aop_title": "Glucocorticoid Receptor Agonism Leading to Impaired Fin Regeneration"
+    },
+    {
+      "aop_id": "AOP 581",
+      "aop_title": "Glucocorticoid receptor (GR) activation during development leads to cognitive function (COG) decrease"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 145": [
+    {
+      "aop_id": "AOP 14",
+      "aop_title": "Glucocorticoid Receptor Activation Leading to Increased Disease Susceptibility"
+    }
+  ],
+  "KE 152": [
+    {
+      "aop_id": "AOP 14",
+      "aop_title": "Glucocorticoid Receptor Activation Leading to Increased Disease Susceptibility"
+    }
+  ],
+  "KE 168": [
+    {
+      "aop_id": "AOP 14",
+      "aop_title": "Glucocorticoid Receptor Activation Leading to Increased Disease Susceptibility"
+    }
+  ],
+  "KE 202": [
+    {
+      "aop_id": "AOP 14",
+      "aop_title": "Glucocorticoid Receptor Activation Leading to Increased Disease Susceptibility"
+    },
+    {
+      "aop_id": "AOP 277",
+      "aop_title": "Impaired IL-1R1 signaling leading to Impaired T-Cell Dependent Antibody Response"
+    },
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 618",
+      "aop_title": "PPARgamma activation leads to a diminished vaccine response"
+    }
+  ],
+  "KE 323": [
+    {
+      "aop_id": "AOP 14",
+      "aop_title": "Glucocorticoid Receptor Activation Leading to Increased Disease Susceptibility"
+    }
+  ],
+  "KE 403": [
+    {
+      "aop_id": "AOP 14",
+      "aop_title": "Glucocorticoid Receptor Activation Leading to Increased Disease Susceptibility"
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    },
+    {
+      "aop_id": "AOP 84",
+      "aop_title": "Suppression of immune system contributes to impaired development and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 85",
+      "aop_title": "Suppression of immune system contributes to abnormal foraging and leads to colony loss/failure"
+    }
+  ],
+  "KE 1493": [
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 38",
+      "aop_title": "Protein Alkylation leading to Liver Fibrosis"
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    },
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    }
+  ],
+  "KE 1494": [
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    }
+  ],
+  "KE 1539": [
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 530",
+      "aop_title": "Endocytotic lysosomal uptake leads to intestinal barrier disruption"
+    }
+  ],
+  "KE 265": [
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 38",
+      "aop_title": "Protein Alkylation leading to Liver Fibrosis"
+    },
+    {
+      "aop_id": "AOP 494",
+      "aop_title": "AhR activation leading to liver fibrosis "
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 344": [
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 38",
+      "aop_title": "Protein Alkylation leading to Liver Fibrosis"
+    },
+    {
+      "aop_id": "AOP 383",
+      "aop_title": "Inhibition of Angiotensin-converting enzyme 2 leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 494",
+      "aop_title": "AhR activation leading to liver fibrosis "
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 68": [
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 241",
+      "aop_title": "Latent Transforming Growth Factor beta1 activation leads to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 38",
+      "aop_title": "Protein Alkylation leading to Liver Fibrosis"
+    },
+    {
+      "aop_id": "AOP 382",
+      "aop_title": "Angiotensin II type 1 receptor (AT1R) agonism leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 898": [
+    {
+      "aop_id": "AOP 144",
+      "aop_title": "Endocytic lysosomal uptake leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 257",
+      "aop_title": "Receptor mediated endocytosis and lysosomal overload leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 530",
+      "aop_title": "Endocytotic lysosomal uptake leads to intestinal barrier disruption"
+    }
+  ],
+  "KE 1250": [
+    {
+      "aop_id": "AOP 148",
+      "aop_title": "EGFR Activation Leading to Decreased Lung Function"
+    },
+    {
+      "aop_id": "AOP 302",
+      "aop_title": "Lung surfactant function inhibition leading to decreased lung function"
+    },
+    {
+      "aop_id": "AOP 411",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function "
+    },
+    {
+      "aop_id": "AOP 418",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 419",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through P53 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 424",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function via CFTR dysfunction"
+    },
+    {
+      "aop_id": "AOP 425",
+      "aop_title": "Oxidative Stress Leading to Decreased Lung Function via Decreased FOXJ1"
+    }
+  ],
+  "KE 2117": [
+    {
+      "aop_id": "AOP 148",
+      "aop_title": "EGFR Activation Leading to Decreased Lung Function"
+    }
+  ],
+  "KE 941": [
+    {
+      "aop_id": "AOP 148",
+      "aop_title": "EGFR Activation Leading to Decreased Lung Function"
+    }
+  ],
+  "KE 962": [
+    {
+      "aop_id": "AOP 148",
+      "aop_title": "EGFR Activation Leading to Decreased Lung Function"
+    }
+  ],
+  "KE 927": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    }
+  ],
+  "KE 932": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 933": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    }
+  ],
+  "KE 934": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    }
+  ],
+  "KE 935": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    }
+  ],
+  "KE 937": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    }
+  ],
+  "KE 951": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    }
+  ],
+  "KE 952": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    },
+    {
+      "aop_id": "AOP 516",
+      "aop_title": "Na+ /K+ -ATPase inhibition leading to hypertension"
+    }
+  ],
+  "KE 973": [
+    {
+      "aop_id": "AOP 149",
+      "aop_title": "Peptide Oxidation Leading to Hypertension"
+    }
+  ],
+  "KE 336": [
+    {
+      "aop_id": "AOP 15",
+      "aop_title": "Alkylation of DNA in male pre-meiotic germ cells leading to heritable mutations"
+    }
+  ],
+  "KE 110": [
+    {
+      "aop_id": "AOP 150",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via reduced VEGF"
+    },
+    {
+      "aop_id": "AOP 43",
+      "aop_title": "Disruption of VEGFR Signaling Leading to Developmental Defects"
+    }
+  ],
+  "KE 317": [
+    {
+      "aop_id": "AOP 150",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via reduced VEGF"
+    },
+    {
+      "aop_id": "AOP 21",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via increased COX-2"
+    },
+    {
+      "aop_id": "AOP 456",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced cardiovascular toxicity"
+    }
+  ],
+  "KE 944": [
+    {
+      "aop_id": "AOP 150",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via reduced VEGF"
+    },
+    {
+      "aop_id": "AOP 151",
+      "aop_title": "AhR activation leading to preeclampsia"
+    },
+    {
+      "aop_id": "AOP 21",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via increased COX-2"
+    },
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    },
+    {
+      "aop_id": "AOP 455",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 456",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced cardiovascular toxicity"
+    },
+    {
+      "aop_id": "AOP 563",
+      "aop_title": "Aryl hydrocarbon Receptor (AHR) activation causes Premature Ovarian Insufficiency via Bax mediated apoptosis"
+    }
+  ],
+  "KE 945": [
+    {
+      "aop_id": "AOP 150",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via reduced VEGF"
+    },
+    {
+      "aop_id": "AOP 151",
+      "aop_title": "AhR activation leading to preeclampsia"
+    }
+  ],
+  "KE 947": [
+    {
+      "aop_id": "AOP 150",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via reduced VEGF"
+    },
+    {
+      "aop_id": "AOP 21",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via increased COX-2"
+    },
+    {
+      "aop_id": "AOP 455",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 456",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced cardiovascular toxicity"
+    },
+    {
+      "aop_id": "AOP 612",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced adenosine triphosphate"
+    },
+    {
+      "aop_id": "AOP 613",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via increased reactive oxygen species production"
+    },
+    {
+      "aop_id": "AOP 614",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced vascular endothelial growth factor"
+    }
+  ],
+  "KE 948": [
+    {
+      "aop_id": "AOP 150",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via reduced VEGF"
+    },
+    {
+      "aop_id": "AOP 151",
+      "aop_title": "AhR activation leading to preeclampsia"
+    },
+    {
+      "aop_id": "AOP 614",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced vascular endothelial growth factor"
+    }
+  ],
+  "KE 1891": [
+    {
+      "aop_id": "AOP 151",
+      "aop_title": "AhR activation leading to preeclampsia"
+    }
+  ],
+  "KE 1892": [
+    {
+      "aop_id": "AOP 151",
+      "aop_title": "AhR activation leading to preeclampsia"
+    }
+  ],
+  "KE 1893": [
+    {
+      "aop_id": "AOP 151",
+      "aop_title": "AhR activation leading to preeclampsia"
+    }
+  ],
+  "KE 957": [
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 366",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein transthyretin (TTR) leading to altered amphibian metamorphosis "
+    }
+  ],
+  "KE 958": [
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    }
+  ],
+  "KE 959": [
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 366",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein transthyretin (TTR) leading to altered amphibian metamorphosis "
+    },
+    {
+      "aop_id": "AOP 367",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein thyroid binding globulin (TBG) leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 960": [
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    }
+  ],
+  "KE 961": [
+    {
+      "aop_id": "AOP 152",
+      "aop_title": "Interference with thyroid serum binding protein transthyretin and subsequent adverse human neurodevelopmental toxicity "
+    },
+    {
+      "aop_id": "AOP 162",
+      "aop_title": "Enhanced hepatic clearance of thyroid hormones leading to thyroid follicular cell adenomas and carcinomas in the rat and mouse"
+    },
+    {
+      "aop_id": "AOP 194",
+      "aop_title": "Hepatic nuclear receptor activation leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 366",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein transthyretin (TTR) leading to altered amphibian metamorphosis "
+    },
+    {
+      "aop_id": "AOP 367",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein thyroid binding globulin (TBG) leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 1056": [
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    },
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    }
+  ],
+  "KE 964": [
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    }
+  ],
+  "KE 968": [
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    },
+    {
+      "aop_id": "AOP 609",
+      "aop_title": "Activation, estrogen receptor alpha leads to prolonged estrus cycle via decreased kisspeptin release"
+    }
+  ],
+  "KE 969": [
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    }
+  ],
+  "KE 970": [
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    }
+  ],
+  "KE 971": [
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    },
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 972": [
+    {
+      "aop_id": "AOP 153",
+      "aop_title": "Aromatase Inhibition leading to Ovulation Inhibition and Decreased Fertility in Female Rats"
+    }
+  ],
+  "KE 1202": [
+    {
+      "aop_id": "AOP 154",
+      "aop_title": "Inhibition of Calcineurin Activity Leading to Impaired T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 979": [
+    {
+      "aop_id": "AOP 154",
+      "aop_title": "Inhibition of Calcineurin Activity Leading to Impaired T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 980": [
+    {
+      "aop_id": "AOP 154",
+      "aop_title": "Inhibition of Calcineurin Activity Leading to Impaired T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 981": [
+    {
+      "aop_id": "AOP 154",
+      "aop_title": "Inhibition of Calcineurin Activity Leading to Impaired T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 984": [
+    {
+      "aop_id": "AOP 154",
+      "aop_title": "Inhibition of Calcineurin Activity Leading to Impaired T-Cell Dependent Antibody Response"
+    },
+    {
+      "aop_id": "AOP 277",
+      "aop_title": "Impaired IL-1R1 signaling leading to Impaired T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1002": [
+    {
+      "aop_id": "AOP 155",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced posterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 156",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 190",
+      "aop_title": "Type II iodothyronine deiodinase (DIO2) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 1003": [
+    {
+      "aop_id": "AOP 155",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced posterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 156",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 157",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced posterior swim bladder inflation "
+    },
+    {
+      "aop_id": "AOP 158",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 189",
+      "aop_title": "Type I iodothyronine deiodinase (DIO1) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    },
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    }
+  ],
+  "KE 1004": [
+    {
+      "aop_id": "AOP 155",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced posterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 157",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced posterior swim bladder inflation "
+    }
+  ],
+  "KE 1005": [
+    {
+      "aop_id": "AOP 155",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced posterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 156",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 157",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced posterior swim bladder inflation "
+    },
+    {
+      "aop_id": "AOP 158",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    },
+    {
+      "aop_id": "AOP 334",
+      "aop_title": "Glucocorticoid Receptor Agonism Leading to Impaired Fin Regeneration"
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 608",
+      "aop_title": "Thyroid Hormone Excess Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 611",
+      "aop_title": "Behavioral abnormalities due to increased expression of dopamine transporter and receptor-related genes"
+    }
+  ],
+  "KE 1007": [
+    {
+      "aop_id": "AOP 156",
+      "aop_title": "Deiodinase 2 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 158",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 159",
+      "aop_title": "Thyroperoxidase inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    }
+  ],
+  "KE 1009": [
+    {
+      "aop_id": "AOP 157",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced posterior swim bladder inflation "
+    },
+    {
+      "aop_id": "AOP 158",
+      "aop_title": "Deiodinase 1 inhibition leading to increased mortality via reduced anterior swim bladder inflation"
+    },
+    {
+      "aop_id": "AOP 189",
+      "aop_title": "Type I iodothyronine deiodinase (DIO1) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 10": [
+    {
+      "aop_id": "AOP 16",
+      "aop_title": "Acetylcholinesterase inhibition leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 312",
+      "aop_title": "Acetylcholinesterase Inhibition leading to Acute Mortality via Impaired Coordination & Movement​"
+    },
+    {
+      "aop_id": "AOP 405",
+      "aop_title": "Organo-Phosphate Chemicals induced inhibition of AChE  leading to impaired cognitive function"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 12": [
+    {
+      "aop_id": "AOP 16",
+      "aop_title": "Acetylcholinesterase inhibition leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 312",
+      "aop_title": "Acetylcholinesterase Inhibition leading to Acute Mortality via Impaired Coordination & Movement​"
+    },
+    {
+      "aop_id": "AOP 405",
+      "aop_title": "Organo-Phosphate Chemicals induced inhibition of AChE  leading to impaired cognitive function"
+    },
+    {
+      "aop_id": "AOP 450",
+      "aop_title": " Inhibition of AChE and activation of CYP2E1 leading to sensory axonal peripheral neuropathy and mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 559",
+      "aop_title": "Inhibition of acetylcholinesterase (AChE) leading to arrhythmias"
+    }
+  ],
+  "KE 1703": [
+    {
+      "aop_id": "AOP 16",
+      "aop_title": "Acetylcholinesterase inhibition leading to acute mortality"
+    }
+  ],
+  "KE 39": [
+    {
+      "aop_id": "AOP 16",
+      "aop_title": "Acetylcholinesterase inhibition leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 312",
+      "aop_title": "Acetylcholinesterase Inhibition leading to Acute Mortality via Impaired Coordination & Movement​"
+    },
+    {
+      "aop_id": "AOP 405",
+      "aop_title": "Organo-Phosphate Chemicals induced inhibition of AChE  leading to impaired cognitive function"
+    }
+  ],
+  "KE 445": [
+    {
+      "aop_id": "AOP 16",
+      "aop_title": "Acetylcholinesterase inhibition leading to acute mortality"
+    },
+    {
+      "aop_id": "AOP 94",
+      "aop_title": "Sodium channel inhibition leading to congenital malformations"
+    }
+  ],
+  "KE 1012": [
+    {
+      "aop_id": "AOP 160",
+      "aop_title": "Ionotropic gamma-aminobutyric acid receptor activation mediated neurotransmission inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 161",
+      "aop_title": "Glutamate-gated chloride channel activation leading to neurotransmission inhibition associated mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1014": [
+    {
+      "aop_id": "AOP 160",
+      "aop_title": "Ionotropic gamma-aminobutyric acid receptor activation mediated neurotransmission inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1015": [
+    {
+      "aop_id": "AOP 160",
+      "aop_title": "Ionotropic gamma-aminobutyric acid receptor activation mediated neurotransmission inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 161",
+      "aop_title": "Glutamate-gated chloride channel activation leading to neurotransmission inhibition associated mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1016": [
+    {
+      "aop_id": "AOP 160",
+      "aop_title": "Ionotropic gamma-aminobutyric acid receptor activation mediated neurotransmission inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 161",
+      "aop_title": "Glutamate-gated chloride channel activation leading to neurotransmission inhibition associated mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 568",
+      "aop_title": "Inhibition, 5-hydroxytryptamine transporter (5-HTT; SERT) leads to Inhibition, Feeding"
+    }
+  ],
+  "KE 762": [
+    {
+      "aop_id": "AOP 160",
+      "aop_title": "Ionotropic gamma-aminobutyric acid receptor activation mediated neurotransmission inhibition leading to mortality"
+    }
+  ],
+  "KE 1018": [
+    {
+      "aop_id": "AOP 161",
+      "aop_title": "Glutamate-gated chloride channel activation leading to neurotransmission inhibition associated mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1019": [
+    {
+      "aop_id": "AOP 161",
+      "aop_title": "Glutamate-gated chloride channel activation leading to neurotransmission inhibition associated mortality"
+    }
+  ],
+  "KE 295": [
+    {
+      "aop_id": "AOP 162",
+      "aop_title": "Enhanced hepatic clearance of thyroid hormones leading to thyroid follicular cell adenomas and carcinomas in the rat and mouse"
+    },
+    {
+      "aop_id": "AOP 194",
+      "aop_title": "Hepatic nuclear receptor activation leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 458",
+      "aop_title": "AhR activation in the liver leading to Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 1028": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    },
+    {
+      "aop_id": "AOP 618",
+      "aop_title": "PPARgamma activation leads to a diminished vaccine response"
+    },
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1029": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    }
+  ],
+  "KE 1032": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    },
+    {
+      "aop_id": "AOP 171",
+      "aop_title": "Chronic cytotoxicity of the serous membrane leading to pleural/peritoneal mesotheliomas in the rat."
+    }
+  ],
+  "KE 1033": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    }
+  ],
+  "KE 1034": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    }
+  ],
+  "KE 1035": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    }
+  ],
+  "KE 1036": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    }
+  ],
+  "KE 1037": [
+    {
+      "aop_id": "AOP 163",
+      "aop_title": "PPARgamma activation leading to sarcomas in rats, mice, and hamsters"
+    }
+  ],
+  "KE 1038": [
+    {
+      "aop_id": "AOP 164",
+      "aop_title": "Beta-2 adrenergic agonist activity leading to mesovarian leiomyomas in the rat and mouse"
+    },
+    {
+      "aop_id": "AOP 554",
+      "aop_title": "β-adrenergic receptor agonists leading to arrhythmias."
+    }
+  ],
+  "KE 1039": [
+    {
+      "aop_id": "AOP 164",
+      "aop_title": "Beta-2 adrenergic agonist activity leading to mesovarian leiomyomas in the rat and mouse"
+    },
+    {
+      "aop_id": "AOP 557",
+      "aop_title": "β2-Receptor agonist leading to Cardiomyopathy"
+    }
+  ],
+  "KE 1040": [
+    {
+      "aop_id": "AOP 164",
+      "aop_title": "Beta-2 adrenergic agonist activity leading to mesovarian leiomyomas in the rat and mouse"
+    }
+  ],
+  "KE 1042": [
+    {
+      "aop_id": "AOP 164",
+      "aop_title": "Beta-2 adrenergic agonist activity leading to mesovarian leiomyomas in the rat and mouse"
+    }
+  ],
+  "KE 1043": [
+    {
+      "aop_id": "AOP 164",
+      "aop_title": "Beta-2 adrenergic agonist activity leading to mesovarian leiomyomas in the rat and mouse"
+    }
+  ],
+  "KE 1044": [
+    {
+      "aop_id": "AOP 164",
+      "aop_title": "Beta-2 adrenergic agonist activity leading to mesovarian leiomyomas in the rat and mouse"
+    }
+  ],
+  "KE 1045": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    }
+  ],
+  "KE 1046": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    },
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    }
+  ],
+  "KE 1047": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    },
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    },
+    {
+      "aop_id": "AOP 623",
+      "aop_title": "Activation, estrogen receptor alpha leads to persistent vaginal cornification via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 637",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased uterine weight via earlier proliferation of cells of the uterine lining"
+    },
+    {
+      "aop_id": "AOP 639",
+      "aop_title": "Activation, estrogen receptor alpha leads to precocious puberty via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    }
+  ],
+  "KE 1049": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    }
+  ],
+  "KE 1050": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    },
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    }
+  ],
+  "KE 1051": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    }
+  ],
+  "KE 1052": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    },
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    }
+  ],
+  "KE 1053": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    },
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    }
+  ],
+  "KE 1054": [
+    {
+      "aop_id": "AOP 165",
+      "aop_title": "Antiestrogen activity leading to ovarian adenomas and granular cell tumors in the mouse"
+    }
+  ],
+  "KE 1057": [
+    {
+      "aop_id": "AOP 166",
+      "aop_title": "PPARalpha activation leading to pancreatic acinar tumors in the rat and mouse"
+    }
+  ],
+  "KE 1058": [
+    {
+      "aop_id": "AOP 166",
+      "aop_title": "PPARalpha activation leading to pancreatic acinar tumors in the rat and mouse"
+    }
+  ],
+  "KE 1059": [
+    {
+      "aop_id": "AOP 166",
+      "aop_title": "PPARalpha activation leading to pancreatic acinar tumors in the rat and mouse"
+    }
+  ],
+  "KE 1060": [
+    {
+      "aop_id": "AOP 166",
+      "aop_title": "PPARalpha activation leading to pancreatic acinar tumors in the rat and mouse"
+    },
+    {
+      "aop_id": "AOP 513",
+      "aop_title": "Reactive Oxygen (ROS) formation leads to cancer via Peroxisome proliferation-activated receptor (PPAR) pathway"
+    }
+  ],
+  "KE 1061": [
+    {
+      "aop_id": "AOP 166",
+      "aop_title": "PPARalpha activation leading to pancreatic acinar tumors in the rat and mouse"
+    }
+  ],
+  "KE 1062": [
+    {
+      "aop_id": "AOP 166",
+      "aop_title": "PPARalpha activation leading to pancreatic acinar tumors in the rat and mouse"
+    }
+  ],
+  "KE 1063": [
+    {
+      "aop_id": "AOP 166",
+      "aop_title": "PPARalpha activation leading to pancreatic acinar tumors in the rat and mouse"
+    }
+  ],
+  "KE 1066": [
+    {
+      "aop_id": "AOP 167",
+      "aop_title": "Early-life estrogen receptor agonism leading to endometrial adenosquamous carcinoma via promotion of sine oculis homeobox 1 progenitor cells"
+    }
+  ],
+  "KE 1068": [
+    {
+      "aop_id": "AOP 167",
+      "aop_title": "Early-life estrogen receptor agonism leading to endometrial adenosquamous carcinoma via promotion of sine oculis homeobox 1 progenitor cells"
+    }
+  ],
+  "KE 1070": [
+    {
+      "aop_id": "AOP 167",
+      "aop_title": "Early-life estrogen receptor agonism leading to endometrial adenosquamous carcinoma via promotion of sine oculis homeobox 1 progenitor cells"
+    }
+  ],
+  "KE 2329": [
+    {
+      "aop_id": "AOP 167",
+      "aop_title": "Early-life estrogen receptor agonism leading to endometrial adenosquamous carcinoma via promotion of sine oculis homeobox 1 progenitor cells"
+    }
+  ],
+  "KE 2330": [
+    {
+      "aop_id": "AOP 167",
+      "aop_title": "Early-life estrogen receptor agonism leading to endometrial adenosquamous carcinoma via promotion of sine oculis homeobox 1 progenitor cells"
+    }
+  ],
+  "KE 1071": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 169",
+      "aop_title": "GnRH pulse disruption leading to pituitary adenomas and carcinomas in the SD rat."
+    }
+  ],
+  "KE 1072": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 169",
+      "aop_title": "GnRH pulse disruption leading to pituitary adenomas and carcinomas in the SD rat."
+    }
+  ],
+  "KE 1074": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 169",
+      "aop_title": "GnRH pulse disruption leading to pituitary adenomas and carcinomas in the SD rat."
+    }
+  ],
+  "KE 1075": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 169",
+      "aop_title": "GnRH pulse disruption leading to pituitary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 609",
+      "aop_title": "Activation, estrogen receptor alpha leads to prolonged estrus cycle via decreased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    }
+  ],
+  "KE 1076": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 169",
+      "aop_title": "GnRH pulse disruption leading to pituitary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    },
+    {
+      "aop_id": "AOP 561",
+      "aop_title": "Aromatase induction leading to estrogen receptor alpha activation via increased estradiol"
+    }
+  ],
+  "KE 1077": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    }
+  ],
+  "KE 1078": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    }
+  ],
+  "KE 1079": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 170",
+      "aop_title": "Anti-dopaminergic activity leading to mammary adenomas and carcinomas in the SD rat"
+    }
+  ],
+  "KE 1080": [
+    {
+      "aop_id": "AOP 168",
+      "aop_title": "GnRH pulse disruption leading to mammary adenomas and carcinomas in the SD rat."
+    },
+    {
+      "aop_id": "AOP 170",
+      "aop_title": "Anti-dopaminergic activity leading to mammary adenomas and carcinomas in the SD rat"
+    }
+  ],
+  "KE 1081": [
+    {
+      "aop_id": "AOP 169",
+      "aop_title": "GnRH pulse disruption leading to pituitary adenomas and carcinomas in the SD rat."
+    }
+  ],
+  "KE 1082": [
+    {
+      "aop_id": "AOP 169",
+      "aop_title": "GnRH pulse disruption leading to pituitary adenomas and carcinomas in the SD rat."
+    }
+  ],
+  "KE 1487": [
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 284",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress leads to chronic kidney disease"
+    }
+  ],
+  "KE 1488": [
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    }
+  ],
+  "KE 1492": [
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 38",
+      "aop_title": "Protein Alkylation leading to Liver Fibrosis"
+    },
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    }
+  ],
+  "KE 1538": [
+    {
+      "aop_id": "AOP 17",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress during brain development leads to impairment of learning and memory"
+    },
+    {
+      "aop_id": "AOP 284",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress leads to chronic kidney disease"
+    }
+  ],
+  "KE 1083": [
+    {
+      "aop_id": "AOP 170",
+      "aop_title": "Anti-dopaminergic activity leading to mammary adenomas and carcinomas in the SD rat"
+    }
+  ],
+  "KE 1084": [
+    {
+      "aop_id": "AOP 170",
+      "aop_title": "Anti-dopaminergic activity leading to mammary adenomas and carcinomas in the SD rat"
+    }
+  ],
+  "KE 1085": [
+    {
+      "aop_id": "AOP 170",
+      "aop_title": "Anti-dopaminergic activity leading to mammary adenomas and carcinomas in the SD rat"
+    }
+  ],
+  "KE 1086": [
+    {
+      "aop_id": "AOP 171",
+      "aop_title": "Chronic cytotoxicity of the serous membrane leading to pleural/peritoneal mesotheliomas in the rat."
+    }
+  ],
+  "KE 1087": [
+    {
+      "aop_id": "AOP 171",
+      "aop_title": "Chronic cytotoxicity of the serous membrane leading to pleural/peritoneal mesotheliomas in the rat."
+    }
+  ],
+  "KE 1089": [
+    {
+      "aop_id": "AOP 171",
+      "aop_title": "Chronic cytotoxicity of the serous membrane leading to pleural/peritoneal mesotheliomas in the rat."
+    }
+  ],
+  "KE 1090": [
+    {
+      "aop_id": "AOP 171",
+      "aop_title": "Chronic cytotoxicity of the serous membrane leading to pleural/peritoneal mesotheliomas in the rat."
+    },
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    }
+  ],
+  "KE 1458": [
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 241",
+      "aop_title": "Latent Transforming Growth Factor beta1 activation leads to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 1495": [
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 237",
+      "aop_title": "Substance interaction with lung resident cell membrane components leading to atherosclerosis via acute phase response"
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    }
+  ],
+  "KE 1496": [
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 237",
+      "aop_title": "Substance interaction with lung resident cell membrane components leading to atherosclerosis via acute phase response"
+    },
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 382",
+      "aop_title": "Angiotensin II type 1 receptor (AT1R) agonism leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 39",
+      "aop_title": "Covalent Binding, Protein, leading to Increase, Allergic Respiratory Hypersensitivity Response"
+    },
+    {
+      "aop_id": "AOP 392",
+      "aop_title": "Decreased fibrinolysis and activated bradykinin system leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    }
+  ],
+  "KE 1497": [
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 303",
+      "aop_title": "Frustrated phagocytosis-induced lung cancer"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 392",
+      "aop_title": "Decreased fibrinolysis and activated bradykinin system leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    },
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 1498": [
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 302",
+      "aop_title": "Lung surfactant function inhibition leading to decreased lung function"
+    }
+  ],
+  "KE 1499": [
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1500": [
+    {
+      "aop_id": "AOP 173",
+      "aop_title": "Substance interaction with the pulmonary resident cell membrane components leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1101": [
+    {
+      "aop_id": "AOP 175",
+      "aop_title": "Thyroperoxidase inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 176",
+      "aop_title": "Sodium Iodide Symporter (NIS) Inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 188",
+      "aop_title": "Iodotyrosine deiodinase (IYD) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 189",
+      "aop_title": "Type I iodothyronine deiodinase (DIO1) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 190",
+      "aop_title": "Type II iodothyronine deiodinase (DIO2) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 191",
+      "aop_title": "Type III iodotyrosine deiodinase (DIO3) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 192",
+      "aop_title": "Pendrin inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 193",
+      "aop_title": "Dual oxidase (DUOX) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 194",
+      "aop_title": "Hepatic nuclear receptor activation leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 366",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein transthyretin (TTR) leading to altered amphibian metamorphosis "
+    },
+    {
+      "aop_id": "AOP 367",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein thyroid binding globulin (TBG) leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1103": [
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    }
+  ],
+  "KE 1104": [
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    }
+  ],
+  "KE 1105": [
+    {
+      "aop_id": "AOP 177",
+      "aop_title": "Cyclooxygenase 1 (COX1) inhibition leading to renal failure and mortality"
+    }
+  ],
+  "KE 1107": [
+    {
+      "aop_id": "AOP 178",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to mitochondrial dysfunction and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 179",
+      "aop_title": "Varroa mite infestation increases virus levels leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 180",
+      "aop_title": "Varroa mite infestation contributes to abnormal foraging leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 181",
+      "aop_title": "Weather event contributes to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 182",
+      "aop_title": "Weather event contributes abnormal foraging leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 183",
+      "aop_title": "Nosema infection increases energetic demands leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 184",
+      "aop_title": "Nosema infection causes abnormal role change that leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 185",
+      "aop_title": "Queen egg-laying decrease leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 77",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony death/failure 1"
+    },
+    {
+      "aop_id": "AOP 79",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to impaired hive thermoregulation and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    },
+    {
+      "aop_id": "AOP 88",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure via abnormal role change within caste"
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    }
+  ],
+  "KE 559": [
+    {
+      "aop_id": "AOP 178",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to mitochondrial dysfunction and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 77",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony death/failure 1"
+    },
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 79",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to impaired hive thermoregulation and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    },
+    {
+      "aop_id": "AOP 88",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure via abnormal role change within caste"
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    }
+  ],
+  "KE 563": [
+    {
+      "aop_id": "AOP 178",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to mitochondrial dysfunction and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 179",
+      "aop_title": "Varroa mite infestation increases virus levels leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 180",
+      "aop_title": "Varroa mite infestation contributes to abnormal foraging leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 181",
+      "aop_title": "Weather event contributes to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 182",
+      "aop_title": "Weather event contributes abnormal foraging leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 183",
+      "aop_title": "Nosema infection increases energetic demands leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 184",
+      "aop_title": "Nosema infection causes abnormal role change that leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 185",
+      "aop_title": "Queen egg-laying decrease leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 77",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony death/failure 1"
+    },
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 79",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to impaired hive thermoregulation and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 81",
+      "aop_title": "Increased metabolic stress contributes to abnormal foraging and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 82",
+      "aop_title": "Abnormal role change in worker caste contributes to reduced brood care and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 84",
+      "aop_title": "Suppression of immune system contributes to impaired development and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 85",
+      "aop_title": "Suppression of immune system contributes to abnormal foraging and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 86",
+      "aop_title": "Decrease Glucose oxidase activity contributes to reduction of antiseptic in food and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    },
+    {
+      "aop_id": "AOP 88",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure via abnormal role change within caste"
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    }
+  ],
+  "KE 1109": [
+    {
+      "aop_id": "AOP 179",
+      "aop_title": "Varroa mite infestation increases virus levels leading to colony loss/failure"
+    }
+  ],
+  "KE 227": [
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    },
+    {
+      "aop_id": "AOP 323",
+      "aop_title": "PPARalpha Agonism Leading to Decreased Viable Offspring via Decreased 11-Ketotestosterone"
+    },
+    {
+      "aop_id": "AOP 37",
+      "aop_title": "PPARα activation leading to hepatocellular adenomas and carcinomas in rodents"
+    },
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    },
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    },
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 612",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced adenosine triphosphate"
+    },
+    {
+      "aop_id": "AOP 613",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via increased reactive oxygen species production"
+    },
+    {
+      "aop_id": "AOP 614",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced vascular endothelial growth factor"
+    }
+  ],
+  "KE 266": [
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    }
+  ],
+  "KE 289": [
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    }
+  ],
+  "KE 348": [
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    }
+  ],
+  "KE 406": [
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    },
+    {
+      "aop_id": "AOP 345",
+      "aop_title": "Androgen receptor (AR) antagonism leading to decreased fertility in females"
+    },
+    {
+      "aop_id": "AOP 348",
+      "aop_title": "Inhibition of 11β-Hydroxysteroid Dehydrogenase leading to decreased population trajectory "
+    },
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 398",
+      "aop_title": "Decreased ALDH1A (RALDH) activity leading to decreased fertility via disrupted meiotic initiation of fetal oogonia "
+    },
+    {
+      "aop_id": "AOP 400",
+      "aop_title": "Inhibition of CYP26B1 activity in fetal testis leading to reduced fertility"
+    },
+    {
+      "aop_id": "AOP 492",
+      "aop_title": "Glutathione conjugation leading to reproductive dysfunction via oxidative stress"
+    },
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    },
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    },
+    {
+      "aop_id": "AOP 64",
+      "aop_title": "Glucocorticoid Receptor (GR) Mediated Adult Leydig Cell Dysfunction Leading to Decreased Male Fertility"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    },
+    {
+      "aop_id": "AOP 7",
+      "aop_title": "Aromatase (Cyp19a1) reduction leading to impaired fertility in adult female"
+    }
+  ],
+  "KE 413": [
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    },
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    },
+    {
+      "aop_id": "AOP 64",
+      "aop_title": "Glucocorticoid Receptor (GR) Mediated Adult Leydig Cell Dysfunction Leading to Decreased Male Fertility"
+    }
+  ],
+  "KE 447": [
+    {
+      "aop_id": "AOP 18",
+      "aop_title": "PPARα activation in utero leading to impaired fertility in males"
+    },
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    }
+  ],
+  "KE 560": [
+    {
+      "aop_id": "AOP 180",
+      "aop_title": "Varroa mite infestation contributes to abnormal foraging leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 182",
+      "aop_title": "Weather event contributes abnormal foraging leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 183",
+      "aop_title": "Nosema infection increases energetic demands leading to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 77",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony death/failure 1"
+    },
+    {
+      "aop_id": "AOP 81",
+      "aop_title": "Increased metabolic stress contributes to abnormal foraging and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 85",
+      "aop_title": "Suppression of immune system contributes to abnormal foraging and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    },
+    {
+      "aop_id": "AOP 88",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure via abnormal role change within caste"
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    }
+  ],
+  "KE 1110": [
+    {
+      "aop_id": "AOP 183",
+      "aop_title": "Nosema infection increases energetic demands leading to colony loss/failure"
+    }
+  ],
+  "KE 1108": [
+    {
+      "aop_id": "AOP 184",
+      "aop_title": "Nosema infection causes abnormal role change that leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    }
+  ],
+  "KE 1114": [
+    {
+      "aop_id": "AOP 186",
+      "aop_title": "unknown MIE leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 487",
+      "aop_title": "Unknown MIE altering cholesterol metabolism leading to decreased cognition"
+    }
+  ],
+  "KE 1115": [
+    {
+      "aop_id": "AOP 186",
+      "aop_title": "unknown MIE leading to renal failure and mortality"
+    },
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    },
+    {
+      "aop_id": "AOP 213",
+      "aop_title": "Inhibition of fatty acid beta oxidation leading to nonalcoholic steatohepatitis (NASH)"
+    },
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    },
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    },
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 282",
+      "aop_title": "Adverse outcome pathway on photochemical toxicity initiated by light exposure"
+    },
+    {
+      "aop_id": "AOP 298",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human treatment-resistant gastric cancer"
+    },
+    {
+      "aop_id": "AOP 299",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 303",
+      "aop_title": "Frustrated phagocytosis-induced lung cancer"
+    },
+    {
+      "aop_id": "AOP 311",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 325",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell death"
+    },
+    {
+      "aop_id": "AOP 326",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 327",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (1)"
+    },
+    {
+      "aop_id": "AOP 328",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (2)"
+    },
+    {
+      "aop_id": "AOP 329",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (3)"
+    },
+    {
+      "aop_id": "AOP 330",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (4)"
+    },
+    {
+      "aop_id": "AOP 331",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 332",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 333",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 382",
+      "aop_title": "Angiotensin II type 1 receptor (AT1R) agonism leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 383",
+      "aop_title": "Inhibition of Angiotensin-converting enzyme 2 leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 384",
+      "aop_title": "Hyperactivation of ACE/Ang-II/AT1R axis leading to chronic kidney disease "
+    },
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    },
+    {
+      "aop_id": "AOP 413",
+      "aop_title": "Oxidation and antagonism of reduced glutathione leading to mortality via acute renal failure"
+    },
+    {
+      "aop_id": "AOP 416",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 418",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 423",
+      "aop_title": " Toxicological mechanisms of hepatocyte apoptosis through the PARP1 dependent cell death pathway "
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    },
+    {
+      "aop_id": "AOP 462",
+      "aop_title": "Activation of reactive oxygen species leading the atherosclerosis"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    },
+    {
+      "aop_id": "AOP 488",
+      "aop_title": "Increased reactive oxygen species production leading to decreased cognitive function"
+    },
+    {
+      "aop_id": "AOP 492",
+      "aop_title": "Glutathione conjugation leading to reproductive dysfunction via oxidative stress"
+    },
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    },
+    {
+      "aop_id": "AOP 500",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via ROS and apoptosis"
+    },
+    {
+      "aop_id": "AOP 505",
+      "aop_title": "Reactive Oxygen Species (ROS) formation leads to cancer via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    },
+    {
+      "aop_id": "AOP 513",
+      "aop_title": "Reactive Oxygen (ROS) formation leads to cancer via Peroxisome proliferation-activated receptor (PPAR) pathway"
+    },
+    {
+      "aop_id": "AOP 521",
+      "aop_title": "Essential element imbalance leads to reproductive failure via oxidative stress"
+    },
+    {
+      "aop_id": "AOP 534",
+      "aop_title": "Succinate dehydrogenase (SDH) inhibition leads to oxidative stress"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 569",
+      "aop_title": "Decreased DNA methylation of FAM50B/PTCHD3 leading to IQ loss of children via PI3K-Akt pathway"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 596",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 598",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 599",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 600",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell growth"
+    },
+    {
+      "aop_id": "AOP 601",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    },
+    {
+      "aop_id": "AOP 603",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 608",
+      "aop_title": "Thyroid Hormone Excess Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 613",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via increased reactive oxygen species production"
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 636",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human amyotrophic lateral sclerosis (ALS)"
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 1122": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1130": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1131": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1132": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1133": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1134": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1135": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1136": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1138": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1151": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1169": [
+    {
+      "aop_id": "AOP 187",
+      "aop_title": "Anticoagulant rodenticide inhibition of vitamin K epoxide reductase resulting coagulopathy and hemorrhage"
+    }
+  ],
+  "KE 1152": [
+    {
+      "aop_id": "AOP 188",
+      "aop_title": "Iodotyrosine deiodinase (IYD) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1116": [
+    {
+      "aop_id": "AOP 189",
+      "aop_title": "Type I iodothyronine deiodinase (DIO1) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 190",
+      "aop_title": "Type II iodothyronine deiodinase (DIO2) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 240": [
+    {
+      "aop_id": "AOP 19",
+      "aop_title": "Androgen receptor antagonism leading to adverse effects in the male foetus (mammals)"
+    }
+  ],
+  "KE 26": [
+    {
+      "aop_id": "AOP 19",
+      "aop_title": "Androgen receptor antagonism leading to adverse effects in the male foetus (mammals)"
+    },
+    {
+      "aop_id": "AOP 306",
+      "aop_title": "Androgen receptor (AR) antagonism leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 344",
+      "aop_title": "Androgen receptor (AR) antagonism leading to nipple retention (NR) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 345",
+      "aop_title": "Androgen receptor (AR) antagonism leading to decreased fertility in females"
+    },
+    {
+      "aop_id": "AOP 372",
+      "aop_title": "Androgen receptor antagonism leading to testicular cancer "
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 477",
+      "aop_title": "Androgen receptor (AR) antagonism leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 619",
+      "aop_title": "Androgen receptor antagonism leads to delayed preputial separation via reduced fibroblast growth factor in genital-tubercle tissues"
+    }
+  ],
+  "KE 286": [
+    {
+      "aop_id": "AOP 19",
+      "aop_title": "Androgen receptor antagonism leading to adverse effects in the male foetus (mammals)"
+    },
+    {
+      "aop_id": "AOP 305",
+      "aop_title": "5α-reductase inhibition leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 306",
+      "aop_title": "Androgen receptor (AR) antagonism leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 307",
+      "aop_title": "Decreased testosterone synthesis leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 344",
+      "aop_title": "Androgen receptor (AR) antagonism leading to nipple retention (NR) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 345",
+      "aop_title": "Androgen receptor (AR) antagonism leading to decreased fertility in females"
+    },
+    {
+      "aop_id": "AOP 372",
+      "aop_title": "Androgen receptor antagonism leading to testicular cancer "
+    },
+    {
+      "aop_id": "AOP 477",
+      "aop_title": "Androgen receptor (AR) antagonism leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 570",
+      "aop_title": "Decreased testosterone synthesis leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 571",
+      "aop_title": "5α-reductase inhibition leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 575",
+      "aop_title": "Decreased testosterone synthesis leading to increased nipple retention (NR) in male (rodent) offspring"
+    },
+    {
+      "aop_id": "AOP 576",
+      "aop_title": "5α-reductase inhibition leading to increased nipple retention (NR) in male (rodent) offspring"
+    }
+  ],
+  "KE 310": [
+    {
+      "aop_id": "AOP 19",
+      "aop_title": "Androgen receptor antagonism leading to adverse effects in the male foetus (mammals)"
+    }
+  ],
+  "KE 337": [
+    {
+      "aop_id": "AOP 19",
+      "aop_title": "Androgen receptor antagonism leading to adverse effects in the male foetus (mammals)"
+    }
+  ],
+  "KE 1828": [
+    {
+      "aop_id": "AOP 190",
+      "aop_title": "Type II iodothyronine deiodinase (DIO2) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1829": [
+    {
+      "aop_id": "AOP 190",
+      "aop_title": "Type II iodothyronine deiodinase (DIO2) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 191",
+      "aop_title": "Type III iodotyrosine deiodinase (DIO3) inhibition leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 393",
+      "aop_title": "AOP for thyroid disorder caused by triphenyl phosphate via TRβ activation"
+    },
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    }
+  ],
+  "KE 1153": [
+    {
+      "aop_id": "AOP 191",
+      "aop_title": "Type III iodotyrosine deiodinase (DIO3) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1154": [
+    {
+      "aop_id": "AOP 191",
+      "aop_title": "Type III iodotyrosine deiodinase (DIO3) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1155": [
+    {
+      "aop_id": "AOP 192",
+      "aop_title": "Pendrin inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1156": [
+    {
+      "aop_id": "AOP 193",
+      "aop_title": "Dual oxidase (DUOX) inhibition leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1157": [
+    {
+      "aop_id": "AOP 194",
+      "aop_title": "Hepatic nuclear receptor activation leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1158": [
+    {
+      "aop_id": "AOP 194",
+      "aop_title": "Hepatic nuclear receptor activation leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 366",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein transthyretin (TTR) leading to altered amphibian metamorphosis "
+    },
+    {
+      "aop_id": "AOP 367",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein thyroid binding globulin (TBG) leading to altered amphibian metamorphosis"
+    },
+    {
+      "aop_id": "AOP 393",
+      "aop_title": "AOP for thyroid disorder caused by triphenyl phosphate via TRβ activation"
+    }
+  ],
+  "KE 1142": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    },
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    },
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 1161": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    }
+  ],
+  "KE 1163": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    }
+  ],
+  "KE 1164": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    }
+  ],
+  "KE 1255": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    }
+  ],
+  "KE 619": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    },
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    },
+    {
+      "aop_id": "AOP 568",
+      "aop_title": "Inhibition, 5-hydroxytryptamine transporter (5-HTT; SERT) leads to Inhibition, Feeding"
+    },
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    },
+    {
+      "aop_id": "AOP 98",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to decreased shelter seeking and increased predation"
+    }
+  ],
+  "KE 621": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    },
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    }
+  ],
+  "KE 626": [
+    {
+      "aop_id": "AOP 195",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT) inhibition leading to population increase"
+    },
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    },
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    },
+    {
+      "aop_id": "AOP 98",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to decreased shelter seeking and increased predation"
+    }
+  ],
+  "KE 1215": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1218": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1220": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1222": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1223": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1226": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1433": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1434": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1435": [
+    {
+      "aop_id": "AOP 196",
+      "aop_title": "Volatile Organic Chemicals Activate TRPA1 Receptor to Induce Sensory Pulmonary Irritation"
+    }
+  ],
+  "KE 1176": [
+    {
+      "aop_id": "AOP 197",
+      "aop_title": "Sodium channel (Nav1.1) inhibition leading to population decline"
+    }
+  ],
+  "KE 1179": [
+    {
+      "aop_id": "AOP 197",
+      "aop_title": "Sodium channel (Nav1.1) inhibition leading to population decline"
+    }
+  ],
+  "KE 584": [
+    {
+      "aop_id": "AOP 197",
+      "aop_title": "Sodium channel (Nav1.1) inhibition leading to population decline"
+    },
+    {
+      "aop_id": "AOP 553",
+      "aop_title": "Inhibition of Voltage-gated sodium channels (Na⁺ channels)  leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 91",
+      "aop_title": "Sodium channel inhibition leading to reduced survival"
+    },
+    {
+      "aop_id": "AOP 93",
+      "aop_title": "sodium channel inhibition leading to increased predation"
+    },
+    {
+      "aop_id": "AOP 94",
+      "aop_title": "Sodium channel inhibition leading to congenital malformations"
+    }
+  ],
+  "KE 1182": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    }
+  ],
+  "KE 1183": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    }
+  ],
+  "KE 1187": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    }
+  ],
+  "KE 1188": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    }
+  ],
+  "KE 1189": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    }
+  ],
+  "KE 1190": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    }
+  ],
+  "KE 1191": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    }
+  ],
+  "KE 1192": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    }
+  ],
+  "KE 1193": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    }
+  ],
+  "KE 1194": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 388",
+      "aop_title": "Deposition of ionising energy  leading to population decline via programmed cell death"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 423",
+      "aop_title": " Toxicological mechanisms of hepatocyte apoptosis through the PARP1 dependent cell death pathway "
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    },
+    {
+      "aop_id": "AOP 435",
+      "aop_title": "Deposition of ionising energy leads to population decline via pollen abnormal"
+    },
+    {
+      "aop_id": "AOP 441",
+      "aop_title": "Ionizing radiation-induced DNA damage leads to microcephaly via apoptosis and premature cell differentiation"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    },
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 1195": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 1196": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    },
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    }
+  ],
+  "KE 1197": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 1198": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 462",
+      "aop_title": "Activation of reactive oxygen species leading the atherosclerosis"
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 1213": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    }
+  ],
+  "KE 1239": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 275",
+      "aop_title": "Histone deacetylase inhibition leads to neural tube defects"
+    },
+    {
+      "aop_id": "AOP 533",
+      "aop_title": "Retinoic acid receptor antagonism during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 1240": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    }
+  ],
+  "KE 1241": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    },
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    }
+  ],
+  "KE 1242": [
+    {
+      "aop_id": "AOP 200",
+      "aop_title": "Estrogen receptor activation leading to breast cancer  "
+    }
+  ],
+  "KE 1205": [
+    {
+      "aop_id": "AOP 201",
+      "aop_title": "Juvenile hormone receptor agonism leading to male offspring induction associated population decline"
+    }
+  ],
+  "KE 1206": [
+    {
+      "aop_id": "AOP 201",
+      "aop_title": "Juvenile hormone receptor agonism leading to male offspring induction associated population decline"
+    }
+  ],
+  "KE 1208": [
+    {
+      "aop_id": "AOP 201",
+      "aop_title": "Juvenile hormone receptor agonism leading to male offspring induction associated population decline"
+    }
+  ],
+  "KE 1209": [
+    {
+      "aop_id": "AOP 201",
+      "aop_title": "Juvenile hormone receptor agonism leading to male offspring induction associated population decline"
+    }
+  ],
+  "KE 1210": [
+    {
+      "aop_id": "AOP 201",
+      "aop_title": "Juvenile hormone receptor agonism leading to male offspring induction associated population decline"
+    }
+  ],
+  "KE 361": [
+    {
+      "aop_id": "AOP 201",
+      "aop_title": "Juvenile hormone receptor agonism leading to male offspring induction associated population decline"
+    }
+  ],
+  "KE 1252": [
+    {
+      "aop_id": "AOP 202",
+      "aop_title": " Inhibitor binding to topoisomerase II leading to infant leukaemia"
+    }
+  ],
+  "KE 1253": [
+    {
+      "aop_id": "AOP 202",
+      "aop_title": " Inhibitor binding to topoisomerase II leading to infant leukaemia"
+    }
+  ],
+  "KE 1254": [
+    {
+      "aop_id": "AOP 202",
+      "aop_title": " Inhibitor binding to topoisomerase II leading to infant leukaemia"
+    }
+  ],
+  "KE 1461": [
+    {
+      "aop_id": "AOP 202",
+      "aop_title": " Inhibitor binding to topoisomerase II leading to infant leukaemia"
+    },
+    {
+      "aop_id": "AOP 330",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (4)"
+    },
+    {
+      "aop_id": "AOP 338",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (3)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    }
+  ],
+  "KE 1141": [
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 218",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased locomotor activity"
+    },
+    {
+      "aop_id": "AOP 219",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased sexual behavior"
+    },
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    }
+  ],
+  "KE 1256": [
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    }
+  ],
+  "KE 1257": [
+    {
+      "aop_id": "AOP 203",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to decreased reproductive success and population decline"
+    },
+    {
+      "aop_id": "AOP 204",
+      "aop_title": "5-hydroxytryptamine transporter inhibition leading to increased reproductive success and population increase"
+    }
+  ],
+  "KE 1258": [
+    {
+      "aop_id": "AOP 205",
+      "aop_title": "AOP from chemical insult to cell death"
+    }
+  ],
+  "KE 1259": [
+    {
+      "aop_id": "AOP 205",
+      "aop_title": "AOP from chemical insult to cell death"
+    }
+  ],
+  "KE 1260": [
+    {
+      "aop_id": "AOP 205",
+      "aop_title": "AOP from chemical insult to cell death"
+    }
+  ],
+  "KE 1262": [
+    {
+      "aop_id": "AOP 205",
+      "aop_title": "AOP from chemical insult to cell death"
+    },
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    },
+    {
+      "aop_id": "AOP 212",
+      "aop_title": "Histone deacetylase inhibition leading to testicular atrophy"
+    },
+    {
+      "aop_id": "AOP 285",
+      "aop_title": "Inhibition of N-linked glycosylation leads to liver injury"
+    },
+    {
+      "aop_id": "AOP 322",
+      "aop_title": "Alkylation of DNA leading to decreased sperm count"
+    },
+    {
+      "aop_id": "AOP 393",
+      "aop_title": "AOP for thyroid disorder caused by triphenyl phosphate via TRβ activation"
+    },
+    {
+      "aop_id": "AOP 419",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through P53 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    },
+    {
+      "aop_id": "AOP 441",
+      "aop_title": "Ionizing radiation-induced DNA damage leads to microcephaly via apoptosis and premature cell differentiation"
+    },
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    },
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 491",
+      "aop_title": "Decrease, GLI1/2 target gene expression leads to orofacial clefting "
+    },
+    {
+      "aop_id": "AOP 500",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via ROS and apoptosis"
+    },
+    {
+      "aop_id": "AOP 502",
+      "aop_title": "Decrease, cholesterol synthesis leads to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    },
+    {
+      "aop_id": "AOP 540",
+      "aop_title": "Oxidative Stress in the Fish Ovary Leads to Reproductive Impairment via Reduced Vitellogenin Production"
+    },
+    {
+      "aop_id": "AOP 563",
+      "aop_title": "Aryl hydrocarbon Receptor (AHR) activation causes Premature Ovarian Insufficiency via Bax mediated apoptosis"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 1263": [
+    {
+      "aop_id": "AOP 205",
+      "aop_title": "AOP from chemical insult to cell death"
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 1270": [
+    {
+      "aop_id": "AOP 206",
+      "aop_title": "Peroxisome proliferator-activated receptors γ inactivation leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1271": [
+    {
+      "aop_id": "AOP 206",
+      "aop_title": "Peroxisome proliferator-activated receptors γ inactivation leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 1275": [
+    {
+      "aop_id": "AOP 206",
+      "aop_title": "Peroxisome proliferator-activated receptors γ inactivation leading to lung fibrosis"
+    }
+  ],
+  "KE 1276": [
+    {
+      "aop_id": "AOP 206",
+      "aop_title": "Peroxisome proliferator-activated receptors γ inactivation leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 382",
+      "aop_title": "Angiotensin II type 1 receptor (AT1R) agonism leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 414",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through TGF-β dependent fibrosis toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 415",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through IL-6 toxicity pathway"
+    }
+  ],
+  "KE 1457": [
+    {
+      "aop_id": "AOP 206",
+      "aop_title": "Peroxisome proliferator-activated receptors γ inactivation leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 241",
+      "aop_title": "Latent Transforming Growth Factor beta1 activation leads to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 280",
+      "aop_title": "α-diketone-induced bronchiolitis obliterans"
+    },
+    {
+      "aop_id": "AOP 298",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human treatment-resistant gastric cancer"
+    },
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 414",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through TGF-β dependent fibrosis toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 415",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    },
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    },
+    {
+      "aop_id": "AOP 474",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer by promoting EMT"
+    }
+  ],
+  "KE 1174": [
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    }
+  ],
+  "KE 1277": [
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    },
+    {
+      "aop_id": "AOP 208",
+      "aop_title": "Janus kinase (JAK)/Signal transducer and activator of transcription (STAT) and Transforming growth factor (TGF)-beta pathways activation leading to reproductive failure"
+    },
+    {
+      "aop_id": "AOP 210",
+      "aop_title": "Activation of c-Jun N-terminal kinase (JNK) and Forkhead box O (FOXO) and reduction of WNT pathways leading to reproductive failure: Integrated multi-OMICS approach for AOP building"
+    },
+    {
+      "aop_id": "AOP 594",
+      "aop_title": "Micro plastic effect on reproduction"
+    }
+  ],
+  "KE 1279": [
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    }
+  ],
+  "KE 1280": [
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    }
+  ],
+  "KE 1281": [
+    {
+      "aop_id": "AOP 207",
+      "aop_title": "NADPH oxidase and P38 MAPK activation leading to reproductive failure in Caenorhabditis elegans"
+    },
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 1282": [
+    {
+      "aop_id": "AOP 208",
+      "aop_title": "Janus kinase (JAK)/Signal transducer and activator of transcription (STAT) and Transforming growth factor (TGF)-beta pathways activation leading to reproductive failure"
+    }
+  ],
+  "KE 1283": [
+    {
+      "aop_id": "AOP 208",
+      "aop_title": "Janus kinase (JAK)/Signal transducer and activator of transcription (STAT) and Transforming growth factor (TGF)-beta pathways activation leading to reproductive failure"
+    },
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    }
+  ],
+  "KE 1284": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    },
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    }
+  ],
+  "KE 1285": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    }
+  ],
+  "KE 1286": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    }
+  ],
+  "KE 1287": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    }
+  ],
+  "KE 1288": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    },
+    {
+      "aop_id": "AOP 594",
+      "aop_title": "Micro plastic effect on reproduction"
+    }
+  ],
+  "KE 1289": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    }
+  ],
+  "KE 1290": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    }
+  ],
+  "KE 1291": [
+    {
+      "aop_id": "AOP 209",
+      "aop_title": "Perturbation of cholesterol and glutathione homeostasis leading to hepatotoxicity: Integrated multi-OMICS approach for building AOP "
+    }
+  ],
+  "KE 1269": [
+    {
+      "aop_id": "AOP 21",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality, via increased COX-2"
+    }
+  ],
+  "KE 1292": [
+    {
+      "aop_id": "AOP 210",
+      "aop_title": "Activation of c-Jun N-terminal kinase (JNK) and Forkhead box O (FOXO) and reduction of WNT pathways leading to reproductive failure: Integrated multi-OMICS approach for AOP building"
+    },
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1293": [
+    {
+      "aop_id": "AOP 210",
+      "aop_title": "Activation of c-Jun N-terminal kinase (JNK) and Forkhead box O (FOXO) and reduction of WNT pathways leading to reproductive failure: Integrated multi-OMICS approach for AOP building"
+    },
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 1294": [
+    {
+      "aop_id": "AOP 210",
+      "aop_title": "Activation of c-Jun N-terminal kinase (JNK) and Forkhead box O (FOXO) and reduction of WNT pathways leading to reproductive failure: Integrated multi-OMICS approach for AOP building"
+    }
+  ],
+  "KE 1295": [
+    {
+      "aop_id": "AOP 210",
+      "aop_title": "Activation of c-Jun N-terminal kinase (JNK) and Forkhead box O (FOXO) and reduction of WNT pathways leading to reproductive failure: Integrated multi-OMICS approach for AOP building"
+    }
+  ],
+  "KE 1502": [
+    {
+      "aop_id": "AOP 212",
+      "aop_title": "Histone deacetylase inhibition leading to testicular atrophy"
+    },
+    {
+      "aop_id": "AOP 274",
+      "aop_title": "Histone deacetylase inhibition leads to impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 275",
+      "aop_title": "Histone deacetylase inhibition leads to neural tube defects"
+    },
+    {
+      "aop_id": "AOP 449",
+      "aop_title": "Ceramide synthase inhibition leading to neural tube defects "
+    }
+  ],
+  "KE 1503": [
+    {
+      "aop_id": "AOP 212",
+      "aop_title": "Histone deacetylase inhibition leading to testicular atrophy"
+    },
+    {
+      "aop_id": "AOP 275",
+      "aop_title": "Histone deacetylase inhibition leads to neural tube defects"
+    }
+  ],
+  "KE 1505": [
+    {
+      "aop_id": "AOP 212",
+      "aop_title": "Histone deacetylase inhibition leading to testicular atrophy"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 393",
+      "aop_title": "AOP for thyroid disorder caused by triphenyl phosphate via TRβ activation"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    },
+    {
+      "aop_id": "AOP 603",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 1506": [
+    {
+      "aop_id": "AOP 212",
+      "aop_title": "Histone deacetylase inhibition leading to testicular atrophy"
+    }
+  ],
+  "KE 1515": [
+    {
+      "aop_id": "AOP 212",
+      "aop_title": "Histone deacetylase inhibition leading to testicular atrophy"
+    }
+  ],
+  "KE 1305": [
+    {
+      "aop_id": "AOP 213",
+      "aop_title": "Inhibition of fatty acid beta oxidation leading to nonalcoholic steatohepatitis (NASH)"
+    }
+  ],
+  "KE 1489": [
+    {
+      "aop_id": "AOP 213",
+      "aop_title": "Inhibition of fatty acid beta oxidation leading to nonalcoholic steatohepatitis (NASH)"
+    },
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 1490": [
+    {
+      "aop_id": "AOP 213",
+      "aop_title": "Inhibition of fatty acid beta oxidation leading to nonalcoholic steatohepatitis (NASH)"
+    }
+  ],
+  "KE 1491": [
+    {
+      "aop_id": "AOP 213",
+      "aop_title": "Inhibition of fatty acid beta oxidation leading to nonalcoholic steatohepatitis (NASH)"
+    }
+  ],
+  "KE 459": [
+    {
+      "aop_id": "AOP 213",
+      "aop_title": "Inhibition of fatty acid beta oxidation leading to nonalcoholic steatohepatitis (NASH)"
+    },
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    },
+    {
+      "aop_id": "AOP 285",
+      "aop_title": "Inhibition of N-linked glycosylation leads to liver injury"
+    },
+    {
+      "aop_id": "AOP 318",
+      "aop_title": "Glucocorticoid Receptor activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    },
+    {
+      "aop_id": "AOP 494",
+      "aop_title": "AhR activation leading to liver fibrosis "
+    },
+    {
+      "aop_id": "AOP 517",
+      "aop_title": "Pregnane X Receptor (PXR) activation leads to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 518",
+      "aop_title": "Liver X Receptor (LXR) activation leads to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 62",
+      "aop_title": "AKT2 activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 1316": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    }
+  ],
+  "KE 1317": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1318": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    }
+  ],
+  "KE 1319": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    }
+  ],
+  "KE 1320": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    },
+    {
+      "aop_id": "AOP 568",
+      "aop_title": "Inhibition, 5-hydroxytryptamine transporter (5-HTT; SERT) leads to Inhibition, Feeding"
+    }
+  ],
+  "KE 1321": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 556",
+      "aop_title": "Decreased Na/K ATPase activity leading to heart failure"
+    }
+  ],
+  "KE 1322": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    }
+  ],
+  "KE 1323": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1324": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1325": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1326": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    }
+  ],
+  "KE 1328": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    }
+  ],
+  "KE 1329": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    }
+  ],
+  "KE 1330": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    },
+    {
+      "aop_id": "AOP 604",
+      "aop_title": "Binding of Alpha 1-Adrenergics to Agonists Leading to Depression"
+    }
+  ],
+  "KE 1334": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    }
+  ],
+  "KE 1335": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 604",
+      "aop_title": "Binding of Alpha 1-Adrenergics to Agonists Leading to Depression"
+    }
+  ],
+  "KE 1336": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1337": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1338": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1339": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    },
+    {
+      "aop_id": "AOP 499",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via disrupted neurotransmitter release"
+    },
+    {
+      "aop_id": "AOP 500",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via ROS and apoptosis"
+    }
+  ],
+  "KE 1340": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1341": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1342": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1343": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1344": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1345": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    }
+  ],
+  "KE 1346": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 604",
+      "aop_title": "Binding of Alpha 1-Adrenergics to Agonists Leading to Depression"
+    }
+  ],
+  "KE 1347": [
+    {
+      "aop_id": "AOP 214",
+      "aop_title": "Network of SSRIs (selective serotonin reuptake inhibitors)"
+    },
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    },
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    },
+    {
+      "aop_id": "AOP 226",
+      "aop_title": "SSRI (Selective serotonin reuptake inhibitor) to hypertension"
+    }
+  ],
+  "KE 1348": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1349": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1350": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    }
+  ],
+  "KE 1351": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    }
+  ],
+  "KE 1352": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    }
+  ],
+  "KE 1353": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 442",
+      "aop_title": "Binding to voltage gate sodium channels during development leads to cognitive impairment"
+    },
+    {
+      "aop_id": "AOP 489",
+      "aop_title": "Inhibition of voltage-gated sodium channels leading to decreased cognition"
+    }
+  ],
+  "KE 1354": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    }
+  ],
+  "KE 1355": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1356": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    }
+  ],
+  "KE 1357": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1358": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    }
+  ],
+  "KE 1359": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    }
+  ],
+  "KE 1360": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    }
+  ],
+  "KE 1361": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    }
+  ],
+  "KE 1362": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1363": [
+    {
+      "aop_id": "AOP 215",
+      "aop_title": "Molecular events lead to epilepsy"
+    },
+    {
+      "aop_id": "AOP 230",
+      "aop_title": "presynaptic neuron 1 activation to epilepsy"
+    },
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1366": [
+    {
+      "aop_id": "AOP 216",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 238",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 299",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 311",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 336",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (1)"
+    },
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 338",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (3)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    }
+  ],
+  "KE 1444": [
+    {
+      "aop_id": "AOP 216",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 299",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and follicular atresia"
+    }
+  ],
+  "KE 1635": [
+    {
+      "aop_id": "AOP 216",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 238",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 272",
+      "aop_title": "Deposition of energy leading to lung cancer"
+    },
+    {
+      "aop_id": "AOP 296",
+      "aop_title": "Oxidative DNA damage leading to chromosomal aberrations and mutations"
+    },
+    {
+      "aop_id": "AOP 322",
+      "aop_title": "Alkylation of DNA leading to decreased sperm count"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 325",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell death"
+    },
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    },
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    },
+    {
+      "aop_id": "AOP 644",
+      "aop_title": "Bulky DNA adducts leading to chromosomal aberrations and mutations"
+    }
+  ],
+  "KE 1686": [
+    {
+      "aop_id": "AOP 216",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 238",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 272",
+      "aop_title": "Deposition of energy leading to lung cancer"
+    },
+    {
+      "aop_id": "AOP 299",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 311",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 388",
+      "aop_title": "Deposition of ionising energy  leading to population decline via programmed cell death"
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    },
+    {
+      "aop_id": "AOP 435",
+      "aop_title": "Deposition of ionising energy leads to population decline via pollen abnormal"
+    },
+    {
+      "aop_id": "AOP 441",
+      "aop_title": "Ionizing radiation-induced DNA damage leads to microcephaly via apoptosis and premature cell differentiation"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    },
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    },
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 482",
+      "aop_title": "Deposition of energy leading to occurrence of bone loss"
+    },
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    }
+  ],
+  "KE 1367": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1368": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1369": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1370": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1371": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1372": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1373": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1374": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1375": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1376": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    },
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    }
+  ],
+  "KE 1377": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1378": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1379": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1380": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1381": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    }
+  ],
+  "KE 1382": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    },
+    {
+      "aop_id": "AOP 229",
+      "aop_title": "Helicobacter pylori to gastric ulcer"
+    }
+  ],
+  "KE 1383": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    },
+    {
+      "aop_id": "AOP 229",
+      "aop_title": "Helicobacter pylori to gastric ulcer"
+    }
+  ],
+  "KE 1384": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    },
+    {
+      "aop_id": "AOP 229",
+      "aop_title": "Helicobacter pylori to gastric ulcer"
+    }
+  ],
+  "KE 1385": [
+    {
+      "aop_id": "AOP 217",
+      "aop_title": "Gastric ulcer formation"
+    },
+    {
+      "aop_id": "AOP 227",
+      "aop_title": "NSAID induced PTGS1 inactivation to gastric ulcer"
+    },
+    {
+      "aop_id": "AOP 228",
+      "aop_title": "NSAID induced PTGS2 inactivation to gastric ulcer"
+    },
+    {
+      "aop_id": "AOP 229",
+      "aop_title": "Helicobacter pylori to gastric ulcer"
+    }
+  ],
+  "KE 1386": [
+    {
+      "aop_id": "AOP 218",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased locomotor activity"
+    },
+    {
+      "aop_id": "AOP 219",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased sexual behavior"
+    }
+  ],
+  "KE 1387": [
+    {
+      "aop_id": "AOP 218",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased locomotor activity"
+    },
+    {
+      "aop_id": "AOP 219",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased sexual behavior"
+    }
+  ],
+  "KE 1388": [
+    {
+      "aop_id": "AOP 218",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased locomotor activity"
+    },
+    {
+      "aop_id": "AOP 219",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased sexual behavior"
+    }
+  ],
+  "KE 1389": [
+    {
+      "aop_id": "AOP 218",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased locomotor activity"
+    }
+  ],
+  "KE 1390": [
+    {
+      "aop_id": "AOP 219",
+      "aop_title": "Inhibition of CYP7B activity leads to decreased reproductive success via decreased sexual behavior"
+    }
+  ],
+  "KE 1391": [
+    {
+      "aop_id": "AOP 220",
+      "aop_title": "Cyp2E1 Activation Leading to Liver Cancer"
+    },
+    {
+      "aop_id": "AOP 450",
+      "aop_title": " Inhibition of AChE and activation of CYP2E1 leading to sensory axonal peripheral neuropathy and mortality"
+    }
+  ],
+  "KE 1393": [
+    {
+      "aop_id": "AOP 220",
+      "aop_title": "Cyp2E1 Activation Leading to Liver Cancer"
+    }
+  ],
+  "KE 1394": [
+    {
+      "aop_id": "AOP 220",
+      "aop_title": "Cyp2E1 Activation Leading to Liver Cancer"
+    }
+  ],
+  "KE 1395": [
+    {
+      "aop_id": "AOP 220",
+      "aop_title": "Cyp2E1 Activation Leading to Liver Cancer"
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 1396": [
+    {
+      "aop_id": "AOP 221",
+      "aop_title": "Mental stress to depression"
+    },
+    {
+      "aop_id": "AOP 222",
+      "aop_title": "Mental stress to agitation"
+    }
+  ],
+  "KE 1397": [
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    }
+  ],
+  "KE 1398": [
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    }
+  ],
+  "KE 1399": [
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    }
+  ],
+  "KE 1400": [
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    },
+    {
+      "aop_id": "AOP 224",
+      "aop_title": "Serotonin transporter activation to depression"
+    },
+    {
+      "aop_id": "AOP 225",
+      "aop_title": "Serotonin transporter activation to agitation"
+    }
+  ],
+  "KE 1401": [
+    {
+      "aop_id": "AOP 223",
+      "aop_title": "Serotonin transporter activation to seizure"
+    }
+  ],
+  "KE 1402": [
+    {
+      "aop_id": "AOP 227",
+      "aop_title": "NSAID induced PTGS1 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1403": [
+    {
+      "aop_id": "AOP 227",
+      "aop_title": "NSAID induced PTGS1 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1404": [
+    {
+      "aop_id": "AOP 227",
+      "aop_title": "NSAID induced PTGS1 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1405": [
+    {
+      "aop_id": "AOP 227",
+      "aop_title": "NSAID induced PTGS1 inactivation to gastric ulcer"
+    },
+    {
+      "aop_id": "AOP 229",
+      "aop_title": "Helicobacter pylori to gastric ulcer"
+    }
+  ],
+  "KE 1406": [
+    {
+      "aop_id": "AOP 227",
+      "aop_title": "NSAID induced PTGS1 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1407": [
+    {
+      "aop_id": "AOP 227",
+      "aop_title": "NSAID induced PTGS1 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1408": [
+    {
+      "aop_id": "AOP 228",
+      "aop_title": "NSAID induced PTGS2 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1409": [
+    {
+      "aop_id": "AOP 228",
+      "aop_title": "NSAID induced PTGS2 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1410": [
+    {
+      "aop_id": "AOP 228",
+      "aop_title": "NSAID induced PTGS2 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1411": [
+    {
+      "aop_id": "AOP 228",
+      "aop_title": "NSAID induced PTGS2 inactivation to gastric ulcer"
+    }
+  ],
+  "KE 1412": [
+    {
+      "aop_id": "AOP 229",
+      "aop_title": "Helicobacter pylori to gastric ulcer"
+    }
+  ],
+  "KE 129": [
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    }
+  ],
+  "KE 274": [
+    {
+      "aop_id": "AOP 23",
+      "aop_title": "Androgen receptor agonism leading to reproductive dysfunction (in repeat-spawning fish)"
+    }
+  ],
+  "KE 1413": [
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1414": [
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1415": [
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1416": [
+    {
+      "aop_id": "AOP 231",
+      "aop_title": "presynaptic neuron 2 repression to epilepsy"
+    }
+  ],
+  "KE 1417": [
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    },
+    {
+      "aop_id": "AOP 507",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 508",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating HIF1α, Semaphorin 6A, and Dll4-Notch pathway"
+    },
+    {
+      "aop_id": "AOP 509",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating apoptosis signal pathway and mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 615",
+      "aop_title": "Suppression of Keap1 cysteine oxidation leading to liver inflammation"
+    }
+  ],
+  "KE 1421": [
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    }
+  ],
+  "KE 1422": [
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    }
+  ],
+  "KE 1423": [
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    }
+  ],
+  "KE 1424": [
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    }
+  ],
+  "KE 2421": [
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    },
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2423": [
+    {
+      "aop_id": "AOP 232",
+      "aop_title": "NFE2/Nrf2 repression to steatosis"
+    }
+  ],
+  "KE 1425": [
+    {
+      "aop_id": "AOP 233",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 234",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via Ca Channel Inhibition"
+    }
+  ],
+  "KE 1426": [
+    {
+      "aop_id": "AOP 233",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 234",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via Ca Channel Inhibition"
+    },
+    {
+      "aop_id": "AOP 235",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 236",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via Ca Channel Inhibition"
+    }
+  ],
+  "KE 1427": [
+    {
+      "aop_id": "AOP 233",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 235",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via K Channel Opening"
+    }
+  ],
+  "KE 1428": [
+    {
+      "aop_id": "AOP 233",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 234",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via Ca Channel Inhibition"
+    }
+  ],
+  "KE 1429": [
+    {
+      "aop_id": "AOP 234",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via Ca Channel Inhibition"
+    },
+    {
+      "aop_id": "AOP 236",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via Ca Channel Inhibition"
+    }
+  ],
+  "KE 1430": [
+    {
+      "aop_id": "AOP 234",
+      "aop_title": "Mu Opioid Receptor Agonism leading to Analgesia via Ca Channel Inhibition"
+    },
+    {
+      "aop_id": "AOP 236",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via Ca Channel Inhibition"
+    }
+  ],
+  "KE 1431": [
+    {
+      "aop_id": "AOP 235",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 236",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via Ca Channel Inhibition"
+    }
+  ],
+  "KE 1432": [
+    {
+      "aop_id": "AOP 235",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via K Channel Opening"
+    },
+    {
+      "aop_id": "AOP 236",
+      "aop_title": "Serotonin 1A Receptor Agonism leading to Anti-depressant Activity via Ca Channel Inhibition"
+    }
+  ],
+  "KE 1438": [
+    {
+      "aop_id": "AOP 237",
+      "aop_title": "Substance interaction with lung resident cell membrane components leading to atherosclerosis via acute phase response"
+    }
+  ],
+  "KE 1439": [
+    {
+      "aop_id": "AOP 237",
+      "aop_title": "Substance interaction with lung resident cell membrane components leading to atherosclerosis via acute phase response"
+    }
+  ],
+  "KE 1443": [
+    {
+      "aop_id": "AOP 237",
+      "aop_title": "Substance interaction with lung resident cell membrane components leading to atherosclerosis via acute phase response"
+    }
+  ],
+  "KE 1775": [
+    {
+      "aop_id": "AOP 238",
+      "aop_title": "Deposition of energy leading to population decline via DNA strand breaks and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 311",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 336",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (1)"
+    },
+    {
+      "aop_id": "AOP 338",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (3)"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    }
+  ],
+  "KE 1456": [
+    {
+      "aop_id": "AOP 241",
+      "aop_title": "Latent Transforming Growth Factor beta1 activation leads to pulmonary fibrosis"
+    }
+  ],
+  "KE 1468": [
+    {
+      "aop_id": "AOP 241",
+      "aop_title": "Latent Transforming Growth Factor beta1 activation leads to pulmonary fibrosis"
+    }
+  ],
+  "KE 1469": [
+    {
+      "aop_id": "AOP 241",
+      "aop_title": "Latent Transforming Growth Factor beta1 activation leads to pulmonary fibrosis"
+    }
+  ],
+  "KE 1462": [
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    }
+  ],
+  "KE 1463": [
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    }
+  ],
+  "KE 1464": [
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    }
+  ],
+  "KE 1465": [
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    }
+  ],
+  "KE 1466": [
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    }
+  ],
+  "KE 1467": [
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    },
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    }
+  ],
+  "KE 636": [
+    {
+      "aop_id": "AOP 242",
+      "aop_title": "Inhibition of lysyl oxidase leading to enhanced chronic fish toxicity"
+    },
+    {
+      "aop_id": "AOP 99",
+      "aop_title": "Histamine (H2) receptor antagonism leading to reduced survival"
+    }
+  ],
+  "KE 1471": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    }
+  ],
+  "KE 1472": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    },
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 389",
+      "aop_title": " Oxygen-evolving complex damage leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 567",
+      "aop_title": "Binding to plastoquinone B site leading to decreased population growth rate via photosystem II inhibition"
+    }
+  ],
+  "KE 1473": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    }
+  ],
+  "KE 1474": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    }
+  ],
+  "KE 1475": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    },
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 389",
+      "aop_title": " Oxygen-evolving complex damage leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 567",
+      "aop_title": "Binding to plastoquinone B site leading to decreased population growth rate via photosystem II inhibition"
+    }
+  ],
+  "KE 1476": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    }
+  ],
+  "KE 1477": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    },
+    {
+      "aop_id": "AOP 276",
+      "aop_title": "Inhibition of complex I of the electron transport chain leading to chemical induced Fanconi syndrome"
+    },
+    {
+      "aop_id": "AOP 328",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (2)"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    }
+  ],
+  "KE 1478": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    }
+  ],
+  "KE 1479": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    },
+    {
+      "aop_id": "AOP 389",
+      "aop_title": " Oxygen-evolving complex damage leading to population decline via inhibition of photosynthesis"
+    }
+  ],
+  "KE 1521": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    },
+    {
+      "aop_id": "AOP 263",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to  growth inhibition via decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 264",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via ATP depletion associated cell death"
+    },
+    {
+      "aop_id": "AOP 265",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via increased cytosolic calcium"
+    },
+    {
+      "aop_id": "AOP 266",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via decreased Na-K ATPase activity"
+    },
+    {
+      "aop_id": "AOP 267",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via glucose depletion"
+    },
+    {
+      "aop_id": "AOP 268",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via mitochondrial swelling"
+    },
+    {
+      "aop_id": "AOP 286",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 287",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (2)"
+    },
+    {
+      "aop_id": "AOP 290",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 291",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (2)"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 325",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell death"
+    },
+    {
+      "aop_id": "AOP 326",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 331",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 332",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 333",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    },
+    {
+      "aop_id": "AOP 567",
+      "aop_title": "Binding to plastoquinone B site leading to decreased population growth rate via photosystem II inhibition"
+    },
+    {
+      "aop_id": "AOP 596",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 598",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 599",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 600",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell growth"
+    },
+    {
+      "aop_id": "AOP 601",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    },
+    {
+      "aop_id": "AOP 603",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell cycle disruption"
+    }
+  ],
+  "KE 40": [
+    {
+      "aop_id": "AOP 245",
+      "aop_title": "Reduction in photophosphorylation leading to growth inhibition in aquatic plants"
+    },
+    {
+      "aop_id": "AOP 258",
+      "aop_title": "Renal protein alkylation leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 480",
+      "aop_title": "Mitochondrial complexes inhibition leading to heart failure via decreased ATP production"
+    },
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    },
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    }
+  ],
+  "KE 36": [
+    {
+      "aop_id": "AOP 25",
+      "aop_title": "Aromatase inhibition leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 346",
+      "aop_title": "Aromatase inhibition leads to male-biased sex ratio via impacts on gonad differentiation"
+    },
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    }
+  ],
+  "KE 1481": [
+    {
+      "aop_id": "AOP 256",
+      "aop_title": "Inhibition of mitochondrial DNA polymerase gamma leading to kidney toxicity"
+    }
+  ],
+  "KE 1482": [
+    {
+      "aop_id": "AOP 256",
+      "aop_title": "Inhibition of mitochondrial DNA polymerase gamma leading to kidney toxicity"
+    }
+  ],
+  "KE 1486": [
+    {
+      "aop_id": "AOP 257",
+      "aop_title": "Receptor mediated endocytosis and lysosomal overload leading to kidney toxicity"
+    }
+  ],
+  "KE 244": [
+    {
+      "aop_id": "AOP 258",
+      "aop_title": "Renal protein alkylation leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 38",
+      "aop_title": "Protein Alkylation leading to Liver Fibrosis"
+    }
+  ],
+  "KE 166": [
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    }
+  ],
+  "KE 178": [
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    },
+    {
+      "aop_id": "AOP 284",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress leads to chronic kidney disease"
+    },
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    },
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    }
+  ],
+  "KE 193": [
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    }
+  ],
+  "KE 50": [
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    }
+  ],
+  "KE 51": [
+    {
+      "aop_id": "AOP 26",
+      "aop_title": "Calcium-mediated neuronal ROS production and energy imbalance"
+    }
+  ],
+  "KE 1508": [
+    {
+      "aop_id": "AOP 260",
+      "aop_title": "CYP2E1 activation and formation of protein adducts leading to neurodegeneration"
+    }
+  ],
+  "KE 1509": [
+    {
+      "aop_id": "AOP 260",
+      "aop_title": "CYP2E1 activation and formation of protein adducts leading to neurodegeneration"
+    }
+  ],
+  "KE 1511": [
+    {
+      "aop_id": "AOP 260",
+      "aop_title": "CYP2E1 activation and formation of protein adducts leading to neurodegeneration"
+    }
+  ],
+  "KE 1512": [
+    {
+      "aop_id": "AOP 260",
+      "aop_title": "CYP2E1 activation and formation of protein adducts leading to neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 285",
+      "aop_title": "Inhibition of N-linked glycosylation leads to liver injury"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 1513": [
+    {
+      "aop_id": "AOP 260",
+      "aop_title": "CYP2E1 activation and formation of protein adducts leading to neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 505",
+      "aop_title": "Reactive Oxygen Species (ROS) formation leads to cancer via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 513",
+      "aop_title": "Reactive Oxygen (ROS) formation leads to cancer via Peroxisome proliferation-activated receptor (PPAR) pathway"
+    }
+  ],
+  "KE 1514": [
+    {
+      "aop_id": "AOP 260",
+      "aop_title": "CYP2E1 activation and formation of protein adducts leading to neurodegeneration"
+    }
+  ],
+  "KE 1529": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    },
+    {
+      "aop_id": "AOP 552",
+      "aop_title": "Inhibiton of L-Type Calcium Channels leading to heart failure via QT interval prolongation and Torsades de Pointes (TdP)"
+    }
+  ],
+  "KE 1530": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    }
+  ],
+  "KE 1531": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    }
+  ],
+  "KE 1532": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    },
+    {
+      "aop_id": "AOP 479",
+      "aop_title": "Mitochondrial complexes inhibition leading to left ventricular function decrease via increased myocardial oxidative stress"
+    },
+    {
+      "aop_id": "AOP 480",
+      "aop_title": "Mitochondrial complexes inhibition leading to heart failure via decreased ATP production"
+    },
+    {
+      "aop_id": "AOP 553",
+      "aop_title": "Inhibition of Voltage-gated sodium channels (Na⁺ channels)  leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 556",
+      "aop_title": "Decreased Na/K ATPase activity leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 558",
+      "aop_title": "Phosphodiesterase inhibition leading to heart failure"
+    }
+  ],
+  "KE 1533": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    }
+  ],
+  "KE 1535": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    },
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    },
+    {
+      "aop_id": "AOP 539",
+      "aop_title": "Decreased Sodium/Potassium ATPase activity leads to Heart failure"
+    },
+    {
+      "aop_id": "AOP 550",
+      "aop_title": "Increased LMNA gene mutation leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 552",
+      "aop_title": "Inhibiton of L-Type Calcium Channels leading to heart failure via QT interval prolongation and Torsades de Pointes (TdP)"
+    },
+    {
+      "aop_id": "AOP 553",
+      "aop_title": "Inhibition of Voltage-gated sodium channels (Na⁺ channels)  leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 555",
+      "aop_title": "Inhibition, Ether-a-go-go (ERG) Voltage-Gated Potassium Channel leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 556",
+      "aop_title": "Decreased Na/K ATPase activity leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 558",
+      "aop_title": "Phosphodiesterase inhibition leading to heart failure"
+    }
+  ],
+  "KE 1536": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    }
+  ],
+  "KE 1537": [
+    {
+      "aop_id": "AOP 261",
+      "aop_title": "L-type calcium channel blockade leading to heart failure via decrease in cardiac contractility"
+    }
+  ],
+  "KE 1446": [
+    {
+      "aop_id": "AOP 263",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to  growth inhibition via decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 264",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via ATP depletion associated cell death"
+    },
+    {
+      "aop_id": "AOP 265",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via increased cytosolic calcium"
+    },
+    {
+      "aop_id": "AOP 266",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via decreased Na-K ATPase activity"
+    },
+    {
+      "aop_id": "AOP 267",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via glucose depletion"
+    },
+    {
+      "aop_id": "AOP 268",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via mitochondrial swelling"
+    },
+    {
+      "aop_id": "AOP 326",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 331",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 332",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 333",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 534",
+      "aop_title": "Succinate dehydrogenase (SDH) inhibition leads to oxidative stress"
+    },
+    {
+      "aop_id": "AOP 596",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 598",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 612",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced adenosine triphosphate"
+    },
+    {
+      "aop_id": "AOP 613",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via increased reactive oxygen species production"
+    }
+  ],
+  "KE 1771": [
+    {
+      "aop_id": "AOP 263",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to  growth inhibition via decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 264",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via ATP depletion associated cell death"
+    },
+    {
+      "aop_id": "AOP 266",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via decreased Na-K ATPase activity"
+    },
+    {
+      "aop_id": "AOP 286",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 287",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (2)"
+    },
+    {
+      "aop_id": "AOP 290",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 291",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (2)"
+    },
+    {
+      "aop_id": "AOP 326",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 328",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (2)"
+    },
+    {
+      "aop_id": "AOP 329",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (3)"
+    },
+    {
+      "aop_id": "AOP 331",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 332",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 333",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 596",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 598",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 599",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 600",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell growth"
+    },
+    {
+      "aop_id": "AOP 601",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 612",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced adenosine triphosphate"
+    }
+  ],
+  "KE 1821": [
+    {
+      "aop_id": "AOP 263",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to  growth inhibition via decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 267",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via glucose depletion"
+    },
+    {
+      "aop_id": "AOP 286",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 290",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 326",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 332",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    },
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 491",
+      "aop_title": "Decrease, GLI1/2 target gene expression leads to orofacial clefting "
+    },
+    {
+      "aop_id": "AOP 502",
+      "aop_title": "Decrease, cholesterol synthesis leads to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    },
+    {
+      "aop_id": "AOP 598",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 601",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    },
+    {
+      "aop_id": "AOP 603",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell cycle disruption"
+    }
+  ],
+  "KE 2064": [
+    {
+      "aop_id": "AOP 265",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via increased cytosolic calcium"
+    }
+  ],
+  "KE 1527": [
+    {
+      "aop_id": "AOP 266",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via decreased Na-K ATPase activity"
+    },
+    {
+      "aop_id": "AOP 361",
+      "aop_title": "Sulfonylureareceptor binding leading to mortality"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 1562": [
+    {
+      "aop_id": "AOP 266",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via decreased Na-K ATPase activity"
+    },
+    {
+      "aop_id": "AOP 276",
+      "aop_title": "Inhibition of complex I of the electron transport chain leading to chemical induced Fanconi syndrome"
+    },
+    {
+      "aop_id": "AOP 516",
+      "aop_title": "Na+ /K+ -ATPase inhibition leading to hypertension"
+    },
+    {
+      "aop_id": "AOP 539",
+      "aop_title": "Decreased Sodium/Potassium ATPase activity leads to Heart failure"
+    },
+    {
+      "aop_id": "AOP 556",
+      "aop_title": "Decreased Na/K ATPase activity leading to heart failure"
+    }
+  ],
+  "KE 2070": [
+    {
+      "aop_id": "AOP 267",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via glucose depletion"
+    }
+  ],
+  "KE 2071": [
+    {
+      "aop_id": "AOP 267",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via glucose depletion"
+    }
+  ],
+  "KE 2072": [
+    {
+      "aop_id": "AOP 268",
+      "aop_title": "Uncoupling of oxidative phosphorylation leading to growth inhibition via mitochondrial swelling"
+    }
+  ],
+  "KE 214": [
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    }
+  ],
+  "KE 288": [
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    }
+  ],
+  "KE 357": [
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    }
+  ],
+  "KE 41": [
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    }
+  ],
+  "KE 87": [
+    {
+      "aop_id": "AOP 27",
+      "aop_title": "Cholestatic Liver Injury induced by Inhibition of the Bile Salt Export Pump (ABCB11)"
+    },
+    {
+      "aop_id": "AOP 303",
+      "aop_title": "Frustrated phagocytosis-induced lung cancer"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 412",
+      "aop_title": "Endothelial cell dysfunction leading to thromboinflammation"
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 1556": [
+    {
+      "aop_id": "AOP 272",
+      "aop_title": "Deposition of energy leading to lung cancer"
+    }
+  ],
+  "KE 1636": [
+    {
+      "aop_id": "AOP 272",
+      "aop_title": "Deposition of energy leading to lung cancer"
+    },
+    {
+      "aop_id": "AOP 296",
+      "aop_title": "Oxidative DNA damage leading to chromosomal aberrations and mutations"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 644",
+      "aop_title": "Bulky DNA adducts leading to chromosomal aberrations and mutations"
+    }
+  ],
+  "KE 1542": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 286",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 287",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (2)"
+    },
+    {
+      "aop_id": "AOP 587",
+      "aop_title": "Inhibition of the mitochondrial complex III of nigro-striatal neurons leads to parkinsonian motor deficits "
+    }
+  ],
+  "KE 1543": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 589",
+      "aop_title": "Inhibition of the mitochondrial complex IV of nigro-striatal neurons leads to parkinsonian motor deficits"
+    }
+  ],
+  "KE 1544": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1545": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 567",
+      "aop_title": "Binding to plastoquinone B site leading to decreased population growth rate via photosystem II inhibition"
+    }
+  ],
+  "KE 1547": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 1548": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1549": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 285",
+      "aop_title": "Inhibition of N-linked glycosylation leads to liver injury"
+    }
+  ],
+  "KE 1653": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1654": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1655": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 887": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 276",
+      "aop_title": "Inhibition of complex I of the electron transport chain leading to chemical induced Fanconi syndrome"
+    },
+    {
+      "aop_id": "AOP 3",
+      "aop_title": "Inhibition of the mitochondrial complex I of nigro-striatal neurons leads to parkinsonian motor deficits"
+    }
+  ],
+  "KE 888": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 276",
+      "aop_title": "Inhibition of complex I of the electron transport chain leading to chemical induced Fanconi syndrome"
+    },
+    {
+      "aop_id": "AOP 3",
+      "aop_title": "Inhibition of the mitochondrial complex I of nigro-striatal neurons leads to parkinsonian motor deficits"
+    }
+  ],
+  "KE 889": [
+    {
+      "aop_id": "AOP 273",
+      "aop_title": "Mitochondrial complex inhibition leading to liver injury"
+    },
+    {
+      "aop_id": "AOP 3",
+      "aop_title": "Inhibition of the mitochondrial complex I of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    },
+    {
+      "aop_id": "AOP 593",
+      "aop_title": "Redox cycling of a chemical by mitochondria leads to degeneration of nigrostriatal dopaminergic neurons "
+    }
+  ],
+  "KE 1557": [
+    {
+      "aop_id": "AOP 274",
+      "aop_title": "Histone deacetylase inhibition leads to impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 436",
+      "aop_title": "Inhibition of RALDH2 causes reduced all-trans retinoic acid levels, leading to transposition of the great arteries"
+    }
+  ],
+  "KE 1558": [
+    {
+      "aop_id": "AOP 274",
+      "aop_title": "Histone deacetylase inhibition leads to impeded craniofacial development"
+    }
+  ],
+  "KE 1559": [
+    {
+      "aop_id": "AOP 274",
+      "aop_title": "Histone deacetylase inhibition leads to impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 455",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced impeded craniofacial development"
+    }
+  ],
+  "KE 1560": [
+    {
+      "aop_id": "AOP 275",
+      "aop_title": "Histone deacetylase inhibition leads to neural tube defects"
+    }
+  ],
+  "KE 1561": [
+    {
+      "aop_id": "AOP 275",
+      "aop_title": "Histone deacetylase inhibition leads to neural tube defects"
+    },
+    {
+      "aop_id": "AOP 449",
+      "aop_title": "Ceramide synthase inhibition leading to neural tube defects "
+    }
+  ],
+  "KE 1563": [
+    {
+      "aop_id": "AOP 276",
+      "aop_title": "Inhibition of complex I of the electron transport chain leading to chemical induced Fanconi syndrome"
+    }
+  ],
+  "KE 1564": [
+    {
+      "aop_id": "AOP 276",
+      "aop_title": "Inhibition of complex I of the electron transport chain leading to chemical induced Fanconi syndrome"
+    }
+  ],
+  "KE 1700": [
+    {
+      "aop_id": "AOP 277",
+      "aop_title": "Impaired IL-1R1 signaling leading to Impaired T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1702": [
+    {
+      "aop_id": "AOP 277",
+      "aop_title": "Impaired IL-1R1 signaling leading to Impaired T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1574": [
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1575": [
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1576": [
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1579": [
+    {
+      "aop_id": "AOP 278",
+      "aop_title": "IKK complex inhibition leading to liver injury"
+    }
+  ],
+  "KE 1580": [
+    {
+      "aop_id": "AOP 279",
+      "aop_title": "Microtubule interacting drugs lead to peripheral neuropathy"
+    }
+  ],
+  "KE 1581": [
+    {
+      "aop_id": "AOP 279",
+      "aop_title": "Microtubule interacting drugs lead to peripheral neuropathy"
+    }
+  ],
+  "KE 1582": [
+    {
+      "aop_id": "AOP 279",
+      "aop_title": "Microtubule interacting drugs lead to peripheral neuropathy"
+    },
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1583": [
+    {
+      "aop_id": "AOP 279",
+      "aop_title": "Microtubule interacting drugs lead to peripheral neuropathy"
+    },
+    {
+      "aop_id": "AOP 450",
+      "aop_title": " Inhibition of AChE and activation of CYP2E1 leading to sensory axonal peripheral neuropathy and mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 106": [
+    {
+      "aop_id": "AOP 28",
+      "aop_title": "Cyclooxygenase inhibition leading reproductive failure"
+    }
+  ],
+  "KE 119": [
+    {
+      "aop_id": "AOP 28",
+      "aop_title": "Cyclooxygenase inhibition leading reproductive failure"
+    }
+  ],
+  "KE 243": [
+    {
+      "aop_id": "AOP 28",
+      "aop_title": "Cyclooxygenase inhibition leading reproductive failure"
+    }
+  ],
+  "KE 253": [
+    {
+      "aop_id": "AOP 28",
+      "aop_title": "Cyclooxygenase inhibition leading reproductive failure"
+    }
+  ],
+  "KE 49": [
+    {
+      "aop_id": "AOP 28",
+      "aop_title": "Cyclooxygenase inhibition leading reproductive failure"
+    }
+  ],
+  "KE 1584": [
+    {
+      "aop_id": "AOP 280",
+      "aop_title": "α-diketone-induced bronchiolitis obliterans"
+    }
+  ],
+  "KE 1585": [
+    {
+      "aop_id": "AOP 280",
+      "aop_title": "α-diketone-induced bronchiolitis obliterans"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 1586": [
+    {
+      "aop_id": "AOP 280",
+      "aop_title": "α-diketone-induced bronchiolitis obliterans"
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 1587": [
+    {
+      "aop_id": "AOP 280",
+      "aop_title": "α-diketone-induced bronchiolitis obliterans"
+    }
+  ],
+  "KE 1588": [
+    {
+      "aop_id": "AOP 280",
+      "aop_title": "α-diketone-induced bronchiolitis obliterans"
+    }
+  ],
+  "KE 1602": [
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 551",
+      "aop_title": "Increased Muscarinic M2 Receptor leading to Arrhythmia"
+    },
+    {
+      "aop_id": "AOP 559",
+      "aop_title": "Inhibition of acetylcholinesterase (AChE) leading to arrhythmias"
+    }
+  ],
+  "KE 1623": [
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    }
+  ],
+  "KE 1788": [
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    }
+  ],
+  "KE 388": [
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    }
+  ],
+  "KE 389": [
+    {
+      "aop_id": "AOP 281",
+      "aop_title": "Acetylcholinesterase Inhibition Leading to Neurodegeneration"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    },
+    {
+      "aop_id": "AOP 556",
+      "aop_title": "Decreased Na/K ATPase activity leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 558",
+      "aop_title": "Phosphodiesterase inhibition leading to heart failure"
+    }
+  ],
+  "KE 1594": [
+    {
+      "aop_id": "AOP 282",
+      "aop_title": "Adverse outcome pathway on photochemical toxicity initiated by light exposure"
+    }
+  ],
+  "KE 1595": [
+    {
+      "aop_id": "AOP 282",
+      "aop_title": "Adverse outcome pathway on photochemical toxicity initiated by light exposure"
+    }
+  ],
+  "KE 1599": [
+    {
+      "aop_id": "AOP 282",
+      "aop_title": "Adverse outcome pathway on photochemical toxicity initiated by light exposure"
+    },
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    }
+  ],
+  "KE 1603": [
+    {
+      "aop_id": "AOP 284",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress leads to chronic kidney disease"
+    },
+    {
+      "aop_id": "AOP 384",
+      "aop_title": "Hyperactivation of ACE/Ang-II/AT1R axis leading to chronic kidney disease "
+    }
+  ],
+  "KE 926": [
+    {
+      "aop_id": "AOP 284",
+      "aop_title": "Binding of electrophilic chemicals to SH(thiol)-group of proteins and /or to seleno-proteins involved in protection against oxidative stress leads to chronic kidney disease"
+    },
+    {
+      "aop_id": "AOP 413",
+      "aop_title": "Oxidation and antagonism of reduced glutathione leading to mortality via acute renal failure"
+    }
+  ],
+  "KE 1604": [
+    {
+      "aop_id": "AOP 285",
+      "aop_title": "Inhibition of N-linked glycosylation leads to liver injury"
+    }
+  ],
+  "KE 1605": [
+    {
+      "aop_id": "AOP 285",
+      "aop_title": "Inhibition of N-linked glycosylation leads to liver injury"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 1606": [
+    {
+      "aop_id": "AOP 285",
+      "aop_title": "Inhibition of N-linked glycosylation leads to liver injury"
+    }
+  ],
+  "KE 1825": [
+    {
+      "aop_id": "AOP 287",
+      "aop_title": "Mitochondrial complex III antagonism leading to growth inhibition (2)"
+    },
+    {
+      "aop_id": "AOP 291",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (2)"
+    },
+    {
+      "aop_id": "AOP 368",
+      "aop_title": "Cytochrome oxidase inhibition leading to increased nasal lesions"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    },
+    {
+      "aop_id": "AOP 418",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 482",
+      "aop_title": "Deposition of energy leading to occurrence of bone loss"
+    },
+    {
+      "aop_id": "AOP 573",
+      "aop_title": "Inhibition, cytochrome oxidase leads to Increased, pulmonary edema"
+    },
+    {
+      "aop_id": "AOP 574",
+      "aop_title": "Inhibition, cytochrome oxidase leads to Loss of olfactory function"
+    }
+  ],
+  "KE 1609": [
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    }
+  ],
+  "KE 1610": [
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    }
+  ],
+  "KE 1611": [
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    }
+  ],
+  "KE 1613": [
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    },
+    {
+      "aop_id": "AOP 289",
+      "aop_title": "Inhibition of 5α-reductase leading to impaired fecundity in female fish"
+    },
+    {
+      "aop_id": "AOP 305",
+      "aop_title": "5α-reductase inhibition leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 527",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Hypospadias, increased"
+    },
+    {
+      "aop_id": "AOP 571",
+      "aop_title": "5α-reductase inhibition leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 576",
+      "aop_title": "5α-reductase inhibition leading to increased nipple retention (NR) in male (rodent) offspring"
+    }
+  ],
+  "KE 1615": [
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    },
+    {
+      "aop_id": "AOP 528",
+      "aop_title": "Decreased Insulin-like peptide 3 (INSL3) leads to Malformation, cryptorchidism - maldescended testis"
+    }
+  ],
+  "KE 1616": [
+    {
+      "aop_id": "AOP 288",
+      "aop_title": "Inhibition of 17α-hydrolase/C 10,20-lyase (Cyp17A1) activity leads to birth reproductive defects (cryptorchidism) in male (mammals)"
+    },
+    {
+      "aop_id": "AOP 372",
+      "aop_title": "Androgen receptor antagonism leading to testicular cancer "
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 528",
+      "aop_title": "Decreased Insulin-like peptide 3 (INSL3) leads to Malformation, cryptorchidism - maldescended testis"
+    }
+  ],
+  "KE 220": [
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 53",
+      "aop_title": "ER agonism leading to reduced survival due to renal failure"
+    },
+    {
+      "aop_id": "AOP 536",
+      "aop_title": "Estrogen receptor agonism leading to reduced survival and population growth due to renal failure"
+    },
+    {
+      "aop_id": "AOP 537",
+      "aop_title": "Estrogen receptor agonism leads to reduced fecundity via increased vitellogenin in the liver"
+    }
+  ],
+  "KE 252": [
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 536",
+      "aop_title": "Estrogen receptor agonism leading to reduced survival and population growth due to renal failure"
+    }
+  ],
+  "KE 307": [
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 536",
+      "aop_title": "Estrogen receptor agonism leading to reduced survival and population growth due to renal failure"
+    },
+    {
+      "aop_id": "AOP 537",
+      "aop_title": "Estrogen receptor agonism leads to reduced fecundity via increased vitellogenin in the liver"
+    }
+  ],
+  "KE 339": [
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    }
+  ],
+  "KE 363": [
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 364": [
+    {
+      "aop_id": "AOP 29",
+      "aop_title": "Estrogen receptor agonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 537",
+      "aop_title": "Estrogen receptor agonism leads to reduced fecundity via increased vitellogenin in the liver"
+    },
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 1785": [
+    {
+      "aop_id": "AOP 290",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (1)"
+    },
+    {
+      "aop_id": "AOP 291",
+      "aop_title": "Mitochondrial ATP synthase antagonism leading to growth inhibition (2)"
+    }
+  ],
+  "KE 1627": [
+    {
+      "aop_id": "AOP 292",
+      "aop_title": "Inhibition of tyrosinase leads to decreased population in fish"
+    }
+  ],
+  "KE 1628": [
+    {
+      "aop_id": "AOP 292",
+      "aop_title": "Inhibition of tyrosinase leads to decreased population in fish"
+    }
+  ],
+  "KE 1629": [
+    {
+      "aop_id": "AOP 292",
+      "aop_title": "Inhibition of tyrosinase leads to decreased population in fish"
+    }
+  ],
+  "KE 1630": [
+    {
+      "aop_id": "AOP 292",
+      "aop_title": "Inhibition of tyrosinase leads to decreased population in fish"
+    }
+  ],
+  "KE 1631": [
+    {
+      "aop_id": "AOP 292",
+      "aop_title": "Inhibition of tyrosinase leads to decreased population in fish"
+    }
+  ],
+  "KE 1632": [
+    {
+      "aop_id": "AOP 293",
+      "aop_title": "Increased DNA damage leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 294",
+      "aop_title": "Increased reactive oxygen and nitrogen species (RONS) leading to increased risk of breast cancer"
+    },
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    },
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    }
+  ],
+  "KE 1634": [
+    {
+      "aop_id": "AOP 296",
+      "aop_title": "Oxidative DNA damage leading to chromosomal aberrations and mutations"
+    },
+    {
+      "aop_id": "AOP 299",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and follicular atresia"
+    },
+    {
+      "aop_id": "AOP 311",
+      "aop_title": "Deposition of energy leading to population decline via DNA oxidation and oocyte apoptosis"
+    },
+    {
+      "aop_id": "AOP 324",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell cycle disruption"
+    },
+    {
+      "aop_id": "AOP 325",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via oxidative DNA damage and cell death"
+    },
+    {
+      "aop_id": "AOP 330",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (4)"
+    },
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    },
+    {
+      "aop_id": "AOP 602",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via oxidative DNA damage"
+    }
+  ],
+  "KE 1637": [
+    {
+      "aop_id": "AOP 297",
+      "aop_title": "Inhibition of retinaldehyde dehydrogenase leads to population decline"
+    }
+  ],
+  "KE 1640": [
+    {
+      "aop_id": "AOP 297",
+      "aop_title": "Inhibition of retinaldehyde dehydrogenase leads to population decline"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    }
+  ],
+  "KE 1641": [
+    {
+      "aop_id": "AOP 297",
+      "aop_title": "Inhibition of retinaldehyde dehydrogenase leads to population decline"
+    }
+  ],
+  "KE 1642": [
+    {
+      "aop_id": "AOP 297",
+      "aop_title": "Inhibition of retinaldehyde dehydrogenase leads to population decline"
+    }
+  ],
+  "KE 1643": [
+    {
+      "aop_id": "AOP 297",
+      "aop_title": "Inhibition of retinaldehyde dehydrogenase leads to population decline"
+    },
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    },
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 365",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered photoreceptor patterning"
+    },
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    }
+  ],
+  "KE 1651": [
+    {
+      "aop_id": "AOP 298",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human treatment-resistant gastric cancer"
+    }
+  ],
+  "KE 1754": [
+    {
+      "aop_id": "AOP 298",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human treatment-resistant gastric cancer"
+    }
+  ],
+  "KE 1755": [
+    {
+      "aop_id": "AOP 298",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human treatment-resistant gastric cancer"
+    }
+  ],
+  "KE 890": [
+    {
+      "aop_id": "AOP 3",
+      "aop_title": "Inhibition of the mitochondrial complex I of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 587",
+      "aop_title": "Inhibition of the mitochondrial complex III of nigro-striatal neurons leads to parkinsonian motor deficits "
+    },
+    {
+      "aop_id": "AOP 588",
+      "aop_title": "Inhibition of the mitochondrial complex II of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 589",
+      "aop_title": "Inhibition of the mitochondrial complex IV of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 593",
+      "aop_title": "Redox cycling of a chemical by mitochondria leads to degeneration of nigrostriatal dopaminergic neurons "
+    }
+  ],
+  "KE 896": [
+    {
+      "aop_id": "AOP 3",
+      "aop_title": "Inhibition of the mitochondrial complex I of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 587",
+      "aop_title": "Inhibition of the mitochondrial complex III of nigro-striatal neurons leads to parkinsonian motor deficits "
+    },
+    {
+      "aop_id": "AOP 588",
+      "aop_title": "Inhibition of the mitochondrial complex II of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 589",
+      "aop_title": "Inhibition of the mitochondrial complex IV of nigro-striatal neurons leads to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 593",
+      "aop_title": "Redox cycling of a chemical by mitochondria leads to degeneration of nigrostriatal dopaminergic neurons "
+    }
+  ],
+  "KE 112": [
+    {
+      "aop_id": "AOP 30",
+      "aop_title": "Estrogen receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    },
+    {
+      "aop_id": "AOP 522",
+      "aop_title": "Estrogen antagonism leading to increased risk of autism-like behavior"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 1656": [
+    {
+      "aop_id": "AOP 300",
+      "aop_title": "Thyroid Receptor Antagonism and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    },
+    {
+      "aop_id": "AOP 485",
+      "aop_title": "Thyroid hormone antagonism leading to impaired oligodendrocyte maturation during development and subsequent decreased cognition"
+    },
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 1657": [
+    {
+      "aop_id": "AOP 301",
+      "aop_title": "Inhibition of Cystathionine Beta synthase leading to impaired the early development of anterior-posterior axis "
+    }
+  ],
+  "KE 1661": [
+    {
+      "aop_id": "AOP 301",
+      "aop_title": "Inhibition of Cystathionine Beta synthase leading to impaired the early development of anterior-posterior axis "
+    }
+  ],
+  "KE 1665": [
+    {
+      "aop_id": "AOP 301",
+      "aop_title": "Inhibition of Cystathionine Beta synthase leading to impaired the early development of anterior-posterior axis "
+    }
+  ],
+  "KE 1666": [
+    {
+      "aop_id": "AOP 301",
+      "aop_title": "Inhibition of Cystathionine Beta synthase leading to impaired the early development of anterior-posterior axis "
+    },
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    }
+  ],
+  "KE 1667": [
+    {
+      "aop_id": "AOP 301",
+      "aop_title": "Inhibition of Cystathionine Beta synthase leading to impaired the early development of anterior-posterior axis "
+    }
+  ],
+  "KE 1672": [
+    {
+      "aop_id": "AOP 302",
+      "aop_title": "Lung surfactant function inhibition leading to decreased lung function"
+    }
+  ],
+  "KE 1673": [
+    {
+      "aop_id": "AOP 302",
+      "aop_title": "Lung surfactant function inhibition leading to decreased lung function"
+    }
+  ],
+  "KE 1677": [
+    {
+      "aop_id": "AOP 302",
+      "aop_title": "Lung surfactant function inhibition leading to decreased lung function"
+    }
+  ],
+  "KE 1668": [
+    {
+      "aop_id": "AOP 303",
+      "aop_title": "Frustrated phagocytosis-induced lung cancer"
+    },
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    }
+  ],
+  "KE 1669": [
+    {
+      "aop_id": "AOP 303",
+      "aop_title": "Frustrated phagocytosis-induced lung cancer"
+    },
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    },
+    {
+      "aop_id": "AOP 416",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 417",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    }
+  ],
+  "KE 1670": [
+    {
+      "aop_id": "AOP 303",
+      "aop_title": "Frustrated phagocytosis-induced lung cancer"
+    },
+    {
+      "aop_id": "AOP 416",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 417",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 420",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through sustained NRF2 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    }
+  ],
+  "KE 1680": [
+    {
+      "aop_id": "AOP 304",
+      "aop_title": "TBX1 inhibition leading to congenital cardiac conotruncal anomalies"
+    }
+  ],
+  "KE 1681": [
+    {
+      "aop_id": "AOP 304",
+      "aop_title": "TBX1 inhibition leading to congenital cardiac conotruncal anomalies"
+    }
+  ],
+  "KE 1682": [
+    {
+      "aop_id": "AOP 304",
+      "aop_title": "TBX1 inhibition leading to congenital cardiac conotruncal anomalies"
+    },
+    {
+      "aop_id": "AOP 436",
+      "aop_title": "Inhibition of RALDH2 causes reduced all-trans retinoic acid levels, leading to transposition of the great arteries"
+    }
+  ],
+  "KE 1683": [
+    {
+      "aop_id": "AOP 304",
+      "aop_title": "TBX1 inhibition leading to congenital cardiac conotruncal anomalies"
+    }
+  ],
+  "KE 1684": [
+    {
+      "aop_id": "AOP 304",
+      "aop_title": "TBX1 inhibition leading to congenital cardiac conotruncal anomalies"
+    }
+  ],
+  "KE 1685": [
+    {
+      "aop_id": "AOP 304",
+      "aop_title": "TBX1 inhibition leading to congenital cardiac conotruncal anomalies"
+    }
+  ],
+  "KE 1688": [
+    {
+      "aop_id": "AOP 305",
+      "aop_title": "5α-reductase inhibition leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 306",
+      "aop_title": "Androgen receptor (AR) antagonism leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 307",
+      "aop_title": "Decreased testosterone synthesis leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    }
+  ],
+  "KE 2298": [
+    {
+      "aop_id": "AOP 307",
+      "aop_title": "Decreased testosterone synthesis leading to short anogenital distance (AGD) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 570",
+      "aop_title": "Decreased testosterone synthesis leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 575",
+      "aop_title": "Decreased testosterone synthesis leading to increased nipple retention (NR) in male (rodent) offspring"
+    }
+  ],
+  "KE 1691": [
+    {
+      "aop_id": "AOP 309",
+      "aop_title": "Luteinizing hormone receptor antagonism leading to reproductive dysfunction"
+    }
+  ],
+  "KE 1692": [
+    {
+      "aop_id": "AOP 309",
+      "aop_title": "Luteinizing hormone receptor antagonism leading to reproductive dysfunction"
+    }
+  ],
+  "KE 1693": [
+    {
+      "aop_id": "AOP 309",
+      "aop_title": "Luteinizing hormone receptor antagonism leading to reproductive dysfunction"
+    }
+  ],
+  "KE 1694": [
+    {
+      "aop_id": "AOP 309",
+      "aop_title": "Luteinizing hormone receptor antagonism leading to reproductive dysfunction"
+    }
+  ],
+  "KE 1695": [
+    {
+      "aop_id": "AOP 309",
+      "aop_title": "Luteinizing hormone receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 566",
+      "aop_title": "Decreased, GnRH pulsatility/release leading to estradiol availability, increased via impaired ovulation"
+    }
+  ],
+  "KE 1696": [
+    {
+      "aop_id": "AOP 309",
+      "aop_title": "Luteinizing hormone receptor antagonism leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 679": [
+    {
+      "aop_id": "AOP 309",
+      "aop_title": "Luteinizing hormone receptor antagonism leading to reproductive dysfunction"
+    }
+  ],
+  "KE 118": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 131": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 161": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 173": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 21": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 213": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 246": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 250": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 321": [
+    {
+      "aop_id": "AOP 31",
+      "aop_title": "Oxidation of iron in hemoglobin leading to hematotoxicity"
+    }
+  ],
+  "KE 1697": [
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    }
+  ],
+  "KE 1698": [
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    }
+  ],
+  "KE 1699": [
+    {
+      "aop_id": "AOP 310",
+      "aop_title": "Embryonic Activation of the AHR leading to Reproductive failure, via epigenetic down-regulation of GnRHR"
+    }
+  ],
+  "KE 1705": [
+    {
+      "aop_id": "AOP 312",
+      "aop_title": "Acetylcholinesterase Inhibition leading to Acute Mortality via Impaired Coordination & Movement​"
+    }
+  ],
+  "KE 1706": [
+    {
+      "aop_id": "AOP 313",
+      "aop_title": "Stimulation of TLR7/8 in dendric cells leading to Psoriatic skin disease"
+    }
+  ],
+  "KE 1707": [
+    {
+      "aop_id": "AOP 313",
+      "aop_title": "Stimulation of TLR7/8 in dendric cells leading to Psoriatic skin disease"
+    }
+  ],
+  "KE 1708": [
+    {
+      "aop_id": "AOP 313",
+      "aop_title": "Stimulation of TLR7/8 in dendric cells leading to Psoriatic skin disease"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1709": [
+    {
+      "aop_id": "AOP 313",
+      "aop_title": "Stimulation of TLR7/8 in dendric cells leading to Psoriatic skin disease"
+    }
+  ],
+  "KE 1822": [
+    {
+      "aop_id": "AOP 313",
+      "aop_title": "Stimulation of TLR7/8 in dendric cells leading to Psoriatic skin disease"
+    }
+  ],
+  "KE 1710": [
+    {
+      "aop_id": "AOP 314",
+      "aop_title": "Binding to estrogen receptor (ER)-α in immune cells leading to exacerbation of systemic lupus erythematosus (SLE)"
+    }
+  ],
+  "KE 1711": [
+    {
+      "aop_id": "AOP 314",
+      "aop_title": "Binding to estrogen receptor (ER)-α in immune cells leading to exacerbation of systemic lupus erythematosus (SLE)"
+    }
+  ],
+  "KE 1712": [
+    {
+      "aop_id": "AOP 314",
+      "aop_title": "Binding to estrogen receptor (ER)-α in immune cells leading to exacerbation of systemic lupus erythematosus (SLE)"
+    }
+  ],
+  "KE 1713": [
+    {
+      "aop_id": "AOP 314",
+      "aop_title": "Binding to estrogen receptor (ER)-α in immune cells leading to exacerbation of systemic lupus erythematosus (SLE)"
+    }
+  ],
+  "KE 1714": [
+    {
+      "aop_id": "AOP 314",
+      "aop_title": "Binding to estrogen receptor (ER)-α in immune cells leading to exacerbation of systemic lupus erythematosus (SLE)"
+    }
+  ],
+  "KE 1715": [
+    {
+      "aop_id": "AOP 315",
+      "aop_title": "Inhibition of JAK3 leading to impairment of T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1716": [
+    {
+      "aop_id": "AOP 315",
+      "aop_title": "Inhibition of JAK3 leading to impairment of T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1717": [
+    {
+      "aop_id": "AOP 315",
+      "aop_title": "Inhibition of JAK3 leading to impairment of T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1718": [
+    {
+      "aop_id": "AOP 315",
+      "aop_title": "Inhibition of JAK3 leading to impairment of T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1719": [
+    {
+      "aop_id": "AOP 315",
+      "aop_title": "Inhibition of JAK3 leading to impairment of T-Cell Dependent Antibody Response"
+    }
+  ],
+  "KE 1720": [
+    {
+      "aop_id": "AOP 316",
+      "aop_title": "Trypsin inhibition leading to pancreatic acinar cell tumors"
+    }
+  ],
+  "KE 1721": [
+    {
+      "aop_id": "AOP 316",
+      "aop_title": "Trypsin inhibition leading to pancreatic acinar cell tumors"
+    }
+  ],
+  "KE 1722": [
+    {
+      "aop_id": "AOP 316",
+      "aop_title": "Trypsin inhibition leading to pancreatic acinar cell tumors"
+    }
+  ],
+  "KE 1723": [
+    {
+      "aop_id": "AOP 316",
+      "aop_title": "Trypsin inhibition leading to pancreatic acinar cell tumors"
+    }
+  ],
+  "KE 1724": [
+    {
+      "aop_id": "AOP 316",
+      "aop_title": "Trypsin inhibition leading to pancreatic acinar cell tumors"
+    }
+  ],
+  "KE 1725": [
+    {
+      "aop_id": "AOP 316",
+      "aop_title": "Trypsin inhibition leading to pancreatic acinar cell tumors"
+    }
+  ],
+  "KE 1834": [
+    {
+      "aop_id": "AOP 318",
+      "aop_title": "Glucocorticoid Receptor activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 291": [
+    {
+      "aop_id": "AOP 318",
+      "aop_title": "Glucocorticoid Receptor activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 517",
+      "aop_title": "Pregnane X Receptor (PXR) activation leads to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 518",
+      "aop_title": "Liver X Receptor (LXR) activation leads to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    },
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 860": [
+    {
+      "aop_id": "AOP 318",
+      "aop_title": "Glucocorticoid Receptor activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 1172": [
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 382",
+      "aop_title": "Angiotensin II type 1 receptor (AT1R) agonism leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    }
+  ],
+  "KE 1740": [
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 383",
+      "aop_title": "Inhibition of Angiotensin-converting enzyme 2 leading to liver fibrosis"
+    }
+  ],
+  "KE 1752": [
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 381",
+      "aop_title": "Binding of viral S-glycoprotein to ACE2 receptor leading to dysgeusia"
+    },
+    {
+      "aop_id": "AOP 384",
+      "aop_title": "Hyperactivation of ACE/Ang-II/AT1R axis leading to chronic kidney disease "
+    },
+    {
+      "aop_id": "AOP 385",
+      "aop_title": "Viral spike protein interaction with ACE2 leads to microvascular dysfunction, via ACE2 dysregulation"
+    }
+  ],
+  "KE 1851": [
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 382",
+      "aop_title": "Angiotensin II type 1 receptor (AT1R) agonism leading to lung fibrosis"
+    }
+  ],
+  "KE 1854": [
+    {
+      "aop_id": "AOP 319",
+      "aop_title": "Binding to ACE2 leading to lung fibrosis"
+    },
+    {
+      "aop_id": "AOP 385",
+      "aop_title": "Viral spike protein interaction with ACE2 leads to microvascular dysfunction, via ACE2 dysregulation"
+    },
+    {
+      "aop_id": "AOP 428",
+      "aop_title": "Binding of S-protein to ACE2 in enterocytes induces ACE2 dysregulation leading to gut dysbiosis "
+    }
+  ],
+  "KE 147": [
+    {
+      "aop_id": "AOP 32",
+      "aop_title": "Inhibition of iNOS, hepatotoxicity, and regenerative proliferation leading to liver tumors"
+    }
+  ],
+  "KE 164": [
+    {
+      "aop_id": "AOP 32",
+      "aop_title": "Inhibition of iNOS, hepatotoxicity, and regenerative proliferation leading to liver tumors"
+    }
+  ],
+  "KE 269": [
+    {
+      "aop_id": "AOP 32",
+      "aop_title": "Inhibition of iNOS, hepatotoxicity, and regenerative proliferation leading to liver tumors"
+    }
+  ],
+  "KE 270": [
+    {
+      "aop_id": "AOP 32",
+      "aop_title": "Inhibition of iNOS, hepatotoxicity, and regenerative proliferation leading to liver tumors"
+    }
+  ],
+  "KE 347": [
+    {
+      "aop_id": "AOP 32",
+      "aop_title": "Inhibition of iNOS, hepatotoxicity, and regenerative proliferation leading to liver tumors"
+    }
+  ],
+  "KE 77": [
+    {
+      "aop_id": "AOP 32",
+      "aop_title": "Inhibition of iNOS, hepatotoxicity, and regenerative proliferation leading to liver tumors"
+    }
+  ],
+  "KE 1738": [
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 379",
+      "aop_title": "Binding to ACE2 leading to thrombosis and disseminated intravascular coagulation"
+    },
+    {
+      "aop_id": "AOP 394",
+      "aop_title": "SARS-CoV-2 infection of olfactory epithelium leading to impaired olfactory function (short-term anosmia)"
+    },
+    {
+      "aop_id": "AOP 395",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on pericytes leads to disseminated intravascular coagulation resulting in cerebrovascular disease (stroke)"
+    },
+    {
+      "aop_id": "AOP 406",
+      "aop_title": "SARS-CoV-2 infection leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 407",
+      "aop_title": "SARS-CoV-2 infection leading to pyroptosis"
+    },
+    {
+      "aop_id": "AOP 422",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 in enterocytes leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    },
+    {
+      "aop_id": "AOP 430",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to viral infection proliferation"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    }
+  ],
+  "KE 1739": [
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 374",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on brain cells (neuronal and non-neuronal) leads to neuroinflammation resulting in encephalitis"
+    },
+    {
+      "aop_id": "AOP 379",
+      "aop_title": "Binding to ACE2 leading to thrombosis and disseminated intravascular coagulation"
+    },
+    {
+      "aop_id": "AOP 381",
+      "aop_title": "Binding of viral S-glycoprotein to ACE2 receptor leading to dysgeusia"
+    },
+    {
+      "aop_id": "AOP 385",
+      "aop_title": "Viral spike protein interaction with ACE2 leads to microvascular dysfunction, via ACE2 dysregulation"
+    },
+    {
+      "aop_id": "AOP 394",
+      "aop_title": "SARS-CoV-2 infection of olfactory epithelium leading to impaired olfactory function (short-term anosmia)"
+    },
+    {
+      "aop_id": "AOP 395",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on pericytes leads to disseminated intravascular coagulation resulting in cerebrovascular disease (stroke)"
+    },
+    {
+      "aop_id": "AOP 406",
+      "aop_title": "SARS-CoV-2 infection leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 407",
+      "aop_title": "SARS-CoV-2 infection leading to pyroptosis"
+    },
+    {
+      "aop_id": "AOP 422",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 in enterocytes leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    },
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    },
+    {
+      "aop_id": "AOP 428",
+      "aop_title": "Binding of S-protein to ACE2 in enterocytes induces ACE2 dysregulation leading to gut dysbiosis "
+    },
+    {
+      "aop_id": "AOP 430",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to viral infection proliferation"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    }
+  ],
+  "KE 1748": [
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1750": [
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    }
+  ],
+  "KE 1847": [
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 379",
+      "aop_title": "Binding to ACE2 leading to thrombosis and disseminated intravascular coagulation"
+    },
+    {
+      "aop_id": "AOP 394",
+      "aop_title": "SARS-CoV-2 infection of olfactory epithelium leading to impaired olfactory function (short-term anosmia)"
+    },
+    {
+      "aop_id": "AOP 406",
+      "aop_title": "SARS-CoV-2 infection leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 407",
+      "aop_title": "SARS-CoV-2 infection leading to pyroptosis"
+    },
+    {
+      "aop_id": "AOP 422",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 in enterocytes leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 430",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to viral infection proliferation"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    }
+  ],
+  "KE 1848": [
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 378",
+      "aop_title": "Dysregulated underperforming Toll Like Receptors (TLRs) leading to high pathogen load"
+    }
+  ],
+  "KE 1901": [
+    {
+      "aop_id": "AOP 320",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 receptor leading to acute respiratory distress associated mortality"
+    },
+    {
+      "aop_id": "AOP 379",
+      "aop_title": "Binding to ACE2 leading to thrombosis and disseminated intravascular coagulation"
+    },
+    {
+      "aop_id": "AOP 422",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 in enterocytes leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 430",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to viral infection proliferation"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    }
+  ],
+  "KE 1757": [
+    {
+      "aop_id": "AOP 322",
+      "aop_title": "Alkylation of DNA leading to decreased sperm count"
+    },
+    {
+      "aop_id": "AOP 400",
+      "aop_title": "Inhibition of CYP26B1 activity in fetal testis leading to reduced fertility"
+    },
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 1756": [
+    {
+      "aop_id": "AOP 323",
+      "aop_title": "PPARalpha Agonism Leading to Decreased Viable Offspring via Decreased 11-Ketotestosterone"
+    },
+    {
+      "aop_id": "AOP 348",
+      "aop_title": "Inhibition of 11β-Hydroxysteroid Dehydrogenase leading to decreased population trajectory "
+    },
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    }
+  ],
+  "KE 1758": [
+    {
+      "aop_id": "AOP 323",
+      "aop_title": "PPARalpha Agonism Leading to Decreased Viable Offspring via Decreased 11-Ketotestosterone"
+    },
+    {
+      "aop_id": "AOP 348",
+      "aop_title": "Inhibition of 11β-Hydroxysteroid Dehydrogenase leading to decreased population trajectory "
+    },
+    {
+      "aop_id": "AOP 521",
+      "aop_title": "Essential element imbalance leads to reproductive failure via oxidative stress"
+    },
+    {
+      "aop_id": "AOP 526",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Impaired, Spermatogenesis"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 2147": [
+    {
+      "aop_id": "AOP 323",
+      "aop_title": "PPARalpha Agonism Leading to Decreased Viable Offspring via Decreased 11-Ketotestosterone"
+    },
+    {
+      "aop_id": "AOP 521",
+      "aop_title": "Essential element imbalance leads to reproductive failure via oxidative stress"
+    }
+  ],
+  "KE 1445": [
+    {
+      "aop_id": "AOP 326",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 329",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (3)"
+    },
+    {
+      "aop_id": "AOP 331",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via lipid peroxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 413",
+      "aop_title": "Oxidation and antagonism of reduced glutathione leading to mortality via acute renal failure"
+    },
+    {
+      "aop_id": "AOP 492",
+      "aop_title": "Glutathione conjugation leading to reproductive dysfunction via oxidative stress"
+    },
+    {
+      "aop_id": "AOP 521",
+      "aop_title": "Essential element imbalance leads to reproductive failure via oxidative stress"
+    },
+    {
+      "aop_id": "AOP 615",
+      "aop_title": "Suppression of Keap1 cysteine oxidation leading to liver inflammation"
+    }
+  ],
+  "KE 1767": [
+    {
+      "aop_id": "AOP 327",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (1)"
+    },
+    {
+      "aop_id": "AOP 332",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and decreased cell proliferation"
+    },
+    {
+      "aop_id": "AOP 333",
+      "aop_title": "Reactive oxygen species leading to growth inhibition via protein oxidation and cell death"
+    },
+    {
+      "aop_id": "AOP 596",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 598",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 599",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 600",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell growth"
+    },
+    {
+      "aop_id": "AOP 601",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell proliferation"
+    },
+    {
+      "aop_id": "AOP 603",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via protein oxidation and cell cycle disruption"
+    }
+  ],
+  "KE 1768": [
+    {
+      "aop_id": "AOP 327",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (1)"
+    }
+  ],
+  "KE 1769": [
+    {
+      "aop_id": "AOP 327",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (1)"
+    }
+  ],
+  "KE 350": [
+    {
+      "aop_id": "AOP 327",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (1)"
+    },
+    {
+      "aop_id": "AOP 328",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (2)"
+    },
+    {
+      "aop_id": "AOP 329",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (3)"
+    },
+    {
+      "aop_id": "AOP 330",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (4)"
+    },
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 358",
+      "aop_title": "Chitinase inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 359",
+      "aop_title": "Chitobiase inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 360",
+      "aop_title": "Chitin synthase 1 inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 361",
+      "aop_title": "Sulfonylureareceptor binding leading to mortality"
+    },
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    },
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    },
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 606",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via inhibition of chitin synthase 1"
+    }
+  ],
+  "KE 1770": [
+    {
+      "aop_id": "AOP 328",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (2)"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    }
+  ],
+  "KE 1772": [
+    {
+      "aop_id": "AOP 329",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (3)"
+    }
+  ],
+  "KE 759": [
+    {
+      "aop_id": "AOP 33",
+      "aop_title": "Kidney toxicity induced by activation of 5HT2C"
+    },
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 413",
+      "aop_title": "Oxidation and antagonism of reduced glutathione leading to mortality via acute renal failure"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    }
+  ],
+  "KE 9": [
+    {
+      "aop_id": "AOP 33",
+      "aop_title": "Kidney toxicity induced by activation of 5HT2C"
+    }
+  ],
+  "KE 1365": [
+    {
+      "aop_id": "AOP 330",
+      "aop_title": "Excessive reactive oxygen species production leading to mortality (4)"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 509",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating apoptosis signal pathway and mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    }
+  ],
+  "KE 1761": [
+    {
+      "aop_id": "AOP 334",
+      "aop_title": "Glucocorticoid Receptor Agonism Leading to Impaired Fin Regeneration"
+    }
+  ],
+  "KE 2089": [
+    {
+      "aop_id": "AOP 334",
+      "aop_title": "Glucocorticoid Receptor Agonism Leading to Impaired Fin Regeneration"
+    },
+    {
+      "aop_id": "AOP 482",
+      "aop_title": "Deposition of energy leading to occurrence of bone loss"
+    }
+  ],
+  "KE 2245": [
+    {
+      "aop_id": "AOP 334",
+      "aop_title": "Glucocorticoid Receptor Agonism Leading to Impaired Fin Regeneration"
+    },
+    {
+      "aop_id": "AOP 482",
+      "aop_title": "Deposition of energy leading to occurrence of bone loss"
+    }
+  ],
+  "KE 1762": [
+    {
+      "aop_id": "AOP 335",
+      "aop_title": "AOP for urothelial carcinogenesis due to chemical cytotoxicity by mitochondrial impairment "
+    }
+  ],
+  "KE 1763": [
+    {
+      "aop_id": "AOP 335",
+      "aop_title": "AOP for urothelial carcinogenesis due to chemical cytotoxicity by mitochondrial impairment "
+    }
+  ],
+  "KE 1619": [
+    {
+      "aop_id": "AOP 336",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (1)"
+    },
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 338",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (3)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    },
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    },
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    },
+    {
+      "aop_id": "AOP 474",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer by promoting EMT"
+    }
+  ],
+  "KE 1773": [
+    {
+      "aop_id": "AOP 336",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (1)"
+    },
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    },
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    }
+  ],
+  "KE 1774": [
+    {
+      "aop_id": "AOP 336",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (1)"
+    },
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 338",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (3)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    }
+  ],
+  "KE 328": [
+    {
+      "aop_id": "AOP 336",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (1)"
+    },
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 338",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (3)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    }
+  ],
+  "KE 1776": [
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    }
+  ],
+  "KE 1777": [
+    {
+      "aop_id": "AOP 337",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (2)"
+    },
+    {
+      "aop_id": "AOP 339",
+      "aop_title": "DNA methyltransferase inhibition leading to population decline (4)"
+    }
+  ],
+  "KE 115": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 517",
+      "aop_title": "Pregnane X Receptor (PXR) activation leads to liver steatosis"
+    }
+  ],
+  "KE 116": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 167": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 518",
+      "aop_title": "Liver X Receptor (LXR) activation leads to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    }
+  ],
+  "KE 228": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 258": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 264": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 345": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 54": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 517",
+      "aop_title": "Pregnane X Receptor (PXR) activation leads to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 66": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    }
+  ],
+  "KE 89": [
+    {
+      "aop_id": "AOP 34",
+      "aop_title": "LXR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 518",
+      "aop_title": "Liver X Receptor (LXR) activation leads to liver steatosis"
+    }
+  ],
+  "KE 1778": [
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    },
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    }
+  ],
+  "KE 1779": [
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    },
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    }
+  ],
+  "KE 1780": [
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    }
+  ],
+  "KE 1781": [
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    },
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    }
+  ],
+  "KE 1782": [
+    {
+      "aop_id": "AOP 340",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (1)"
+    },
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    }
+  ],
+  "KE 1783": [
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    }
+  ],
+  "KE 1784": [
+    {
+      "aop_id": "AOP 341",
+      "aop_title": "DNA methyltransferase inhibition leading to transgenerational effects (2)"
+    }
+  ],
+  "KE 103": [
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    }
+  ],
+  "KE 1266": [
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    }
+  ],
+  "KE 1267": [
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    }
+  ],
+  "KE 2373": [
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    }
+  ],
+  "KE 988": [
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    }
+  ],
+  "KE 990": [
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    },
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    },
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 993": [
+    {
+      "aop_id": "AOP 342",
+      "aop_title": "Ecdysone receptor hyperactivation leading to mortality via mis-timed activation of nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    }
+  ],
+  "KE 2374": [
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 606",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via inhibition of chitin synthase 1"
+    }
+  ],
+  "KE 2375": [
+    {
+      "aop_id": "AOP 343",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via mis-timed ecdysone receptor-responsive nuclear receptor cascade"
+    },
+    {
+      "aop_id": "AOP 606",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via inhibition of chitin synthase 1"
+    }
+  ],
+  "KE 1786": [
+    {
+      "aop_id": "AOP 344",
+      "aop_title": "Androgen receptor (AR) antagonism leading to nipple retention (NR) in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 575",
+      "aop_title": "Decreased testosterone synthesis leading to increased nipple retention (NR) in male (rodent) offspring"
+    },
+    {
+      "aop_id": "AOP 576",
+      "aop_title": "5α-reductase inhibition leading to increased nipple retention (NR) in male (rodent) offspring"
+    }
+  ],
+  "KE 1800": [
+    {
+      "aop_id": "AOP 345",
+      "aop_title": "Androgen receptor (AR) antagonism leading to decreased fertility in females"
+    }
+  ],
+  "KE 405": [
+    {
+      "aop_id": "AOP 345",
+      "aop_title": "Androgen receptor (AR) antagonism leading to decreased fertility in females"
+    },
+    {
+      "aop_id": "AOP 398",
+      "aop_title": "Decreased ALDH1A (RALDH) activity leading to decreased fertility via disrupted meiotic initiation of fetal oogonia "
+    },
+    {
+      "aop_id": "AOP 7",
+      "aop_title": "Aromatase (Cyp19a1) reduction leading to impaired fertility in adult female"
+    }
+  ],
+  "KE 1789": [
+    {
+      "aop_id": "AOP 346",
+      "aop_title": "Aromatase inhibition leads to male-biased sex ratio via impacts on gonad differentiation"
+    }
+  ],
+  "KE 1790": [
+    {
+      "aop_id": "AOP 346",
+      "aop_title": "Aromatase inhibition leads to male-biased sex ratio via impacts on gonad differentiation"
+    },
+    {
+      "aop_id": "AOP 376",
+      "aop_title": "Androgen receptor agonism leading to male-biased sex ratio"
+    }
+  ],
+  "KE 1791": [
+    {
+      "aop_id": "AOP 346",
+      "aop_title": "Aromatase inhibition leads to male-biased sex ratio via impacts on gonad differentiation"
+    },
+    {
+      "aop_id": "AOP 376",
+      "aop_title": "Androgen receptor agonism leading to male-biased sex ratio"
+    }
+  ],
+  "KE 1792": [
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1793": [
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1794": [
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1795": [
+    {
+      "aop_id": "AOP 347",
+      "aop_title": "Toll-like receptor 4 activation and peroxisome proliferator-activated receptor gamma inactivation leading to pulmonary fibrosis"
+    }
+  ],
+  "KE 1799": [
+    {
+      "aop_id": "AOP 348",
+      "aop_title": "Inhibition of 11β-Hydroxysteroid Dehydrogenase leading to decreased population trajectory "
+    }
+  ],
+  "KE 1796": [
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    }
+  ],
+  "KE 1798": [
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    }
+  ],
+  "KE 1835": [
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    }
+  ],
+  "KE 1836": [
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    }
+  ],
+  "KE 1837": [
+    {
+      "aop_id": "AOP 349",
+      "aop_title": "Inhibition of 11β-hydroxylase leading to decresed population trajectory "
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 169": [
+    {
+      "aop_id": "AOP 35",
+      "aop_title": "Narcosis leading to respiratory failure"
+    }
+  ],
+  "KE 46": [
+    {
+      "aop_id": "AOP 35",
+      "aop_title": "Narcosis leading to respiratory failure"
+    }
+  ],
+  "KE 1524": [
+    {
+      "aop_id": "AOP 358",
+      "aop_title": "Chitinase inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 359",
+      "aop_title": "Chitobiase inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 360",
+      "aop_title": "Chitin synthase 1 inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 361",
+      "aop_title": "Sulfonylureareceptor binding leading to mortality"
+    },
+    {
+      "aop_id": "AOP 606",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via inhibition of chitin synthase 1"
+    }
+  ],
+  "KE 1806": [
+    {
+      "aop_id": "AOP 358",
+      "aop_title": "Chitinase inhibition leading to mortality"
+    }
+  ],
+  "KE 996": [
+    {
+      "aop_id": "AOP 358",
+      "aop_title": "Chitinase inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 359",
+      "aop_title": "Chitobiase inhibition leading to mortality"
+    }
+  ],
+  "KE 1807": [
+    {
+      "aop_id": "AOP 359",
+      "aop_title": "Chitobiase inhibition leading to mortality"
+    }
+  ],
+  "KE 140": [
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    }
+  ],
+  "KE 179": [
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    },
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    },
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 599",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and cell injury/death"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 600",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell growth"
+    },
+    {
+      "aop_id": "AOP 601",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell proliferation"
+    }
+  ],
+  "KE 231": [
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    }
+  ],
+  "KE 232": [
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    }
+  ],
+  "KE 233": [
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    },
+    {
+      "aop_id": "AOP 513",
+      "aop_title": "Reactive Oxygen (ROS) formation leads to cancer via Peroxisome proliferation-activated receptor (PPAR) pathway"
+    }
+  ],
+  "KE 327": [
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    },
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 8": [
+    {
+      "aop_id": "AOP 36",
+      "aop_title": "Peroxisomal Fatty Acid Beta-Oxidation Inhibition Leading to Steatosis"
+    }
+  ],
+  "KE 1522": [
+    {
+      "aop_id": "AOP 360",
+      "aop_title": "Chitin synthase 1 inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 606",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via inhibition of chitin synthase 1"
+    }
+  ],
+  "KE 1523": [
+    {
+      "aop_id": "AOP 360",
+      "aop_title": "Chitin synthase 1 inhibition leading to mortality"
+    },
+    {
+      "aop_id": "AOP 361",
+      "aop_title": "Sulfonylureareceptor binding leading to mortality"
+    },
+    {
+      "aop_id": "AOP 606",
+      "aop_title": "Ecdysone receptor antagonism leading to mortality via inhibition of chitin synthase 1"
+    }
+  ],
+  "KE 1525": [
+    {
+      "aop_id": "AOP 361",
+      "aop_title": "Sulfonylureareceptor binding leading to mortality"
+    }
+  ],
+  "KE 1526": [
+    {
+      "aop_id": "AOP 361",
+      "aop_title": "Sulfonylureareceptor binding leading to mortality"
+    }
+  ],
+  "KE 1633": [
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 1814": [
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    }
+  ],
+  "KE 1815": [
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 1817": [
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    },
+    {
+      "aop_id": "AOP 423",
+      "aop_title": " Toxicological mechanisms of hepatocyte apoptosis through the PARP1 dependent cell death pathway "
+    }
+  ],
+  "KE 1818": [
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    }
+  ],
+  "KE 1819": [
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    }
+  ],
+  "KE 1820": [
+    {
+      "aop_id": "AOP 362",
+      "aop_title": "Immune mediated hepatitis"
+    }
+  ],
+  "KE 1877": [
+    {
+      "aop_id": "AOP 363",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via altered retinal layer structure"
+    }
+  ],
+  "KE 1878": [
+    {
+      "aop_id": "AOP 364",
+      "aop_title": "Thyroperoxidase inhibition leading to altered visual function via decreased eye size"
+    },
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    }
+  ],
+  "KE 1830": [
+    {
+      "aop_id": "AOP 366",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein transthyretin (TTR) leading to altered amphibian metamorphosis "
+    },
+    {
+      "aop_id": "AOP 367",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein thyroid binding globulin (TBG) leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1831": [
+    {
+      "aop_id": "AOP 367",
+      "aop_title": "Competitive binding to thyroid hormone carrier protein thyroid binding globulin (TBG) leading to altered amphibian metamorphosis"
+    }
+  ],
+  "KE 1840": [
+    {
+      "aop_id": "AOP 368",
+      "aop_title": "Cytochrome oxidase inhibition leading to increased nasal lesions"
+    },
+    {
+      "aop_id": "AOP 573",
+      "aop_title": "Inhibition, cytochrome oxidase leads to Increased, pulmonary edema"
+    },
+    {
+      "aop_id": "AOP 574",
+      "aop_title": "Inhibition, cytochrome oxidase leads to Loss of olfactory function"
+    }
+  ],
+  "KE 2312": [
+    {
+      "aop_id": "AOP 368",
+      "aop_title": "Cytochrome oxidase inhibition leading to increased nasal lesions"
+    }
+  ],
+  "KE 1170": [
+    {
+      "aop_id": "AOP 37",
+      "aop_title": "PPARα activation leading to hepatocellular adenomas and carcinomas in rodents"
+    }
+  ],
+  "KE 1171": [
+    {
+      "aop_id": "AOP 37",
+      "aop_title": "PPARα activation leading to hepatocellular adenomas and carcinomas in rodents"
+    }
+  ],
+  "KE 1839": [
+    {
+      "aop_id": "AOP 372",
+      "aop_title": "Androgen receptor antagonism leading to testicular cancer "
+    }
+  ],
+  "KE 1841": [
+    {
+      "aop_id": "AOP 374",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on brain cells (neuronal and non-neuronal) leads to neuroinflammation resulting in encephalitis"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 1809": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1842": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1843": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1844": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 393",
+      "aop_title": "AOP for thyroid disorder caused by triphenyl phosphate via TRβ activation"
+    }
+  ],
+  "KE 1846": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 379",
+      "aop_title": "Binding to ACE2 leading to thrombosis and disseminated intravascular coagulation"
+    },
+    {
+      "aop_id": "AOP 395",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on pericytes leads to disseminated intravascular coagulation resulting in cerebrovascular disease (stroke)"
+    }
+  ],
+  "KE 1857": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 412",
+      "aop_title": "Endothelial cell dysfunction leading to thromboinflammation"
+    }
+  ],
+  "KE 1868": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 392",
+      "aop_title": "Decreased fibrinolysis and activated bradykinin system leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 406",
+      "aop_title": "SARS-CoV-2 infection leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 468",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to hyperinflammation (via cell death)"
+    }
+  ],
+  "KE 1869": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 379",
+      "aop_title": "Binding to ACE2 leading to thrombosis and disseminated intravascular coagulation"
+    },
+    {
+      "aop_id": "AOP 406",
+      "aop_title": "SARS-CoV-2 infection leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 407",
+      "aop_title": "SARS-CoV-2 infection leading to pyroptosis"
+    },
+    {
+      "aop_id": "AOP 488",
+      "aop_title": "Increased reactive oxygen species production leading to decreased cognitive function"
+    }
+  ],
+  "KE 1895": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 406",
+      "aop_title": "SARS-CoV-2 infection leading to hyperinflammation"
+    },
+    {
+      "aop_id": "AOP 407",
+      "aop_title": "SARS-CoV-2 infection leading to pyroptosis"
+    }
+  ],
+  "KE 1897": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1898": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1899": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 1900": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    }
+  ],
+  "KE 902": [
+    {
+      "aop_id": "AOP 377",
+      "aop_title": "Dysregulated prolonged Toll Like Receptor 9 (TLR9) activation leading to Multi Organ Failure involving Acute Respiratory Distress Syndrome (ARDS)"
+    },
+    {
+      "aop_id": "AOP 615",
+      "aop_title": "Suppression of Keap1 cysteine oxidation leading to liver inflammation"
+    },
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 1845": [
+    {
+      "aop_id": "AOP 379",
+      "aop_title": "Binding to ACE2 leading to thrombosis and disseminated intravascular coagulation"
+    }
+  ],
+  "KE 1787": [
+    {
+      "aop_id": "AOP 381",
+      "aop_title": "Binding of viral S-glycoprotein to ACE2 receptor leading to dysgeusia"
+    },
+    {
+      "aop_id": "AOP 385",
+      "aop_title": "Viral spike protein interaction with ACE2 leads to microvascular dysfunction, via ACE2 dysregulation"
+    },
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    }
+  ],
+  "KE 1849": [
+    {
+      "aop_id": "AOP 381",
+      "aop_title": "Binding of viral S-glycoprotein to ACE2 receptor leading to dysgeusia"
+    }
+  ],
+  "KE 1850": [
+    {
+      "aop_id": "AOP 381",
+      "aop_title": "Binding of viral S-glycoprotein to ACE2 receptor leading to dysgeusia"
+    }
+  ],
+  "KE 1856": [
+    {
+      "aop_id": "AOP 381",
+      "aop_title": "Binding of viral S-glycoprotein to ACE2 receptor leading to dysgeusia"
+    }
+  ],
+  "KE 1501": [
+    {
+      "aop_id": "AOP 383",
+      "aop_title": "Inhibition of Angiotensin-converting enzyme 2 leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 414",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through TGF-β dependent fibrosis toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 415",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 494",
+      "aop_title": "AhR activation leading to liver fibrosis "
+    }
+  ],
+  "KE 1743": [
+    {
+      "aop_id": "AOP 383",
+      "aop_title": "Inhibition of Angiotensin-converting enzyme 2 leading to liver fibrosis"
+    }
+  ],
+  "KE 1852": [
+    {
+      "aop_id": "AOP 383",
+      "aop_title": "Inhibition of Angiotensin-converting enzyme 2 leading to liver fibrosis"
+    },
+    {
+      "aop_id": "AOP 384",
+      "aop_title": "Hyperactivation of ACE/Ang-II/AT1R axis leading to chronic kidney disease "
+    }
+  ],
+  "KE 1853": [
+    {
+      "aop_id": "AOP 384",
+      "aop_title": "Hyperactivation of ACE/Ang-II/AT1R axis leading to chronic kidney disease "
+    },
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    }
+  ],
+  "KE 1855": [
+    {
+      "aop_id": "AOP 384",
+      "aop_title": "Hyperactivation of ACE/Ang-II/AT1R axis leading to chronic kidney disease "
+    }
+  ],
+  "KE 2096": [
+    {
+      "aop_id": "AOP 385",
+      "aop_title": "Viral spike protein interaction with ACE2 leads to microvascular dysfunction, via ACE2 dysregulation"
+    }
+  ],
+  "KE 1861": [
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    }
+  ],
+  "KE 1862": [
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 389",
+      "aop_title": " Oxygen-evolving complex damage leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 567",
+      "aop_title": "Binding to plastoquinone B site leading to decreased population growth rate via photosystem II inhibition"
+    }
+  ],
+  "KE 1863": [
+    {
+      "aop_id": "AOP 386",
+      "aop_title": "Deposition of ionizing energy leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 387",
+      "aop_title": "Deposition of ionising energy leading to population decline via mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 388",
+      "aop_title": "Deposition of ionising energy  leading to population decline via programmed cell death"
+    },
+    {
+      "aop_id": "AOP 389",
+      "aop_title": " Oxygen-evolving complex damage leading to population decline via inhibition of photosynthesis"
+    },
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    },
+    {
+      "aop_id": "AOP 435",
+      "aop_title": "Deposition of ionising energy leads to population decline via pollen abnormal"
+    },
+    {
+      "aop_id": "AOP 444",
+      "aop_title": "Ionizing radiation leads to reduced reproduction in Eisenia fetida via reduced spermatogenesis and cocoon hatchability"
+    },
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 1864": [
+    {
+      "aop_id": "AOP 388",
+      "aop_title": "Deposition of ionising energy  leading to population decline via programmed cell death"
+    }
+  ],
+  "KE 1865": [
+    {
+      "aop_id": "AOP 389",
+      "aop_title": " Oxygen-evolving complex damage leading to population decline via inhibition of photosynthesis"
+    }
+  ],
+  "KE 272": [
+    {
+      "aop_id": "AOP 39",
+      "aop_title": "Covalent Binding, Protein, leading to Increase, Allergic Respiratory Hypersensitivity Response"
+    },
+    {
+      "aop_id": "AOP 40",
+      "aop_title": "Covalent Protein binding leading to Skin Sensitisation"
+    }
+  ],
+  "KE 313": [
+    {
+      "aop_id": "AOP 39",
+      "aop_title": "Covalent Binding, Protein, leading to Increase, Allergic Respiratory Hypersensitivity Response"
+    }
+  ],
+  "KE 396": [
+    {
+      "aop_id": "AOP 39",
+      "aop_title": "Covalent Binding, Protein, leading to Increase, Allergic Respiratory Hypersensitivity Response"
+    },
+    {
+      "aop_id": "AOP 40",
+      "aop_title": "Covalent Protein binding leading to Skin Sensitisation"
+    }
+  ],
+  "KE 398": [
+    {
+      "aop_id": "AOP 39",
+      "aop_title": "Covalent Binding, Protein, leading to Increase, Allergic Respiratory Hypersensitivity Response"
+    },
+    {
+      "aop_id": "AOP 40",
+      "aop_title": "Covalent Protein binding leading to Skin Sensitisation"
+    }
+  ],
+  "KE 1866": [
+    {
+      "aop_id": "AOP 392",
+      "aop_title": "Decreased fibrinolysis and activated bradykinin system leading to hyperinflammation"
+    }
+  ],
+  "KE 1867": [
+    {
+      "aop_id": "AOP 392",
+      "aop_title": "Decreased fibrinolysis and activated bradykinin system leading to hyperinflammation"
+    }
+  ],
+  "KE 1555": [
+    {
+      "aop_id": "AOP 393",
+      "aop_title": "AOP for thyroid disorder caused by triphenyl phosphate via TRβ activation"
+    }
+  ],
+  "KE 1870": [
+    {
+      "aop_id": "AOP 394",
+      "aop_title": "SARS-CoV-2 infection of olfactory epithelium leading to impaired olfactory function (short-term anosmia)"
+    }
+  ],
+  "KE 1871": [
+    {
+      "aop_id": "AOP 394",
+      "aop_title": "SARS-CoV-2 infection of olfactory epithelium leading to impaired olfactory function (short-term anosmia)"
+    }
+  ],
+  "KE 1872": [
+    {
+      "aop_id": "AOP 394",
+      "aop_title": "SARS-CoV-2 infection of olfactory epithelium leading to impaired olfactory function (short-term anosmia)"
+    }
+  ],
+  "KE 1873": [
+    {
+      "aop_id": "AOP 394",
+      "aop_title": "SARS-CoV-2 infection of olfactory epithelium leading to impaired olfactory function (short-term anosmia)"
+    }
+  ],
+  "KE 1874": [
+    {
+      "aop_id": "AOP 395",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on pericytes leads to disseminated intravascular coagulation resulting in cerebrovascular disease (stroke)"
+    }
+  ],
+  "KE 1875": [
+    {
+      "aop_id": "AOP 395",
+      "aop_title": "Binding of Sars-CoV-2 spike protein to ACE 2 receptors expressed on pericytes leads to disseminated intravascular coagulation resulting in cerebrovascular disease (stroke)"
+    }
+  ],
+  "KE 1550": [
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    }
+  ],
+  "KE 997": [
+    {
+      "aop_id": "AOP 396",
+      "aop_title": "Deposition of ionizing energy leads to population decline via impaired meiosis"
+    }
+  ],
+  "KE 1879": [
+    {
+      "aop_id": "AOP 397",
+      "aop_title": "Bulky DNA adducts leading to mutations"
+    },
+    {
+      "aop_id": "AOP 644",
+      "aop_title": "Bulky DNA adducts leading to chromosomal aberrations and mutations"
+    }
+  ],
+  "KE 1880": [
+    {
+      "aop_id": "AOP 398",
+      "aop_title": "Decreased ALDH1A (RALDH) activity leading to decreased fertility via disrupted meiotic initiation of fetal oogonia "
+    },
+    {
+      "aop_id": "AOP 436",
+      "aop_title": "Inhibition of RALDH2 causes reduced all-trans retinoic acid levels, leading to transposition of the great arteries"
+    }
+  ],
+  "KE 1881": [
+    {
+      "aop_id": "AOP 398",
+      "aop_title": "Decreased ALDH1A (RALDH) activity leading to decreased fertility via disrupted meiotic initiation of fetal oogonia "
+    },
+    {
+      "aop_id": "AOP 436",
+      "aop_title": "Inhibition of RALDH2 causes reduced all-trans retinoic acid levels, leading to transposition of the great arteries"
+    }
+  ],
+  "KE 1882": [
+    {
+      "aop_id": "AOP 398",
+      "aop_title": "Decreased ALDH1A (RALDH) activity leading to decreased fertility via disrupted meiotic initiation of fetal oogonia "
+    }
+  ],
+  "KE 1883": [
+    {
+      "aop_id": "AOP 398",
+      "aop_title": "Decreased ALDH1A (RALDH) activity leading to decreased fertility via disrupted meiotic initiation of fetal oogonia "
+    },
+    {
+      "aop_id": "AOP 563",
+      "aop_title": "Aryl hydrocarbon Receptor (AHR) activation causes Premature Ovarian Insufficiency via Bax mediated apoptosis"
+    }
+  ],
+  "KE 2419": [
+    {
+      "aop_id": "AOP 398",
+      "aop_title": "Decreased ALDH1A (RALDH) activity leading to decreased fertility via disrupted meiotic initiation of fetal oogonia "
+    }
+  ],
+  "KE 1884": [
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    }
+  ],
+  "KE 1885": [
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    }
+  ],
+  "KE 1886": [
+    {
+      "aop_id": "AOP 399",
+      "aop_title": "Inhibition of Fyna leading to increased mortality via decreased eye size (Microphthalmos)"
+    }
+  ],
+  "KE 1264": [
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    }
+  ],
+  "KE 1265": [
+    {
+      "aop_id": "AOP 4",
+      "aop_title": "Ecdysone receptor agonism leading to mortality via suppression of Ftz-f1"
+    }
+  ],
+  "KE 826": [
+    {
+      "aop_id": "AOP 40",
+      "aop_title": "Covalent Protein binding leading to Skin Sensitisation"
+    }
+  ],
+  "KE 827": [
+    {
+      "aop_id": "AOP 40",
+      "aop_title": "Covalent Protein binding leading to Skin Sensitisation"
+    }
+  ],
+  "KE 1887": [
+    {
+      "aop_id": "AOP 400",
+      "aop_title": "Inhibition of CYP26B1 activity in fetal testis leading to reduced fertility"
+    }
+  ],
+  "KE 1888": [
+    {
+      "aop_id": "AOP 400",
+      "aop_title": "Inhibition of CYP26B1 activity in fetal testis leading to reduced fertility"
+    }
+  ],
+  "KE 1889": [
+    {
+      "aop_id": "AOP 400",
+      "aop_title": "Inhibition of CYP26B1 activity in fetal testis leading to reduced fertility"
+    }
+  ],
+  "KE 1890": [
+    {
+      "aop_id": "AOP 400",
+      "aop_title": "Inhibition of CYP26B1 activity in fetal testis leading to reduced fertility"
+    }
+  ],
+  "KE 2420": [
+    {
+      "aop_id": "AOP 400",
+      "aop_title": "Inhibition of CYP26B1 activity in fetal testis leading to reduced fertility"
+    }
+  ],
+  "KE 1299": [
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    }
+  ],
+  "KE 1300": [
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    }
+  ],
+  "KE 1310": [
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    }
+  ],
+  "KE 1995": [
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    },
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 2029": [
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    }
+  ],
+  "KE 462": [
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    },
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 472": [
+    {
+      "aop_id": "AOP 401",
+      "aop_title": "G protein-coupled estrogen receptor 1 (GPER) signal pathway in the lipid metabolism disrupting effects"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 2093": [
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2094": [
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    }
+  ],
+  "KE 2095": [
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    }
+  ],
+  "KE 771": [
+    {
+      "aop_id": "AOP 402",
+      "aop_title": "Thyroid peroxidase (TPO) inhibition leads to periventricular heterotopia formation in the developing rat brain"
+    }
+  ],
+  "KE 1967": [
+    {
+      "aop_id": "AOP 407",
+      "aop_title": "SARS-CoV-2 infection leading to pyroptosis"
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 1896": [
+    {
+      "aop_id": "AOP 409",
+      "aop_title": "Frustrated phagocytosis leads to malignant mesothelioma"
+    },
+    {
+      "aop_id": "AOP 503",
+      "aop_title": "Activation of uterine estrogen receptor-alfa leading to endometrial adenocarcinoma, via epigenetic modulation"
+    }
+  ],
+  "KE 139": [
+    {
+      "aop_id": "AOP 41",
+      "aop_title": "Sustained AhR Activation leading to Rodent Liver Tumours"
+    }
+  ],
+  "KE 165": [
+    {
+      "aop_id": "AOP 41",
+      "aop_title": "Sustained AhR Activation leading to Rodent Liver Tumours"
+    }
+  ],
+  "KE 853": [
+    {
+      "aop_id": "AOP 41",
+      "aop_title": "Sustained AhR Activation leading to Rodent Liver Tumours"
+    }
+  ],
+  "KE 854": [
+    {
+      "aop_id": "AOP 41",
+      "aop_title": "Sustained AhR Activation leading to Rodent Liver Tumours"
+    },
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    }
+  ],
+  "KE 856": [
+    {
+      "aop_id": "AOP 41",
+      "aop_title": "Sustained AhR Activation leading to Rodent Liver Tumours"
+    }
+  ],
+  "KE 1008": [
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    }
+  ],
+  "KE 1647": [
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    }
+  ],
+  "KE 1902": [
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    }
+  ],
+  "KE 1903": [
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    }
+  ],
+  "KE 1904": [
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    }
+  ],
+  "KE 1905": [
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    }
+  ],
+  "KE 1930": [
+    {
+      "aop_id": "AOP 410",
+      "aop_title": "GSK3beta inactivation leading to increased mortality via defects in developing inner ear"
+    }
+  ],
+  "KE 1908": [
+    {
+      "aop_id": "AOP 411",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function "
+    },
+    {
+      "aop_id": "AOP 424",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function via CFTR dysfunction"
+    },
+    {
+      "aop_id": "AOP 425",
+      "aop_title": "Oxidative Stress Leading to Decreased Lung Function via Decreased FOXJ1"
+    }
+  ],
+  "KE 1909": [
+    {
+      "aop_id": "AOP 411",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function "
+    },
+    {
+      "aop_id": "AOP 424",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function via CFTR dysfunction"
+    },
+    {
+      "aop_id": "AOP 425",
+      "aop_title": "Oxidative Stress Leading to Decreased Lung Function via Decreased FOXJ1"
+    }
+  ],
+  "KE 1913": [
+    {
+      "aop_id": "AOP 412",
+      "aop_title": "Endothelial cell dysfunction leading to thromboinflammation"
+    },
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    }
+  ],
+  "KE 1914": [
+    {
+      "aop_id": "AOP 412",
+      "aop_title": "Endothelial cell dysfunction leading to thromboinflammation"
+    }
+  ],
+  "KE 1915": [
+    {
+      "aop_id": "AOP 412",
+      "aop_title": "Endothelial cell dysfunction leading to thromboinflammation"
+    }
+  ],
+  "KE 1916": [
+    {
+      "aop_id": "AOP 412",
+      "aop_title": "Endothelial cell dysfunction leading to thromboinflammation"
+    }
+  ],
+  "KE 1607": [
+    {
+      "aop_id": "AOP 413",
+      "aop_title": "Oxidation and antagonism of reduced glutathione leading to mortality via acute renal failure"
+    }
+  ],
+  "KE 1920": [
+    {
+      "aop_id": "AOP 414",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through TGF-β dependent fibrosis toxicity pathway"
+    }
+  ],
+  "KE 1921": [
+    {
+      "aop_id": "AOP 415",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung fibrosis through IL-6 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 416",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through IL-6 toxicity pathway"
+    }
+  ],
+  "KE 1933": [
+    {
+      "aop_id": "AOP 416",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through IL-6 toxicity pathway"
+    }
+  ],
+  "KE 17": [
+    {
+      "aop_id": "AOP 417",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through AHR-ARNT toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 418",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through AHR-ARNT toxicity pathway"
+    }
+  ],
+  "KE 1922": [
+    {
+      "aop_id": "AOP 417",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through AHR-ARNT toxicity pathway"
+    }
+  ],
+  "KE 1923": [
+    {
+      "aop_id": "AOP 419",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to impaired lung function through P53 toxicity pathway"
+    }
+  ],
+  "KE 1917": [
+    {
+      "aop_id": "AOP 420",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to lung cancer through sustained NRF2 toxicity pathway"
+    },
+    {
+      "aop_id": "AOP 421",
+      "aop_title": "PPARG activation leading to intrahepatic cholestasis"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    }
+  ],
+  "KE 1931": [
+    {
+      "aop_id": "AOP 422",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 in enterocytes leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    },
+    {
+      "aop_id": "AOP 530",
+      "aop_title": "Endocytotic lysosomal uptake leads to intestinal barrier disruption"
+    },
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2030": [
+    {
+      "aop_id": "AOP 423",
+      "aop_title": " Toxicological mechanisms of hepatocyte apoptosis through the PARP1 dependent cell death pathway "
+    }
+  ],
+  "KE 2031": [
+    {
+      "aop_id": "AOP 423",
+      "aop_title": " Toxicological mechanisms of hepatocyte apoptosis through the PARP1 dependent cell death pathway "
+    }
+  ],
+  "KE 1906": [
+    {
+      "aop_id": "AOP 424",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function via CFTR dysfunction"
+    }
+  ],
+  "KE 1907": [
+    {
+      "aop_id": "AOP 424",
+      "aop_title": "Oxidative stress Leading to Decreased Lung Function via CFTR dysfunction"
+    }
+  ],
+  "KE 1911": [
+    {
+      "aop_id": "AOP 425",
+      "aop_title": "Oxidative Stress Leading to Decreased Lung Function via Decreased FOXJ1"
+    }
+  ],
+  "KE 1912": [
+    {
+      "aop_id": "AOP 425",
+      "aop_title": "Oxidative Stress Leading to Decreased Lung Function via Decreased FOXJ1"
+    }
+  ],
+  "KE 1934": [
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    }
+  ],
+  "KE 1946": [
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    }
+  ],
+  "KE 1947": [
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    }
+  ],
+  "KE 1948": [
+    {
+      "aop_id": "AOP 426",
+      "aop_title": "SARS-CoV-2 spike protein binding to ACE2 receptors expressed on pericytes leads to endothelial cell dysfunction, microvascular injury and myocardial infarction. "
+    }
+  ],
+  "KE 1741": [
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    }
+  ],
+  "KE 1935": [
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    }
+  ],
+  "KE 1936": [
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    }
+  ],
+  "KE 1937": [
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    }
+  ],
+  "KE 1938": [
+    {
+      "aop_id": "AOP 427",
+      "aop_title": "ACE2 downregulation following SARS-CoV-2 infection triggers dysregulation of RAAS and can lead to heart failure."
+    }
+  ],
+  "KE 1954": [
+    {
+      "aop_id": "AOP 428",
+      "aop_title": "Binding of S-protein to ACE2 in enterocytes induces ACE2 dysregulation leading to gut dysbiosis "
+    }
+  ],
+  "KE 1816": [
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    }
+  ],
+  "KE 1941": [
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    }
+  ],
+  "KE 1942": [
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    }
+  ],
+  "KE 1943": [
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    }
+  ],
+  "KE 1944": [
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    }
+  ],
+  "KE 1945": [
+    {
+      "aop_id": "AOP 429",
+      "aop_title": "A cholesterol/glucose dysmetabolism initiated Tau-driven AOP toward memory loss (AO) in sporadic Alzheimer's Disease with plausible MIE's plug-ins for environmental neurotoxicants"
+    },
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    }
+  ],
+  "KE 1001": [
+    {
+      "aop_id": "AOP 43",
+      "aop_title": "Disruption of VEGFR Signaling Leading to Developmental Defects"
+    }
+  ],
+  "KE 28": [
+    {
+      "aop_id": "AOP 43",
+      "aop_title": "Disruption of VEGFR Signaling Leading to Developmental Defects"
+    },
+    {
+      "aop_id": "AOP 614",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced vascular endothelial growth factor"
+    }
+  ],
+  "KE 298": [
+    {
+      "aop_id": "AOP 43",
+      "aop_title": "Disruption of VEGFR Signaling Leading to Developmental Defects"
+    }
+  ],
+  "KE 305": [
+    {
+      "aop_id": "AOP 43",
+      "aop_title": "Disruption of VEGFR Signaling Leading to Developmental Defects"
+    }
+  ],
+  "KE 1939": [
+    {
+      "aop_id": "AOP 430",
+      "aop_title": "Binding of SARS-CoV-2 to ACE2 leads to viral infection proliferation"
+    }
+  ],
+  "KE 1949": [
+    {
+      "aop_id": "AOP 431",
+      "aop_title": "Increased tumor necrosis factor (TNF) leading to increased risk of gestational diabetes mellitus (GDM)"
+    }
+  ],
+  "KE 1950": [
+    {
+      "aop_id": "AOP 431",
+      "aop_title": "Increased tumor necrosis factor (TNF) leading to increased risk of gestational diabetes mellitus (GDM)"
+    }
+  ],
+  "KE 1951": [
+    {
+      "aop_id": "AOP 431",
+      "aop_title": "Increased tumor necrosis factor (TNF) leading to increased risk of gestational diabetes mellitus (GDM)"
+    }
+  ],
+  "KE 1952": [
+    {
+      "aop_id": "AOP 431",
+      "aop_title": "Increased tumor necrosis factor (TNF) leading to increased risk of gestational diabetes mellitus (GDM)"
+    }
+  ],
+  "KE 1953": [
+    {
+      "aop_id": "AOP 431",
+      "aop_title": "Increased tumor necrosis factor (TNF) leading to increased risk of gestational diabetes mellitus (GDM)"
+    }
+  ],
+  "KE 1955": [
+    {
+      "aop_id": "AOP 432",
+      "aop_title": "Deposition of Energy by Ionizing Radiation leading to Acute Myeloid Leukemia"
+    }
+  ],
+  "KE 1961": [
+    {
+      "aop_id": "AOP 433",
+      "aop_title": "hERG channel blockade leading to sudden cardiac death"
+    },
+    {
+      "aop_id": "AOP 519",
+      "aop_title": "Cardiac ion channels blockade  leading to  increased incidence of cardiovascular morbidity and mortality "
+    },
+    {
+      "aop_id": "AOP 555",
+      "aop_title": "Inhibition, Ether-a-go-go (ERG) Voltage-Gated Potassium Channel leading to heart failure"
+    }
+  ],
+  "KE 1962": [
+    {
+      "aop_id": "AOP 433",
+      "aop_title": "hERG channel blockade leading to sudden cardiac death"
+    },
+    {
+      "aop_id": "AOP 552",
+      "aop_title": "Inhibiton of L-Type Calcium Channels leading to heart failure via QT interval prolongation and Torsades de Pointes (TdP)"
+    },
+    {
+      "aop_id": "AOP 555",
+      "aop_title": "Inhibition, Ether-a-go-go (ERG) Voltage-Gated Potassium Channel leading to heart failure"
+    }
+  ],
+  "KE 1963": [
+    {
+      "aop_id": "AOP 433",
+      "aop_title": "hERG channel blockade leading to sudden cardiac death"
+    },
+    {
+      "aop_id": "AOP 552",
+      "aop_title": "Inhibiton of L-Type Calcium Channels leading to heart failure via QT interval prolongation and Torsades de Pointes (TdP)"
+    }
+  ],
+  "KE 1964": [
+    {
+      "aop_id": "AOP 433",
+      "aop_title": "hERG channel blockade leading to sudden cardiac death"
+    }
+  ],
+  "KE 2099": [
+    {
+      "aop_id": "AOP 433",
+      "aop_title": "hERG channel blockade leading to sudden cardiac death"
+    }
+  ],
+  "KE 2100": [
+    {
+      "aop_id": "AOP 433",
+      "aop_title": "hERG channel blockade leading to sudden cardiac death"
+    }
+  ],
+  "KE 1965": [
+    {
+      "aop_id": "AOP 435",
+      "aop_title": "Deposition of ionising energy leads to population decline via pollen abnormal"
+    }
+  ],
+  "KE 442": [
+    {
+      "aop_id": "AOP 435",
+      "aop_title": "Deposition of ionising energy leads to population decline via pollen abnormal"
+    },
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    }
+  ],
+  "KE 1970": [
+    {
+      "aop_id": "AOP 436",
+      "aop_title": "Inhibition of RALDH2 causes reduced all-trans retinoic acid levels, leading to transposition of the great arteries"
+    }
+  ],
+  "KE 105": [
+    {
+      "aop_id": "AOP 437",
+      "aop_title": "Inhibition of mitochondrial electron transport chain (ETC) complexes leading to kidney toxicity"
+    },
+    {
+      "aop_id": "AOP 447",
+      "aop_title": "Kidney failure induced by inhibition of mitochondrial electron transfer chain through apoptosis, inflammation and oxidative stress pathways"
+    },
+    {
+      "aop_id": "AOP 479",
+      "aop_title": "Mitochondrial complexes inhibition leading to left ventricular function decrease via increased myocardial oxidative stress"
+    },
+    {
+      "aop_id": "AOP 480",
+      "aop_title": "Mitochondrial complexes inhibition leading to heart failure via decreased ATP production"
+    }
+  ],
+  "KE 1971": [
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    },
+    {
+      "aop_id": "AOP 578",
+      "aop_title": "AhR activation leading to cancer progression via immunosuppression"
+    }
+  ],
+  "KE 1982": [
+    {
+      "aop_id": "AOP 439",
+      "aop_title": "Activation of the AhR leading to metastatic breast cancer "
+    },
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    }
+  ],
+  "KE 1972": [
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    }
+  ],
+  "KE 1973": [
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    }
+  ],
+  "KE 2092": [
+    {
+      "aop_id": "AOP 440",
+      "aop_title": "Hypothalamus estrogen receptors activity suppression leading to ovarian cancer via ovarian epithelial cell hyperplasia"
+    }
+  ],
+  "KE 1974": [
+    {
+      "aop_id": "AOP 441",
+      "aop_title": "Ionizing radiation-induced DNA damage leads to microcephaly via apoptosis and premature cell differentiation"
+    }
+  ],
+  "KE 1978": [
+    {
+      "aop_id": "AOP 441",
+      "aop_title": "Ionizing radiation-induced DNA damage leads to microcephaly via apoptosis and premature cell differentiation"
+    },
+    {
+      "aop_id": "AOP 523",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to microcephaly"
+    }
+  ],
+  "KE 1979": [
+    {
+      "aop_id": "AOP 441",
+      "aop_title": "Ionizing radiation-induced DNA damage leads to microcephaly via apoptosis and premature cell differentiation"
+    }
+  ],
+  "KE 2200": [
+    {
+      "aop_id": "AOP 441",
+      "aop_title": "Ionizing radiation-induced DNA damage leads to microcephaly via apoptosis and premature cell differentiation"
+    }
+  ],
+  "KE 1977": [
+    {
+      "aop_id": "AOP 442",
+      "aop_title": "Binding to voltage gate sodium channels during development leads to cognitive impairment"
+    },
+    {
+      "aop_id": "AOP 489",
+      "aop_title": "Inhibition of voltage-gated sodium channels leading to decreased cognition"
+    }
+  ],
+  "KE 1983": [
+    {
+      "aop_id": "AOP 442",
+      "aop_title": "Binding to voltage gate sodium channels during development leads to cognitive impairment"
+    },
+    {
+      "aop_id": "AOP 551",
+      "aop_title": "Increased Muscarinic M2 Receptor leading to Arrhythmia"
+    }
+  ],
+  "KE 2005": [
+    {
+      "aop_id": "AOP 442",
+      "aop_title": "Binding to voltage gate sodium channels during development leads to cognitive impairment"
+    }
+  ],
+  "KE 1554": [
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    }
+  ],
+  "KE 1980": [
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    }
+  ],
+  "KE 1981": [
+    {
+      "aop_id": "AOP 443",
+      "aop_title": " DNA damage and mutations leading to Metastatic Breast Cancer"
+    }
+  ],
+  "KE 1065": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    },
+    {
+      "aop_id": "AOP 503",
+      "aop_title": "Activation of uterine estrogen receptor-alfa leading to endometrial adenocarcinoma, via epigenetic modulation"
+    },
+    {
+      "aop_id": "AOP 504",
+      "aop_title": "SULT1E1 inhibition leading to uterine adenocarcinoma via increased estrogen availability at target organ level"
+    },
+    {
+      "aop_id": "AOP 561",
+      "aop_title": "Aromatase induction leading to estrogen receptor alpha activation via increased estradiol"
+    },
+    {
+      "aop_id": "AOP 565",
+      "aop_title": "17β-Hydroxysteroid dehydrogenase 2, inhibition leading to activation, estrogen receptor alpha"
+    },
+    {
+      "aop_id": "AOP 609",
+      "aop_title": "Activation, estrogen receptor alpha leads to prolonged estrus cycle via decreased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 623",
+      "aop_title": "Activation, estrogen receptor alpha leads to persistent vaginal cornification via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 637",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased uterine weight via earlier proliferation of cells of the uterine lining"
+    },
+    {
+      "aop_id": "AOP 639",
+      "aop_title": "Activation, estrogen receptor alpha leads to precocious puberty via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    },
+    {
+      "aop_id": "AOP 641",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased, phenotypic female-biased sex ratio via increased, differentiation to ovaries"
+    }
+  ],
+  "KE 1985": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    },
+    {
+      "aop_id": "AOP 623",
+      "aop_title": "Activation, estrogen receptor alpha leads to persistent vaginal cornification via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 637",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased uterine weight via earlier proliferation of cells of the uterine lining"
+    },
+    {
+      "aop_id": "AOP 639",
+      "aop_title": "Activation, estrogen receptor alpha leads to precocious puberty via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    }
+  ],
+  "KE 1986": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    },
+    {
+      "aop_id": "AOP 609",
+      "aop_title": "Activation, estrogen receptor alpha leads to prolonged estrus cycle via decreased kisspeptin release"
+    }
+  ],
+  "KE 1987": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    }
+  ],
+  "KE 1988": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    }
+  ],
+  "KE 1989": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    }
+  ],
+  "KE 1990": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    }
+  ],
+  "KE 1991": [
+    {
+      "aop_id": "AOP 445",
+      "aop_title": "Estrogen Receptor Alpha Agonism leads to Impaired Reproduction"
+    }
+  ],
+  "KE 2023": [
+    {
+      "aop_id": "AOP 449",
+      "aop_title": "Ceramide synthase inhibition leading to neural tube defects "
+    }
+  ],
+  "KE 2024": [
+    {
+      "aop_id": "AOP 449",
+      "aop_title": "Ceramide synthase inhibition leading to neural tube defects "
+    }
+  ],
+  "KE 2025": [
+    {
+      "aop_id": "AOP 449",
+      "aop_title": "Ceramide synthase inhibition leading to neural tube defects "
+    }
+  ],
+  "KE 2026": [
+    {
+      "aop_id": "AOP 449",
+      "aop_title": "Ceramide synthase inhibition leading to neural tube defects "
+    }
+  ],
+  "KE 2033": [
+    {
+      "aop_id": "AOP 449",
+      "aop_title": "Ceramide synthase inhibition leading to neural tube defects "
+    }
+  ],
+  "KE 618": [
+    {
+      "aop_id": "AOP 450",
+      "aop_title": " Inhibition of AChE and activation of CYP2E1 leading to sensory axonal peripheral neuropathy and mortality"
+    },
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    }
+  ],
+  "KE 2006": [
+    {
+      "aop_id": "AOP 451",
+      "aop_title": "Interaction with lung resident cell membrane components leads to lung cancer"
+    }
+  ],
+  "KE 2007": [
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    }
+  ],
+  "KE 2008": [
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    }
+  ],
+  "KE 2009": [
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    },
+    {
+      "aop_id": "AOP 507",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    },
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 2010": [
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    },
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 2011": [
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    }
+  ],
+  "KE 2012": [
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    }
+  ],
+  "KE 2013": [
+    {
+      "aop_id": "AOP 452",
+      "aop_title": "Adverse outcome pathway of PM-induced respiratory toxicity"
+    }
+  ],
+  "KE 2017": [
+    {
+      "aop_id": "AOP 454",
+      "aop_title": "PM2.5-related AOP frameworks on liver diseases"
+    },
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2019": [
+    {
+      "aop_id": "AOP 454",
+      "aop_title": "PM2.5-related AOP frameworks on liver diseases"
+    },
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 2065": [
+    {
+      "aop_id": "AOP 454",
+      "aop_title": "PM2.5-related AOP frameworks on liver diseases"
+    }
+  ],
+  "KE 2119": [
+    {
+      "aop_id": "AOP 454",
+      "aop_title": "PM2.5-related AOP frameworks on liver diseases"
+    },
+    {
+      "aop_id": "AOP 457",
+      "aop_title": "Succinate dehydrogenase inhibition leading to increased insulin resistance through reduction in circulating thyroxine"
+    },
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    },
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 2020": [
+    {
+      "aop_id": "AOP 455",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 456",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced cardiovascular toxicity"
+    }
+  ],
+  "KE 2021": [
+    {
+      "aop_id": "AOP 455",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced impeded craniofacial development"
+    },
+    {
+      "aop_id": "AOP 456",
+      "aop_title": "Aryl hydrocarbon receptor activation leading to early life stage mortality via sox9 repression induced cardiovascular toxicity"
+    }
+  ],
+  "KE 2118": [
+    {
+      "aop_id": "AOP 457",
+      "aop_title": "Succinate dehydrogenase inhibition leading to increased insulin resistance through reduction in circulating thyroxine"
+    },
+    {
+      "aop_id": "AOP 474",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer by promoting EMT"
+    },
+    {
+      "aop_id": "AOP 534",
+      "aop_title": "Succinate dehydrogenase (SDH) inhibition leads to oxidative stress"
+    },
+    {
+      "aop_id": "AOP 546",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer through hypoxic-like mechanisms"
+    },
+    {
+      "aop_id": "AOP 588",
+      "aop_title": "Inhibition of the mitochondrial complex II of nigro-striatal neurons leads to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2120": [
+    {
+      "aop_id": "AOP 457",
+      "aop_title": "Succinate dehydrogenase inhibition leading to increased insulin resistance through reduction in circulating thyroxine"
+    }
+  ],
+  "KE 373": [
+    {
+      "aop_id": "AOP 46",
+      "aop_title": "AFB1: Mutagenic Mode-of-Action leading to Hepatocellular Carcinoma (HCC)"
+    },
+    {
+      "aop_id": "AOP 472",
+      "aop_title": "DNA adduct formation leading to kidney failure"
+    }
+  ],
+  "KE 376": [
+    {
+      "aop_id": "AOP 46",
+      "aop_title": "AFB1: Mutagenic Mode-of-Action leading to Hepatocellular Carcinoma (HCC)"
+    }
+  ],
+  "KE 378": [
+    {
+      "aop_id": "AOP 46",
+      "aop_title": "AFB1: Mutagenic Mode-of-Action leading to Hepatocellular Carcinoma (HCC)"
+    }
+  ],
+  "KE 409": [
+    {
+      "aop_id": "AOP 46",
+      "aop_title": "AFB1: Mutagenic Mode-of-Action leading to Hepatocellular Carcinoma (HCC)"
+    }
+  ],
+  "KE 491": [
+    {
+      "aop_id": "AOP 46",
+      "aop_title": "AFB1: Mutagenic Mode-of-Action leading to Hepatocellular Carcinoma (HCC)"
+    }
+  ],
+  "KE 493": [
+    {
+      "aop_id": "AOP 46",
+      "aop_title": "AFB1: Mutagenic Mode-of-Action leading to Hepatocellular Carcinoma (HCC)"
+    }
+  ],
+  "KE 2027": [
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    }
+  ],
+  "KE 2028": [
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 502",
+      "aop_title": "Decrease, cholesterol synthesis leads to orofacial clefting"
+    }
+  ],
+  "KE 2040": [
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 491",
+      "aop_title": "Decrease, GLI1/2 target gene expression leads to orofacial clefting "
+    },
+    {
+      "aop_id": "AOP 502",
+      "aop_title": "Decrease, cholesterol synthesis leads to orofacial clefting"
+    }
+  ],
+  "KE 2041": [
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 491",
+      "aop_title": "Decrease, GLI1/2 target gene expression leads to orofacial clefting "
+    },
+    {
+      "aop_id": "AOP 502",
+      "aop_title": "Decrease, cholesterol synthesis leads to orofacial clefting"
+    }
+  ],
+  "KE 2042": [
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 491",
+      "aop_title": "Decrease, GLI1/2 target gene expression leads to orofacial clefting "
+    },
+    {
+      "aop_id": "AOP 502",
+      "aop_title": "Decrease, cholesterol synthesis leads to orofacial clefting"
+    }
+  ],
+  "KE 2043": [
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    },
+    {
+      "aop_id": "AOP 491",
+      "aop_title": "Decrease, GLI1/2 target gene expression leads to orofacial clefting "
+    },
+    {
+      "aop_id": "AOP 502",
+      "aop_title": "Decrease, cholesterol synthesis leads to orofacial clefting"
+    }
+  ],
+  "KE 2044": [
+    {
+      "aop_id": "AOP 460",
+      "aop_title": "Antagonism of Smoothened receptor leading to orofacial clefting"
+    }
+  ],
+  "KE 1442": [
+    {
+      "aop_id": "AOP 462",
+      "aop_title": "Activation of reactive oxygen species leading the atherosclerosis"
+    }
+  ],
+  "KE 2068": [
+    {
+      "aop_id": "AOP 462",
+      "aop_title": "Activation of reactive oxygen species leading the atherosclerosis"
+    },
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    }
+  ],
+  "KE 467": [
+    {
+      "aop_id": "AOP 462",
+      "aop_title": "Activation of reactive oxygen species leading the atherosclerosis"
+    },
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 901": [
+    {
+      "aop_id": "AOP 462",
+      "aop_title": "Activation of reactive oxygen species leading the atherosclerosis"
+    }
+  ],
+  "KE 2034": [
+    {
+      "aop_id": "AOP 463",
+      "aop_title": "The AOP framwork on silica nanopariticles induced hepatoxicity"
+    }
+  ],
+  "KE 1812": [
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2036": [
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2037": [
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    },
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    }
+  ],
+  "KE 2038": [
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2039": [
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2187": [
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2188": [
+    {
+      "aop_id": "AOP 464",
+      "aop_title": "Calcium overload in dopaminergic neurons of the substantia nigra leading to parkinsonian motor deficits"
+    }
+  ],
+  "KE 2045": [
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    }
+  ],
+  "KE 2046": [
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    }
+  ],
+  "KE 2047": [
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    }
+  ],
+  "KE 2048": [
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    }
+  ],
+  "KE 2049": [
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    }
+  ],
+  "KE 2050": [
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    },
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 748": [
+    {
+      "aop_id": "AOP 465",
+      "aop_title": "Alcohol dehydrogenase leading to reproductive dysfunction"
+    }
+  ],
+  "KE 2051": [
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    }
+  ],
+  "KE 2052": [
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    }
+  ],
+  "KE 2053": [
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    }
+  ],
+  "KE 2054": [
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    }
+  ],
+  "KE 2055": [
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    }
+  ],
+  "KE 2056": [
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    }
+  ],
+  "KE 2057": [
+    {
+      "aop_id": "AOP 466",
+      "aop_title": "Doda decarboxylase leading to mortality"
+    }
+  ],
+  "KE 2058": [
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 2059": [
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 2060": [
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 2061": [
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 2062": [
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 2063": [
+    {
+      "aop_id": "AOP 467",
+      "aop_title": "Knickkopf leading to mortality"
+    }
+  ],
+  "KE 2067": [
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    }
+  ],
+  "KE 2069": [
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    }
+  ],
+  "KE 2244": [
+    {
+      "aop_id": "AOP 470",
+      "aop_title": "Deposition of energy leads to abnormal vascular remodeling"
+    },
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    }
+  ],
+  "KE 1177": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 191": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 498",
+      "aop_title": "Increased LCN2/iron complex leading to neurological disorders"
+    }
+  ],
+  "KE 2078": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    }
+  ],
+  "KE 2150": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 498",
+      "aop_title": "Increased LCN2/iron complex leading to neurological disorders"
+    },
+    {
+      "aop_id": "AOP 501",
+      "aop_title": "Excessive iron accumulation leading to neurological disorders"
+    }
+  ],
+  "KE 2151": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 499",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via disrupted neurotransmitter release"
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    },
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    }
+  ],
+  "KE 2195": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    },
+    {
+      "aop_id": "AOP 569",
+      "aop_title": "Decreased DNA methylation of FAM50B/PTCHD3 leading to IQ loss of children via PI3K-Akt pathway"
+    }
+  ],
+  "KE 2196": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 2197": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 2198": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 637": [
+    {
+      "aop_id": "AOP 471",
+      "aop_title": "Neuron defect induced early behavioral change"
+    }
+  ],
+  "KE 2073": [
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    }
+  ],
+  "KE 2074": [
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    }
+  ],
+  "KE 2075": [
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    }
+  ],
+  "KE 2076": [
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    }
+  ],
+  "KE 2077": [
+    {
+      "aop_id": "AOP 473",
+      "aop_title": "Energy deposition from internalized Ra-226 decay lower oxygen binding capacity of hemocyanin"
+    }
+  ],
+  "KE 2243": [
+    {
+      "aop_id": "AOP 474",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer by promoting EMT"
+    },
+    {
+      "aop_id": "AOP 546",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer through hypoxic-like mechanisms"
+    }
+  ],
+  "KE 2242": [
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    }
+  ],
+  "KE 875": [
+    {
+      "aop_id": "AOP 475",
+      "aop_title": "Binding of chemicals to ionotropic glutamate receptors leads to impairment of learning and memory via loss of drebrin from dendritic spines of neurons"
+    },
+    {
+      "aop_id": "AOP 48",
+      "aop_title": "Binding of agonists to ionotropic glutamate receptors in adult brain causes excitotoxicity that mediates neuronal cell death, contributing to learning and memory impairment."
+    }
+  ],
+  "KE 2079": [
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    }
+  ],
+  "KE 2080": [
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 2141": [
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    }
+  ],
+  "KE 2142": [
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    }
+  ],
+  "KE 446": [
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    }
+  ],
+  "KE 496": [
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 64",
+      "aop_title": "Glucocorticoid Receptor (GR) Mediated Adult Leydig Cell Dysfunction Leading to Decreased Male Fertility"
+    }
+  ],
+  "KE 520": [
+    {
+      "aop_id": "AOP 476",
+      "aop_title": "Adverse Outcome Pathways diagram related to PBDEs associated male reproductive toxicity"
+    },
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 64",
+      "aop_title": "Glucocorticoid Receptor (GR) Mediated Adult Leydig Cell Dysfunction Leading to Decreased Male Fertility"
+    },
+    {
+      "aop_id": "AOP 70",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Proteomic Alterations in the Adult Leydig Cell"
+    },
+    {
+      "aop_id": "AOP 71",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Glucocorticoid Activation"
+    }
+  ],
+  "KE 2082": [
+    {
+      "aop_id": "AOP 477",
+      "aop_title": "Androgen receptor (AR) antagonism leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 527",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Hypospadias, increased"
+    },
+    {
+      "aop_id": "AOP 570",
+      "aop_title": "Decreased testosterone synthesis leading to hypospadias in male (mammalian) offspring"
+    },
+    {
+      "aop_id": "AOP 571",
+      "aop_title": "5α-reductase inhibition leading to hypospadias in male (mammalian) offspring"
+    }
+  ],
+  "KE 2081": [
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    }
+  ],
+  "KE 2083": [
+    {
+      "aop_id": "AOP 478",
+      "aop_title": "Deposition of energy leading to occurrence of cataracts"
+    }
+  ],
+  "KE 2084": [
+    {
+      "aop_id": "AOP 479",
+      "aop_title": "Mitochondrial complexes inhibition leading to left ventricular function decrease via increased myocardial oxidative stress"
+    }
+  ],
+  "KE 2215": [
+    {
+      "aop_id": "AOP 479",
+      "aop_title": "Mitochondrial complexes inhibition leading to left ventricular function decrease via increased myocardial oxidative stress"
+    },
+    {
+      "aop_id": "AOP 480",
+      "aop_title": "Mitochondrial complexes inhibition leading to heart failure via decreased ATP production"
+    }
+  ],
+  "KE 2085": [
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 2086": [
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 2087": [
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 2088": [
+    {
+      "aop_id": "AOP 481",
+      "aop_title": "AOPs of amorphous silica nanoparticles: ROS-mediated oxidative stress increased respiratory dysfunction and diseases."
+    }
+  ],
+  "KE 2090": [
+    {
+      "aop_id": "AOP 482",
+      "aop_title": "Deposition of energy leading to occurrence of bone loss"
+    }
+  ],
+  "KE 2091": [
+    {
+      "aop_id": "AOP 482",
+      "aop_title": "Deposition of energy leading to occurrence of bone loss"
+    }
+  ],
+  "KE 2097": [
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    }
+  ],
+  "KE 2098": [
+    {
+      "aop_id": "AOP 483",
+      "aop_title": "Deposition of Energy Leading to Learning and Memory Impairment"
+    }
+  ],
+  "KE 2104": [
+    {
+      "aop_id": "AOP 485",
+      "aop_title": "Thyroid hormone antagonism leading to impaired oligodendrocyte maturation during development and subsequent decreased cognition"
+    }
+  ],
+  "KE 2105": [
+    {
+      "aop_id": "AOP 485",
+      "aop_title": "Thyroid hormone antagonism leading to impaired oligodendrocyte maturation during development and subsequent decreased cognition"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2106": [
+    {
+      "aop_id": "AOP 485",
+      "aop_title": "Thyroid hormone antagonism leading to impaired oligodendrocyte maturation during development and subsequent decreased cognition"
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 608",
+      "aop_title": "Thyroid Hormone Excess Leading to Reduced, Swimming Performance via Hypomyelination"
+    }
+  ],
+  "KE 2107": [
+    {
+      "aop_id": "AOP 485",
+      "aop_title": "Thyroid hormone antagonism leading to impaired oligodendrocyte maturation during development and subsequent decreased cognition"
+    },
+    {
+      "aop_id": "AOP 487",
+      "aop_title": "Unknown MIE altering cholesterol metabolism leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 488",
+      "aop_title": "Increased reactive oxygen species production leading to decreased cognitive function"
+    },
+    {
+      "aop_id": "AOP 489",
+      "aop_title": "Inhibition of voltage-gated sodium channels leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 605",
+      "aop_title": "Thyroid Peroxidase Inhibition Leading to Reduced, Swimming Performance via Hypomyelination"
+    },
+    {
+      "aop_id": "AOP 608",
+      "aop_title": "Thyroid Hormone Excess Leading to Reduced, Swimming Performance via Hypomyelination"
+    }
+  ],
+  "KE 2108": [
+    {
+      "aop_id": "AOP 485",
+      "aop_title": "Thyroid hormone antagonism leading to impaired oligodendrocyte maturation during development and subsequent decreased cognition"
+    },
+    {
+      "aop_id": "AOP 487",
+      "aop_title": "Unknown MIE altering cholesterol metabolism leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 488",
+      "aop_title": "Increased reactive oxygen species production leading to decreased cognitive function"
+    },
+    {
+      "aop_id": "AOP 489",
+      "aop_title": "Inhibition of voltage-gated sodium channels leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2109": [
+    {
+      "aop_id": "AOP 486",
+      "aop_title": "Binding to the extracellular protein laminin leading to decreased cognitive function"
+    }
+  ],
+  "KE 2110": [
+    {
+      "aop_id": "AOP 486",
+      "aop_title": "Binding to the extracellular protein laminin leading to decreased cognitive function"
+    }
+  ],
+  "KE 2111": [
+    {
+      "aop_id": "AOP 486",
+      "aop_title": "Binding to the extracellular protein laminin leading to decreased cognitive function"
+    }
+  ],
+  "KE 2112": [
+    {
+      "aop_id": "AOP 486",
+      "aop_title": "Binding to the extracellular protein laminin leading to decreased cognitive function"
+    }
+  ],
+  "KE 2113": [
+    {
+      "aop_id": "AOP 486",
+      "aop_title": "Binding to the extracellular protein laminin leading to decreased cognitive function"
+    }
+  ],
+  "KE 2114": [
+    {
+      "aop_id": "AOP 486",
+      "aop_title": "Binding to the extracellular protein laminin leading to decreased cognitive function"
+    }
+  ],
+  "KE 2115": [
+    {
+      "aop_id": "AOP 487",
+      "aop_title": "Unknown MIE altering cholesterol metabolism leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2116": [
+    {
+      "aop_id": "AOP 487",
+      "aop_title": "Unknown MIE altering cholesterol metabolism leading to decreased cognition"
+    },
+    {
+      "aop_id": "AOP 488",
+      "aop_title": "Increased reactive oxygen species production leading to decreased cognitive function"
+    },
+    {
+      "aop_id": "AOP 489",
+      "aop_title": "Inhibition of voltage-gated sodium channels leading to decreased cognition"
+    }
+  ],
+  "KE 1998": [
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    }
+  ],
+  "KE 2121": [
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    },
+    {
+      "aop_id": "AOP 569",
+      "aop_title": "Decreased DNA methylation of FAM50B/PTCHD3 leading to IQ loss of children via PI3K-Akt pathway"
+    }
+  ],
+  "KE 2122": [
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    }
+  ],
+  "KE 2123": [
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    }
+  ],
+  "KE 2124": [
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    },
+    {
+      "aop_id": "AOP 563",
+      "aop_title": "Aryl hydrocarbon Receptor (AHR) activation causes Premature Ovarian Insufficiency via Bax mediated apoptosis"
+    }
+  ],
+  "KE 2186": [
+    {
+      "aop_id": "AOP 490",
+      "aop_title": "Co-activation of IP3R and RyR leads to reduced IQ and increased socio-economic burden through non-cholinergic mechanisms"
+    }
+  ],
+  "KE 130": [
+    {
+      "aop_id": "AOP 492",
+      "aop_title": "Glutathione conjugation leading to reproductive dysfunction via oxidative stress"
+    }
+  ],
+  "KE 2131": [
+    {
+      "aop_id": "AOP 492",
+      "aop_title": "Glutathione conjugation leading to reproductive dysfunction via oxidative stress"
+    }
+  ],
+  "KE 2125": [
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 2126": [
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    },
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    }
+  ],
+  "KE 2127": [
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 2128": [
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 2129": [
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 2130": [
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 2132": [
+    {
+      "aop_id": "AOP 493",
+      "aop_title": "ERa inactivation alters AT expansion and functions and leads to insulin resistance and metabolically unhealthy obesity"
+    }
+  ],
+  "KE 2134": [
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    }
+  ],
+  "KE 2135": [
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    }
+  ],
+  "KE 2136": [
+    {
+      "aop_id": "AOP 495",
+      "aop_title": "Androgen receptor activation leading to prostate cancer"
+    }
+  ],
+  "KE 2137": [
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    },
+    {
+      "aop_id": "AOP 623",
+      "aop_title": "Activation, estrogen receptor alpha leads to persistent vaginal cornification via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 637",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased uterine weight via earlier proliferation of cells of the uterine lining"
+    },
+    {
+      "aop_id": "AOP 639",
+      "aop_title": "Activation, estrogen receptor alpha leads to precocious puberty via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    }
+  ],
+  "KE 2139": [
+    {
+      "aop_id": "AOP 496",
+      "aop_title": "Androgen receptor agonism leading to reproduction dysfunction （in zebrafish）"
+    }
+  ],
+  "KE 2144": [
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    }
+  ],
+  "KE 2145": [
+    {
+      "aop_id": "AOP 497",
+      "aop_title": "ERa inactivation alters mitochondrial functions and insulin signalling in skeletal muscle and leads to insulin resistance and metabolic syndrome"
+    }
+  ],
+  "KE 2148": [
+    {
+      "aop_id": "AOP 498",
+      "aop_title": "Increased LCN2/iron complex leading to neurological disorders"
+    }
+  ],
+  "KE 2149": [
+    {
+      "aop_id": "AOP 498",
+      "aop_title": "Increased LCN2/iron complex leading to neurological disorders"
+    },
+    {
+      "aop_id": "AOP 501",
+      "aop_title": "Excessive iron accumulation leading to neurological disorders"
+    }
+  ],
+  "KE 2146": [
+    {
+      "aop_id": "AOP 499",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via disrupted neurotransmitter release"
+    },
+    {
+      "aop_id": "AOP 500",
+      "aop_title": "Activation of MEK-ERK1/2 leads to deficits in learning and cognition via ROS and apoptosis"
+    }
+  ],
+  "KE 2152": [
+    {
+      "aop_id": "AOP 503",
+      "aop_title": "Activation of uterine estrogen receptor-alfa leading to endometrial adenocarcinoma, via epigenetic modulation"
+    }
+  ],
+  "KE 2153": [
+    {
+      "aop_id": "AOP 503",
+      "aop_title": "Activation of uterine estrogen receptor-alfa leading to endometrial adenocarcinoma, via epigenetic modulation"
+    }
+  ],
+  "KE 2154": [
+    {
+      "aop_id": "AOP 503",
+      "aop_title": "Activation of uterine estrogen receptor-alfa leading to endometrial adenocarcinoma, via epigenetic modulation"
+    }
+  ],
+  "KE 2155": [
+    {
+      "aop_id": "AOP 504",
+      "aop_title": "SULT1E1 inhibition leading to uterine adenocarcinoma via increased estrogen availability at target organ level"
+    }
+  ],
+  "KE 2251": [
+    {
+      "aop_id": "AOP 504",
+      "aop_title": "SULT1E1 inhibition leading to uterine adenocarcinoma via increased estrogen availability at target organ level"
+    },
+    {
+      "aop_id": "AOP 561",
+      "aop_title": "Aromatase induction leading to estrogen receptor alpha activation via increased estradiol"
+    },
+    {
+      "aop_id": "AOP 565",
+      "aop_title": "17β-Hydroxysteroid dehydrogenase 2, inhibition leading to activation, estrogen receptor alpha"
+    },
+    {
+      "aop_id": "AOP 566",
+      "aop_title": "Decreased, GnRH pulsatility/release leading to estradiol availability, increased via impaired ovulation"
+    }
+  ],
+  "KE 2158": [
+    {
+      "aop_id": "AOP 506",
+      "aop_title": "Binding of Influenza A Virus (IAV) to Sialic Acid Glycan Receptor leads to viral infection proliferation"
+    }
+  ],
+  "KE 2159": [
+    {
+      "aop_id": "AOP 506",
+      "aop_title": "Binding of Influenza A Virus (IAV) to Sialic Acid Glycan Receptor leads to viral infection proliferation"
+    }
+  ],
+  "KE 2180": [
+    {
+      "aop_id": "AOP 506",
+      "aop_title": "Binding of Influenza A Virus (IAV) to Sialic Acid Glycan Receptor leads to viral infection proliferation"
+    }
+  ],
+  "KE 2192": [
+    {
+      "aop_id": "AOP 506",
+      "aop_title": "Binding of Influenza A Virus (IAV) to Sialic Acid Glycan Receptor leads to viral infection proliferation"
+    }
+  ],
+  "KE 2193": [
+    {
+      "aop_id": "AOP 506",
+      "aop_title": "Binding of Influenza A Virus (IAV) to Sialic Acid Glycan Receptor leads to viral infection proliferation"
+    }
+  ],
+  "KE 2194": [
+    {
+      "aop_id": "AOP 506",
+      "aop_title": "Binding of Influenza A Virus (IAV) to Sialic Acid Glycan Receptor leads to viral infection proliferation"
+    }
+  ],
+  "KE 1928": [
+    {
+      "aop_id": "AOP 507",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 508",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating HIF1α, Semaphorin 6A, and Dll4-Notch pathway"
+    },
+    {
+      "aop_id": "AOP 509",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating apoptosis signal pathway and mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    },
+    {
+      "aop_id": "AOP 538",
+      "aop_title": "Adverse outcome pathway of PFAS-induced vascular disrupting effects  via activating oxidative stress related pathways "
+    }
+  ],
+  "KE 2161": [
+    {
+      "aop_id": "AOP 507",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 508",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating HIF1α, Semaphorin 6A, and Dll4-Notch pathway"
+    },
+    {
+      "aop_id": "AOP 509",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating apoptosis signal pathway and mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    },
+    {
+      "aop_id": "AOP 538",
+      "aop_title": "Adverse outcome pathway of PFAS-induced vascular disrupting effects  via activating oxidative stress related pathways "
+    }
+  ],
+  "KE 2181": [
+    {
+      "aop_id": "AOP 507",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects via inflammation pathway"
+    },
+    {
+      "aop_id": "AOP 508",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating HIF1α, Semaphorin 6A, and Dll4-Notch pathway"
+    },
+    {
+      "aop_id": "AOP 509",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating apoptosis signal pathway and mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 2162": [
+    {
+      "aop_id": "AOP 508",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating HIF1α, Semaphorin 6A, and Dll4-Notch pathway"
+    }
+  ],
+  "KE 2163": [
+    {
+      "aop_id": "AOP 508",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating HIF1α, Semaphorin 6A, and Dll4-Notch pathway"
+    }
+  ],
+  "KE 2164": [
+    {
+      "aop_id": "AOP 508",
+      "aop_title": "Nrf2 inhibition leading to vascular disrupting effects through activating HIF1α, Semaphorin 6A, and Dll4-Notch pathway"
+    },
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 414": [
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    }
+  ],
+  "KE 415": [
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    }
+  ],
+  "KE 416": [
+    {
+      "aop_id": "AOP 51",
+      "aop_title": "PPARα activation leading to impaired fertility in adult male rodents "
+    }
+  ],
+  "KE 2165": [
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    }
+  ],
+  "KE 2166": [
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    }
+  ],
+  "KE 2167": [
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    }
+  ],
+  "KE 2168": [
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    }
+  ],
+  "KE 2169": [
+    {
+      "aop_id": "AOP 510",
+      "aop_title": "Demethylation of PPAR promotor leading to vascular disrupting effects"
+    }
+  ],
+  "KE 2170": [
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 2171": [
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 2172": [
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 2173": [
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 2174": [
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 2178": [
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 2179": [
+    {
+      "aop_id": "AOP 511",
+      "aop_title": "The AOP framework on ROS-mediated oxidative stress induced vascular disrupting effects "
+    }
+  ],
+  "KE 239": [
+    {
+      "aop_id": "AOP 517",
+      "aop_title": "Pregnane X Receptor (PXR) activation leads to liver steatosis"
+    },
+    {
+      "aop_id": "AOP 545",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased cholesterol synthesis"
+    },
+    {
+      "aop_id": "AOP 548",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased PCSK9 protein expression"
+    },
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 2199": [
+    {
+      "aop_id": "AOP 518",
+      "aop_title": "Liver X Receptor (LXR) activation leads to liver steatosis"
+    }
+  ],
+  "KE 1929": [
+    {
+      "aop_id": "AOP 519",
+      "aop_title": "Cardiac ion channels blockade  leading to  increased incidence of cardiovascular morbidity and mortality "
+    }
+  ],
+  "KE 2282": [
+    {
+      "aop_id": "AOP 519",
+      "aop_title": "Cardiac ion channels blockade  leading to  increased incidence of cardiovascular morbidity and mortality "
+    }
+  ],
+  "KE 2283": [
+    {
+      "aop_id": "AOP 519",
+      "aop_title": "Cardiac ion channels blockade  leading to  increased incidence of cardiovascular morbidity and mortality "
+    },
+    {
+      "aop_id": "AOP 555",
+      "aop_title": "Inhibition, Ether-a-go-go (ERG) Voltage-Gated Potassium Channel leading to heart failure"
+    }
+  ],
+  "KE 417": [
+    {
+      "aop_id": "AOP 52",
+      "aop_title": "ER agonism leading to skewed sex ratios due to altered sexual differentiation in males"
+    }
+  ],
+  "KE 2201": [
+    {
+      "aop_id": "AOP 520",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 523",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to microcephaly"
+    },
+    {
+      "aop_id": "AOP 532",
+      "aop_title": "Retinoic acid receptor agonism during cerebellar development leading to impaired locomotor function"
+    }
+  ],
+  "KE 2202": [
+    {
+      "aop_id": "AOP 520",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 523",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to microcephaly"
+    },
+    {
+      "aop_id": "AOP 581",
+      "aop_title": "Glucocorticoid receptor (GR) activation during development leads to cognitive function (COG) decrease"
+    }
+  ],
+  "KE 2203": [
+    {
+      "aop_id": "AOP 520",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 523",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to microcephaly"
+    },
+    {
+      "aop_id": "AOP 581",
+      "aop_title": "Glucocorticoid receptor (GR) activation during development leads to cognitive function (COG) decrease"
+    }
+  ],
+  "KE 2204": [
+    {
+      "aop_id": "AOP 520",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2205": [
+    {
+      "aop_id": "AOP 521",
+      "aop_title": "Essential element imbalance leads to reproductive failure via oxidative stress"
+    }
+  ],
+  "KE 2206": [
+    {
+      "aop_id": "AOP 521",
+      "aop_title": "Essential element imbalance leads to reproductive failure via oxidative stress"
+    }
+  ],
+  "KE 2207": [
+    {
+      "aop_id": "AOP 522",
+      "aop_title": "Estrogen antagonism leading to increased risk of autism-like behavior"
+    }
+  ],
+  "KE 2208": [
+    {
+      "aop_id": "AOP 522",
+      "aop_title": "Estrogen antagonism leading to increased risk of autism-like behavior"
+    },
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    }
+  ],
+  "KE 2209": [
+    {
+      "aop_id": "AOP 522",
+      "aop_title": "Estrogen antagonism leading to increased risk of autism-like behavior"
+    }
+  ],
+  "KE 2210": [
+    {
+      "aop_id": "AOP 523",
+      "aop_title": "Retinoic acid receptor agonism during neurodevelopment leading to microcephaly"
+    }
+  ],
+  "KE 2252": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2253": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2254": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2255": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2256": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2257": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2260": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2275": [
+    {
+      "aop_id": "AOP 524",
+      "aop_title": "Gluten-driven immune activation leading to celiac disease in genetically predisposed individuals "
+    }
+  ],
+  "KE 2216": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2217": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2218": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2219": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2220": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2221": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2222": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2223": [
+    {
+      "aop_id": "AOP 525",
+      "aop_title": "Reduced oligodendrocyte differentiation during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 2212": [
+    {
+      "aop_id": "AOP 526",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Impaired, Spermatogenesis"
+    }
+  ],
+  "KE 647": [
+    {
+      "aop_id": "AOP 526",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Impaired, Spermatogenesis"
+    },
+    {
+      "aop_id": "AOP 527",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Hypospadias, increased"
+    },
+    {
+      "aop_id": "AOP 70",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Proteomic Alterations in the Adult Leydig Cell"
+    }
+  ],
+  "KE 656": [
+    {
+      "aop_id": "AOP 526",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Impaired, Spermatogenesis"
+    },
+    {
+      "aop_id": "AOP 527",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Hypospadias, increased"
+    },
+    {
+      "aop_id": "AOP 66",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent Glucocorticoid Activation in the Fetal Testis"
+    },
+    {
+      "aop_id": "AOP 67",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Estradiaol Activation in the Fetal Testis"
+    },
+    {
+      "aop_id": "AOP 68",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Alterations in the Fetal Testis Protome"
+    }
+  ],
+  "KE 2213": [
+    {
+      "aop_id": "AOP 527",
+      "aop_title": "Decreased, Chicken Ovalbumin Upstream Promoter Transcription Factor II (COUP-TFII) leads to Hypospadias, increased"
+    }
+  ],
+  "KE 2214": [
+    {
+      "aop_id": "AOP 528",
+      "aop_title": "Decreased Insulin-like peptide 3 (INSL3) leads to Malformation, cryptorchidism - maldescended testis"
+    }
+  ],
+  "KE 2224": [
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    }
+  ],
+  "KE 2225": [
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    }
+  ],
+  "KE 2226": [
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    }
+  ],
+  "KE 2227": [
+    {
+      "aop_id": "AOP 529",
+      "aop_title": "Xenobiotic binding to peroxisome proliferator-activated receptors (PPARs) causes dysregulation of lipid metabolism leading to liver steatosis"
+    }
+  ],
+  "KE 418": [
+    {
+      "aop_id": "AOP 53",
+      "aop_title": "ER agonism leading to reduced survival due to renal failure"
+    }
+  ],
+  "KE 419": [
+    {
+      "aop_id": "AOP 53",
+      "aop_title": "ER agonism leading to reduced survival due to renal failure"
+    }
+  ],
+  "KE 421": [
+    {
+      "aop_id": "AOP 53",
+      "aop_title": "ER agonism leading to reduced survival due to renal failure"
+    }
+  ],
+  "KE 422": [
+    {
+      "aop_id": "AOP 53",
+      "aop_title": "ER agonism leading to reduced survival due to renal failure"
+    }
+  ],
+  "KE 2228": [
+    {
+      "aop_id": "AOP 532",
+      "aop_title": "Retinoic acid receptor agonism during cerebellar development leading to impaired locomotor function"
+    }
+  ],
+  "KE 2229": [
+    {
+      "aop_id": "AOP 532",
+      "aop_title": "Retinoic acid receptor agonism during cerebellar development leading to impaired locomotor function"
+    }
+  ],
+  "KE 2230": [
+    {
+      "aop_id": "AOP 532",
+      "aop_title": "Retinoic acid receptor agonism during cerebellar development leading to impaired locomotor function"
+    }
+  ],
+  "KE 2231": [
+    {
+      "aop_id": "AOP 532",
+      "aop_title": "Retinoic acid receptor agonism during cerebellar development leading to impaired locomotor function"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2232": [
+    {
+      "aop_id": "AOP 533",
+      "aop_title": "Retinoic acid receptor antagonism during neurodevelopment leading to impaired learning and memory"
+    }
+  ],
+  "KE 851": [
+    {
+      "aop_id": "AOP 533",
+      "aop_title": "Retinoic acid receptor antagonism during neurodevelopment leading to impaired learning and memory"
+    },
+    {
+      "aop_id": "AOP 54",
+      "aop_title": "Inhibition of Na+/I- symporter (NIS) leads to learning and memory impairment "
+    }
+  ],
+  "KE 2233": [
+    {
+      "aop_id": "AOP 535",
+      "aop_title": "Binding and activation of GPER leading to learning and memory impairments"
+    }
+  ],
+  "KE 2240": [
+    {
+      "aop_id": "AOP 538",
+      "aop_title": "Adverse outcome pathway of PFAS-induced vascular disrupting effects  via activating oxidative stress related pathways "
+    }
+  ],
+  "KE 2241": [
+    {
+      "aop_id": "AOP 538",
+      "aop_title": "Adverse outcome pathway of PFAS-induced vascular disrupting effects  via activating oxidative stress related pathways "
+    }
+  ],
+  "KE 2236": [
+    {
+      "aop_id": "AOP 539",
+      "aop_title": "Decreased Sodium/Potassium ATPase activity leads to Heart failure"
+    }
+  ],
+  "KE 2237": [
+    {
+      "aop_id": "AOP 539",
+      "aop_title": "Decreased Sodium/Potassium ATPase activity leads to Heart failure"
+    }
+  ],
+  "KE 2238": [
+    {
+      "aop_id": "AOP 539",
+      "aop_title": "Decreased Sodium/Potassium ATPase activity leads to Heart failure"
+    }
+  ],
+  "KE 2239": [
+    {
+      "aop_id": "AOP 539",
+      "aop_title": "Decreased Sodium/Potassium ATPase activity leads to Heart failure"
+    }
+  ],
+  "KE 2261": [
+    {
+      "aop_id": "AOP 539",
+      "aop_title": "Decreased Sodium/Potassium ATPase activity leads to Heart failure"
+    }
+  ],
+  "KE 2262": [
+    {
+      "aop_id": "AOP 543",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via lysolecithin cell membrane integration"
+    },
+    {
+      "aop_id": "AOP 544",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via increased inflammation"
+    }
+  ],
+  "KE 2263": [
+    {
+      "aop_id": "AOP 543",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via lysolecithin cell membrane integration"
+    },
+    {
+      "aop_id": "AOP 544",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via increased inflammation"
+    }
+  ],
+  "KE 2264": [
+    {
+      "aop_id": "AOP 543",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via lysolecithin cell membrane integration"
+    }
+  ],
+  "KE 2265": [
+    {
+      "aop_id": "AOP 543",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via lysolecithin cell membrane integration"
+    },
+    {
+      "aop_id": "AOP 544",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via increased inflammation"
+    }
+  ],
+  "KE 2266": [
+    {
+      "aop_id": "AOP 543",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via lysolecithin cell membrane integration"
+    },
+    {
+      "aop_id": "AOP 544",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via increased inflammation"
+    },
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2267": [
+    {
+      "aop_id": "AOP 543",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via lysolecithin cell membrane integration"
+    },
+    {
+      "aop_id": "AOP 544",
+      "aop_title": " Inhibition of neuropathy target esterase leading to delayed neuropathy via increased inflammation"
+    }
+  ],
+  "KE 2268": [
+    {
+      "aop_id": "AOP 545",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased cholesterol synthesis"
+    },
+    {
+      "aop_id": "AOP 548",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased PCSK9 protein expression"
+    }
+  ],
+  "KE 2269": [
+    {
+      "aop_id": "AOP 545",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased cholesterol synthesis"
+    },
+    {
+      "aop_id": "AOP 548",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased PCSK9 protein expression"
+    }
+  ],
+  "KE 2270": [
+    {
+      "aop_id": "AOP 545",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased cholesterol synthesis"
+    }
+  ],
+  "KE 2271": [
+    {
+      "aop_id": "AOP 545",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased cholesterol synthesis"
+    },
+    {
+      "aop_id": "AOP 548",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased PCSK9 protein expression"
+    }
+  ],
+  "KE 590": [
+    {
+      "aop_id": "AOP 546",
+      "aop_title": "Succinate dehydrogenase inactivation leads to cancer through hypoxic-like mechanisms"
+    },
+    {
+      "aop_id": "AOP 94",
+      "aop_title": "Sodium channel inhibition leading to congenital malformations"
+    }
+  ],
+  "KE 2274": [
+    {
+      "aop_id": "AOP 547",
+      "aop_title": "Androgen receptor agonism leading to long anogenital distance in female offspring"
+    }
+  ],
+  "KE 2365": [
+    {
+      "aop_id": "AOP 547",
+      "aop_title": "Androgen receptor agonism leading to long anogenital distance in female offspring"
+    }
+  ],
+  "KE 2276": [
+    {
+      "aop_id": "AOP 548",
+      "aop_title": "Activation, Pregnane-X receptor, NR1I2 leads to increased plasma low-density lipoprotein (LDL) cholesterol via increased PCSK9 protein expression"
+    }
+  ],
+  "KE 2277": [
+    {
+      "aop_id": "AOP 549",
+      "aop_title": "Aromatase inhibition leads to reproductive toxicity (including growth and developmental toxicity) in adult female zebrafish"
+    }
+  ],
+  "KE 1924": [
+    {
+      "aop_id": "AOP 550",
+      "aop_title": "Increased LMNA gene mutation leading to heart failure"
+    }
+  ],
+  "KE 2066": [
+    {
+      "aop_id": "AOP 550",
+      "aop_title": "Increased LMNA gene mutation leading to heart failure"
+    }
+  ],
+  "KE 2278": [
+    {
+      "aop_id": "AOP 550",
+      "aop_title": "Increased LMNA gene mutation leading to heart failure"
+    }
+  ],
+  "KE 2279": [
+    {
+      "aop_id": "AOP 550",
+      "aop_title": "Increased LMNA gene mutation leading to heart failure"
+    }
+  ],
+  "KE 2280": [
+    {
+      "aop_id": "AOP 551",
+      "aop_title": "Increased Muscarinic M2 Receptor leading to Arrhythmia"
+    },
+    {
+      "aop_id": "AOP 559",
+      "aop_title": "Inhibition of acetylcholinesterase (AChE) leading to arrhythmias"
+    }
+  ],
+  "KE 2281": [
+    {
+      "aop_id": "AOP 552",
+      "aop_title": "Inhibiton of L-Type Calcium Channels leading to heart failure via QT interval prolongation and Torsades de Pointes (TdP)"
+    }
+  ],
+  "KE 2284": [
+    {
+      "aop_id": "AOP 554",
+      "aop_title": "β-adrenergic receptor agonists leading to arrhythmias."
+    }
+  ],
+  "KE 2285": [
+    {
+      "aop_id": "AOP 554",
+      "aop_title": "β-adrenergic receptor agonists leading to arrhythmias."
+    }
+  ],
+  "KE 593": [
+    {
+      "aop_id": "AOP 555",
+      "aop_title": "Inhibition, Ether-a-go-go (ERG) Voltage-Gated Potassium Channel leading to heart failure"
+    },
+    {
+      "aop_id": "AOP 95",
+      "aop_title": "Ether-a-go-go (ERG) voltage-gated potassium channel inhibition leading to reduced survival"
+    }
+  ],
+  "KE 2287": [
+    {
+      "aop_id": "AOP 556",
+      "aop_title": "Decreased Na/K ATPase activity leading to heart failure"
+    }
+  ],
+  "KE 2157": [
+    {
+      "aop_id": "AOP 557",
+      "aop_title": "β2-Receptor agonist leading to Cardiomyopathy"
+    }
+  ],
+  "KE 2288": [
+    {
+      "aop_id": "AOP 558",
+      "aop_title": "Phosphodiesterase inhibition leading to heart failure"
+    }
+  ],
+  "KE 2289": [
+    {
+      "aop_id": "AOP 558",
+      "aop_title": "Phosphodiesterase inhibition leading to heart failure"
+    }
+  ],
+  "KE 2290": [
+    {
+      "aop_id": "AOP 560",
+      "aop_title": "Inhibition of Funny current (If) leading to Arrhythmias"
+    }
+  ],
+  "KE 2291": [
+    {
+      "aop_id": "AOP 560",
+      "aop_title": "Inhibition of Funny current (If) leading to Arrhythmias"
+    },
+    {
+      "aop_id": "AOP 562",
+      "aop_title": "HCN Channel Inhibition leading to Arrhythmias"
+    }
+  ],
+  "KE 2292": [
+    {
+      "aop_id": "AOP 560",
+      "aop_title": "Inhibition of Funny current (If) leading to Arrhythmias"
+    },
+    {
+      "aop_id": "AOP 562",
+      "aop_title": "HCN Channel Inhibition leading to Arrhythmias"
+    }
+  ],
+  "KE 2293": [
+    {
+      "aop_id": "AOP 561",
+      "aop_title": "Aromatase induction leading to estrogen receptor alpha activation via increased estradiol"
+    }
+  ],
+  "KE 2294": [
+    {
+      "aop_id": "AOP 561",
+      "aop_title": "Aromatase induction leading to estrogen receptor alpha activation via increased estradiol"
+    },
+    {
+      "aop_id": "AOP 623",
+      "aop_title": "Activation, estrogen receptor alpha leads to persistent vaginal cornification via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 637",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased uterine weight via earlier proliferation of cells of the uterine lining"
+    },
+    {
+      "aop_id": "AOP 639",
+      "aop_title": "Activation, estrogen receptor alpha leads to precocious puberty via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    }
+  ],
+  "KE 2295": [
+    {
+      "aop_id": "AOP 562",
+      "aop_title": "HCN Channel Inhibition leading to Arrhythmias"
+    }
+  ],
+  "KE 2296": [
+    {
+      "aop_id": "AOP 562",
+      "aop_title": "HCN Channel Inhibition leading to Arrhythmias"
+    }
+  ],
+  "KE 2305": [
+    {
+      "aop_id": "AOP 563",
+      "aop_title": "Aryl hydrocarbon Receptor (AHR) activation causes Premature Ovarian Insufficiency via Bax mediated apoptosis"
+    }
+  ],
+  "KE 1541": [
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    }
+  ],
+  "KE 2299": [
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    }
+  ],
+  "KE 2300": [
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    }
+  ],
+  "KE 2301": [
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    }
+  ],
+  "KE 2302": [
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    }
+  ],
+  "KE 566": [
+    {
+      "aop_id": "AOP 564",
+      "aop_title": "DBDPE-induced inhibition of mitochondrial complex Ⅰ leading to population decline via neurotoxicity and metabotoxicity."
+    },
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 82",
+      "aop_title": "Abnormal role change in worker caste contributes to reduced brood care and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 86",
+      "aop_title": "Decrease Glucose oxidase activity contributes to reduction of antiseptic in food and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    }
+  ],
+  "KE 2250": [
+    {
+      "aop_id": "AOP 565",
+      "aop_title": "17β-Hydroxysteroid dehydrogenase 2, inhibition leading to activation, estrogen receptor alpha"
+    }
+  ],
+  "KE 2303": [
+    {
+      "aop_id": "AOP 566",
+      "aop_title": "Decreased, GnRH pulsatility/release leading to estradiol availability, increased via impaired ovulation"
+    }
+  ],
+  "KE 2306": [
+    {
+      "aop_id": "AOP 566",
+      "aop_title": "Decreased, GnRH pulsatility/release leading to estradiol availability, increased via impaired ovulation"
+    },
+    {
+      "aop_id": "AOP 623",
+      "aop_title": "Activation, estrogen receptor alpha leads to persistent vaginal cornification via increased kisspeptin release"
+    }
+  ],
+  "KE 2307": [
+    {
+      "aop_id": "AOP 567",
+      "aop_title": "Binding to plastoquinone B site leading to decreased population growth rate via photosystem II inhibition"
+    }
+  ],
+  "KE 2308": [
+    {
+      "aop_id": "AOP 568",
+      "aop_title": "Inhibition, 5-hydroxytryptamine transporter (5-HTT; SERT) leads to Inhibition, Feeding"
+    }
+  ],
+  "KE 2309": [
+    {
+      "aop_id": "AOP 569",
+      "aop_title": "Decreased DNA methylation of FAM50B/PTCHD3 leading to IQ loss of children via PI3K-Akt pathway"
+    }
+  ],
+  "KE 2310": [
+    {
+      "aop_id": "AOP 569",
+      "aop_title": "Decreased DNA methylation of FAM50B/PTCHD3 leading to IQ loss of children via PI3K-Akt pathway"
+    }
+  ],
+  "KE 2311": [
+    {
+      "aop_id": "AOP 569",
+      "aop_title": "Decreased DNA methylation of FAM50B/PTCHD3 leading to IQ loss of children via PI3K-Akt pathway"
+    }
+  ],
+  "KE 216": [
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 450": [
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 451": [
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 465": [
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 466": [
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 80": [
+    {
+      "aop_id": "AOP 57",
+      "aop_title": "AhR activation leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 2316": [
+    {
+      "aop_id": "AOP 573",
+      "aop_title": "Inhibition, cytochrome oxidase leads to Increased, pulmonary edema"
+    }
+  ],
+  "KE 2317": [
+    {
+      "aop_id": "AOP 574",
+      "aop_title": "Inhibition, cytochrome oxidase leads to Loss of olfactory function"
+    }
+  ],
+  "KE 2444": [
+    {
+      "aop_id": "AOP 577",
+      "aop_title": "AhR activation leading to endometriosis"
+    }
+  ],
+  "KE 2323": [
+    {
+      "aop_id": "AOP 578",
+      "aop_title": "AhR activation leading to cancer progression via immunosuppression"
+    }
+  ],
+  "KE 2324": [
+    {
+      "aop_id": "AOP 578",
+      "aop_title": "AhR activation leading to cancer progression via immunosuppression"
+    }
+  ],
+  "KE 2326": [
+    {
+      "aop_id": "AOP 578",
+      "aop_title": "AhR activation leading to cancer progression via immunosuppression"
+    }
+  ],
+  "KE 454": [
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 456": [
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    }
+  ],
+  "KE 457": [
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 62",
+      "aop_title": "AKT2 activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 458": [
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    },
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 463": [
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    }
+  ],
+  "KE 468": [
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    }
+  ],
+  "KE 470": [
+    {
+      "aop_id": "AOP 58",
+      "aop_title": "NR1I3 (CAR) suppression leading to hepatic steatosis"
+    }
+  ],
+  "KE 2331": [
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    }
+  ],
+  "KE 2332": [
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    }
+  ],
+  "KE 2333": [
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    }
+  ],
+  "KE 2334": [
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    }
+  ],
+  "KE 2335": [
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    }
+  ],
+  "KE 2336": [
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    }
+  ],
+  "KE 2337": [
+    {
+      "aop_id": "AOP 580",
+      "aop_title": "Mineralocorticoid Receptor Activation Leading to Increased Body Mass Index"
+    }
+  ],
+  "KE 2211": [
+    {
+      "aop_id": "AOP 581",
+      "aop_title": "Glucocorticoid receptor (GR) activation during development leads to cognitive function (COG) decrease"
+    }
+  ],
+  "KE 461": [
+    {
+      "aop_id": "AOP 59",
+      "aop_title": "HNF4alpha suppression leading to hepatic steatosis"
+    }
+  ],
+  "KE 2339": [
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    }
+  ],
+  "KE 2340": [
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    }
+  ],
+  "KE 2341": [
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    }
+  ],
+  "KE 2342": [
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    }
+  ],
+  "KE 2343": [
+    {
+      "aop_id": "AOP 590",
+      "aop_title": "Increase of intracellular copper leading to cuproptosis via interference with energy metabolism "
+    }
+  ],
+  "KE 2344": [
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 2345": [
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 2346": [
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 2347": [
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 2348": [
+    {
+      "aop_id": "AOP 591",
+      "aop_title": "DBDPE-induced DNA damage increase in liver leading to Non-alcoholic fatty liver disease via liver steatosis and inhibition of regeneration"
+    }
+  ],
+  "KE 2349": [
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 2350": [
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 2351": [
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 2352": [
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 2353": [
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 2354": [
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 2355": [
+    {
+      "aop_id": "AOP 592",
+      "aop_title": "DBDPE-induced DNA strand breaks and LDH activity inhibition leading to population growth rate decline via energy metabolism disrupt and apoptosis"
+    }
+  ],
+  "KE 2362": [
+    {
+      "aop_id": "AOP 593",
+      "aop_title": "Redox cycling of a chemical by mitochondria leads to degeneration of nigrostriatal dopaminergic neurons "
+    }
+  ],
+  "KE 2363": [
+    {
+      "aop_id": "AOP 593",
+      "aop_title": "Redox cycling of a chemical by mitochondria leads to degeneration of nigrostriatal dopaminergic neurons "
+    },
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 1238": [
+    {
+      "aop_id": "AOP 594",
+      "aop_title": "Micro plastic effect on reproduction"
+    }
+  ],
+  "KE 2366": [
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 2367": [
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 2369": [
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    }
+  ],
+  "KE 495": [
+    {
+      "aop_id": "AOP 595",
+      "aop_title": "Emerging OPFRS reproductive outcome pathway"
+    },
+    {
+      "aop_id": "AOP 64",
+      "aop_title": "Glucocorticoid Receptor (GR) Mediated Adult Leydig Cell Dysfunction Leading to Decreased Male Fertility"
+    }
+  ],
+  "KE 1000": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 1528": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 858": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 861": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 862": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 863": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 864": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 998": [
+    {
+      "aop_id": "AOP 6",
+      "aop_title": "Antagonist binding to PPARα leading to body-weight loss"
+    }
+  ],
+  "KE 471": [
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 474": [
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 477": [
+    {
+      "aop_id": "AOP 60",
+      "aop_title": "NR1I2 (Pregnane X Receptor, PXR)  activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 2327": [
+    {
+      "aop_id": "AOP 600",
+      "aop_title": "Excessive reactive oxygen species leading to growth inhibition via fatty acid oxidation and reduced cell growth"
+    }
+  ],
+  "KE 2370": [
+    {
+      "aop_id": "AOP 604",
+      "aop_title": "Binding of Alpha 1-Adrenergics to Agonists Leading to Depression"
+    }
+  ],
+  "KE 2371": [
+    {
+      "aop_id": "AOP 604",
+      "aop_title": "Binding of Alpha 1-Adrenergics to Agonists Leading to Depression"
+    }
+  ],
+  "KE 478": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 479": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 480": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 482": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 483": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 878": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 879": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 880": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 881": [
+    {
+      "aop_id": "AOP 61",
+      "aop_title": "NFE2L2/FXR activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 2258": [
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2376": [
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2377": [
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2378": [
+    {
+      "aop_id": "AOP 610",
+      "aop_title": "Decreased thyroid hormone levels in the brain regulated via transport, metabolism and TR activation leading to decreased cognition and motor function"
+    }
+  ],
+  "KE 2379": [
+    {
+      "aop_id": "AOP 611",
+      "aop_title": "Behavioral abnormalities due to increased expression of dopamine transporter and receptor-related genes"
+    }
+  ],
+  "KE 2380": [
+    {
+      "aop_id": "AOP 611",
+      "aop_title": "Behavioral abnormalities due to increased expression of dopamine transporter and receptor-related genes"
+    }
+  ],
+  "KE 2381": [
+    {
+      "aop_id": "AOP 611",
+      "aop_title": "Behavioral abnormalities due to increased expression of dopamine transporter and receptor-related genes"
+    }
+  ],
+  "KE 2382": [
+    {
+      "aop_id": "AOP 611",
+      "aop_title": "Behavioral abnormalities due to increased expression of dopamine transporter and receptor-related genes"
+    }
+  ],
+  "KE 602": [
+    {
+      "aop_id": "AOP 611",
+      "aop_title": "Behavioral abnormalities due to increased expression of dopamine transporter and receptor-related genes"
+    },
+    {
+      "aop_id": "AOP 96",
+      "aop_title": "Axonal sodium channel modulation leading to acute mortality"
+    }
+  ],
+  "KE 1312": [
+    {
+      "aop_id": "AOP 612",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced adenosine triphosphate"
+    },
+    {
+      "aop_id": "AOP 613",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via increased reactive oxygen species production"
+    }
+  ],
+  "KE 2383": [
+    {
+      "aop_id": "AOP 612",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced adenosine triphosphate"
+    },
+    {
+      "aop_id": "AOP 613",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via increased reactive oxygen species production"
+    },
+    {
+      "aop_id": "AOP 614",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced vascular endothelial growth factor"
+    }
+  ],
+  "KE 2384": [
+    {
+      "aop_id": "AOP 612",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via reduced adenosine triphosphate"
+    },
+    {
+      "aop_id": "AOP 613",
+      "aop_title": "Peroxisome proliferator-activated receptor alpha activation leading to early life stage mortality via increased reactive oxygen species production"
+    }
+  ],
+  "KE 1994": [
+    {
+      "aop_id": "AOP 615",
+      "aop_title": "Suppression of Keap1 cysteine oxidation leading to liver inflammation"
+    }
+  ],
+  "KE 2385": [
+    {
+      "aop_id": "AOP 615",
+      "aop_title": "Suppression of Keap1 cysteine oxidation leading to liver inflammation"
+    }
+  ],
+  "KE 2387": [
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 2388": [
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 2389": [
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 2390": [
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 2391": [
+    {
+      "aop_id": "AOP 616",
+      "aop_title": "organic UV filter and its Photoproducts reproductive toxicity pathways "
+    }
+  ],
+  "KE 2394": [
+    {
+      "aop_id": "AOP 618",
+      "aop_title": "PPARgamma activation leads to a diminished vaccine response"
+    }
+  ],
+  "KE 2395": [
+    {
+      "aop_id": "AOP 618",
+      "aop_title": "PPARgamma activation leads to a diminished vaccine response"
+    }
+  ],
+  "KE 2396": [
+    {
+      "aop_id": "AOP 618",
+      "aop_title": "PPARgamma activation leads to a diminished vaccine response"
+    }
+  ],
+  "KE 2397": [
+    {
+      "aop_id": "AOP 618",
+      "aop_title": "PPARgamma activation leads to a diminished vaccine response"
+    }
+  ],
+  "KE 2398": [
+    {
+      "aop_id": "AOP 618",
+      "aop_title": "PPARgamma activation leads to a diminished vaccine response"
+    }
+  ],
+  "KE 2393": [
+    {
+      "aop_id": "AOP 619",
+      "aop_title": "Androgen receptor antagonism leads to delayed preputial separation via reduced fibroblast growth factor in genital-tubercle tissues"
+    }
+  ],
+  "KE 2399": [
+    {
+      "aop_id": "AOP 619",
+      "aop_title": "Androgen receptor antagonism leads to delayed preputial separation via reduced fibroblast growth factor in genital-tubercle tissues"
+    }
+  ],
+  "KE 2400": [
+    {
+      "aop_id": "AOP 619",
+      "aop_title": "Androgen receptor antagonism leads to delayed preputial separation via reduced fibroblast growth factor in genital-tubercle tissues"
+    }
+  ],
+  "KE 2401": [
+    {
+      "aop_id": "AOP 619",
+      "aop_title": "Androgen receptor antagonism leads to delayed preputial separation via reduced fibroblast growth factor in genital-tubercle tissues"
+    }
+  ],
+  "KE 484": [
+    {
+      "aop_id": "AOP 62",
+      "aop_title": "AKT2 activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 486": [
+    {
+      "aop_id": "AOP 62",
+      "aop_title": "AKT2 activation leading to hepatic steatosis"
+    }
+  ],
+  "KE 2403": [
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    }
+  ],
+  "KE 2404": [
+    {
+      "aop_id": "AOP 622",
+      "aop_title": "Calcineurin inhibitor induced nephrotoxicity leading to kidney failure"
+    }
+  ],
+  "KE 2402": [
+    {
+      "aop_id": "AOP 623",
+      "aop_title": "Activation, estrogen receptor alpha leads to persistent vaginal cornification via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 637",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased uterine weight via earlier proliferation of cells of the uterine lining"
+    },
+    {
+      "aop_id": "AOP 639",
+      "aop_title": "Activation, estrogen receptor alpha leads to precocious puberty via increased kisspeptin release"
+    },
+    {
+      "aop_id": "AOP 640",
+      "aop_title": "Activation, estrogen receptor alpha leads to decreased fertility via prolonged estrus cycle"
+    }
+  ],
+  "KE 134": [
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 2405": [
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 2406": [
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 2407": [
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 2408": [
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 2410": [
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 2412": [
+    {
+      "aop_id": "AOP 624",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 626",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via insulin resistance-associated endoplasmic reticulum stress"
+    },
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 1306": [
+    {
+      "aop_id": "AOP 627",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated mitochondrial dysfunction"
+    },
+    {
+      "aop_id": "AOP 628",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated oxidative stress"
+    },
+    {
+      "aop_id": "AOP 629",
+      "aop_title": "Increased 11β-Hydroxysteroid dehydrogenase type 1 activity leading to MASLD progression via lipogenesis-associated endoplasmic reticulum stress"
+    }
+  ],
+  "KE 488": [
+    {
+      "aop_id": "AOP 63",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction"
+    }
+  ],
+  "KE 685": [
+    {
+      "aop_id": "AOP 63",
+      "aop_title": "Cyclooxygenase inhibition leading to reproductive dysfunction"
+    }
+  ],
+  "KE 2409": [
+    {
+      "aop_id": "AOP 630",
+      "aop_title": "Decreased 11β-Hydroxysteroid dehydrogenase type 2 activity leading to MASLD progression via insulin resistance-associated mitochondrial dysfunction"
+    }
+  ],
+  "KE 2416": [
+    {
+      "aop_id": "AOP 636",
+      "aop_title": "Increase in reactive oxygen species (ROS) leading to human amyotrophic lateral sclerosis (ALS)"
+    }
+  ],
+  "KE 2413": [
+    {
+      "aop_id": "AOP 637",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased uterine weight via earlier proliferation of cells of the uterine lining"
+    }
+  ],
+  "KE 2414": [
+    {
+      "aop_id": "AOP 638",
+      "aop_title": "Co-exposure to microplastics and cadmium leading to progression from NAFLD to liver tumorigenesis"
+    }
+  ],
+  "KE 2415": [
+    {
+      "aop_id": "AOP 639",
+      "aop_title": "Activation, estrogen receptor alpha leads to precocious puberty via increased kisspeptin release"
+    }
+  ],
+  "KE 494": [
+    {
+      "aop_id": "AOP 64",
+      "aop_title": "Glucocorticoid Receptor (GR) Mediated Adult Leydig Cell Dysfunction Leading to Decreased Male Fertility"
+    }
+  ],
+  "KE 2417": [
+    {
+      "aop_id": "AOP 641",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased, phenotypic female-biased sex ratio via increased, differentiation to ovaries"
+    }
+  ],
+  "KE 2418": [
+    {
+      "aop_id": "AOP 641",
+      "aop_title": "Activation, estrogen receptor alpha leads to increased, phenotypic female-biased sex ratio via increased, differentiation to ovaries"
+    }
+  ],
+  "KE 2422": [
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2424": [
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2425": [
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2426": [
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2427": [
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2428": [
+    {
+      "aop_id": "AOP 642",
+      "aop_title": "Intestinal FXR inhibition leading to steatohepatitis via gut‑liver axis dysregulation"
+    }
+  ],
+  "KE 2430": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    },
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 2431": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 2432": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 2434": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 2435": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 2436": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 2437": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 2438": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 2439": [
+    {
+      "aop_id": "AOP 645",
+      "aop_title": "Binding and activation of AhR lead to cardiovascular aging"
+    }
+  ],
+  "KE 1507": [
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 1824": [
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 2440": [
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 2441": [
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 2442": [
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 2443": [
+    {
+      "aop_id": "AOP 646",
+      "aop_title": "Binding and activation of AhR/PPARγ lead to lipid metabolism disorders"
+    }
+  ],
+  "KE 186": [
+    {
+      "aop_id": "AOP 65",
+      "aop_title": "XX Inhibition of Sodium Iodide Symporter and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 192": [
+    {
+      "aop_id": "AOP 65",
+      "aop_title": "XX Inhibition of Sodium Iodide Symporter and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 505": [
+    {
+      "aop_id": "AOP 66",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent Glucocorticoid Activation in the Fetal Testis"
+    },
+    {
+      "aop_id": "AOP 67",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Estradiaol Activation in the Fetal Testis"
+    },
+    {
+      "aop_id": "AOP 68",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Alterations in the Fetal Testis Protome"
+    }
+  ],
+  "KE 653": [
+    {
+      "aop_id": "AOP 66",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent Glucocorticoid Activation in the Fetal Testis"
+    }
+  ],
+  "KE 654": [
+    {
+      "aop_id": "AOP 66",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent Glucocorticoid Activation in the Fetal Testis"
+    }
+  ],
+  "KE 655": [
+    {
+      "aop_id": "AOP 66",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent Glucocorticoid Activation in the Fetal Testis"
+    },
+    {
+      "aop_id": "AOP 67",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Estradiaol Activation in the Fetal Testis"
+    },
+    {
+      "aop_id": "AOP 68",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Alterations in the Fetal Testis Protome"
+    },
+    {
+      "aop_id": "AOP 74",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Hypermethylation in the Fetal Testis"
+    }
+  ],
+  "KE 657": [
+    {
+      "aop_id": "AOP 66",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent Glucocorticoid Activation in the Fetal Testis"
+    },
+    {
+      "aop_id": "AOP 68",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Alterations in the Fetal Testis Protome"
+    }
+  ],
+  "KE 658": [
+    {
+      "aop_id": "AOP 67",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Estradiaol Activation in the Fetal Testis"
+    }
+  ],
+  "KE 659": [
+    {
+      "aop_id": "AOP 67",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Estradiaol Activation in the Fetal Testis"
+    }
+  ],
+  "KE 660": [
+    {
+      "aop_id": "AOP 67",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Estradiaol Activation in the Fetal Testis"
+    }
+  ],
+  "KE 661": [
+    {
+      "aop_id": "AOP 68",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Alterations in the Fetal Testis Protome"
+    }
+  ],
+  "KE 642": [
+    {
+      "aop_id": "AOP 69",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Decreased Cholesterol Synthesis or Transport in the Adult Leydig Cell"
+    }
+  ],
+  "KE 643": [
+    {
+      "aop_id": "AOP 69",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Decreased Cholesterol Synthesis or Transport in the Adult Leydig Cell"
+    }
+  ],
+  "KE 644": [
+    {
+      "aop_id": "AOP 69",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Decreased Cholesterol Synthesis or Transport in the Adult Leydig Cell"
+    }
+  ],
+  "KE 645": [
+    {
+      "aop_id": "AOP 69",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Decreased Cholesterol Synthesis or Transport in the Adult Leydig Cell"
+    }
+  ],
+  "KE 646": [
+    {
+      "aop_id": "AOP 69",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Decreased Cholesterol Synthesis or Transport in the Adult Leydig Cell"
+    }
+  ],
+  "KE 408": [
+    {
+      "aop_id": "AOP 7",
+      "aop_title": "Aromatase (Cyp19a1) reduction leading to impaired fertility in adult female"
+    }
+  ],
+  "KE 640": [
+    {
+      "aop_id": "AOP 70",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Proteomic Alterations in the Adult Leydig Cell"
+    }
+  ],
+  "KE 648": [
+    {
+      "aop_id": "AOP 70",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Proteomic Alterations in the Adult Leydig Cell"
+    }
+  ],
+  "KE 649": [
+    {
+      "aop_id": "AOP 70",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Proteomic Alterations in the Adult Leydig Cell"
+    }
+  ],
+  "KE 525": [
+    {
+      "aop_id": "AOP 71",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Glucocorticoid Activation"
+    }
+  ],
+  "KE 650": [
+    {
+      "aop_id": "AOP 71",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Glucocorticoid Activation"
+    }
+  ],
+  "KE 651": [
+    {
+      "aop_id": "AOP 71",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Glucocorticoid Activation"
+    }
+  ],
+  "KE 652": [
+    {
+      "aop_id": "AOP 71",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Glucocorticoid Activation"
+    }
+  ],
+  "KE 1447": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1448": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1449": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1450": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1451": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1452": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1453": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 1454": [
+    {
+      "aop_id": "AOP 72",
+      "aop_title": "Epigenetic modification of PPARG leading to adipogenesis"
+    }
+  ],
+  "KE 526": [
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 528": [
+    {
+      "aop_id": "AOP 73",
+      "aop_title": "Xenobiotic Inhibition of Dopamine-beta-Hydroxylase and subsequent reduced fecundity"
+    }
+  ],
+  "KE 540": [
+    {
+      "aop_id": "AOP 74",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Hypermethylation in the Fetal Testis"
+    }
+  ],
+  "KE 541": [
+    {
+      "aop_id": "AOP 74",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Hypermethylation in the Fetal Testis"
+    }
+  ],
+  "KE 543": [
+    {
+      "aop_id": "AOP 74",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Hypermethylation in the Fetal Testis"
+    }
+  ],
+  "KE 662": [
+    {
+      "aop_id": "AOP 74",
+      "aop_title": "Modulation of Adult Leydig Cell Function Subsequent to Hypermethylation in the Fetal Testis"
+    }
+  ],
+  "KE 1243": [
+    {
+      "aop_id": "AOP 77",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony death/failure 1"
+    },
+    {
+      "aop_id": "AOP 87",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure "
+    },
+    {
+      "aop_id": "AOP 88",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure via abnormal role change within caste"
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    }
+  ],
+  "KE 564": [
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 82",
+      "aop_title": "Abnormal role change in worker caste contributes to reduced brood care and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 86",
+      "aop_title": "Decrease Glucose oxidase activity contributes to reduction of antiseptic in food and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    }
+  ],
+  "KE 565": [
+    {
+      "aop_id": "AOP 78",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal role change within the worker bee caste leading to colony death failure 1"
+    },
+    {
+      "aop_id": "AOP 82",
+      "aop_title": "Abnormal role change in worker caste contributes to reduced brood care and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    }
+  ],
+  "KE 568": [
+    {
+      "aop_id": "AOP 79",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to impaired hive thermoregulation and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 84",
+      "aop_title": "Suppression of immune system contributes to impaired development and leads to colony loss/failure"
+    }
+  ],
+  "KE 319": [
+    {
+      "aop_id": "AOP 8",
+      "aop_title": "Upregulation of Thyroid Hormone Catabolism via Activation of Hepatic Nuclear Receptors, and Subsequent Adverse Neurodevelopmental Outcomes in Mammals"
+    }
+  ],
+  "KE 570": [
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    }
+  ],
+  "KE 571": [
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    }
+  ],
+  "KE 572": [
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 81",
+      "aop_title": "Increased metabolic stress contributes to abnormal foraging and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 84",
+      "aop_title": "Suppression of immune system contributes to impaired development and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 85",
+      "aop_title": "Suppression of immune system contributes to abnormal foraging and leads to colony loss/failure"
+    }
+  ],
+  "KE 664": [
+    {
+      "aop_id": "AOP 80",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to accumulation of damaged mitochondrial DNA and leads to colony loss/failure"
+    }
+  ],
+  "KE 573": [
+    {
+      "aop_id": "AOP 81",
+      "aop_title": "Increased metabolic stress contributes to abnormal foraging and leads to colony loss/failure"
+    }
+  ],
+  "KE 574": [
+    {
+      "aop_id": "AOP 81",
+      "aop_title": "Increased metabolic stress contributes to abnormal foraging and leads to colony loss/failure"
+    }
+  ],
+  "KE 576": [
+    {
+      "aop_id": "AOP 84",
+      "aop_title": "Suppression of immune system contributes to impaired development and leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 85",
+      "aop_title": "Suppression of immune system contributes to abnormal foraging and leads to colony loss/failure"
+    }
+  ],
+  "KE 577": [
+    {
+      "aop_id": "AOP 84",
+      "aop_title": "Suppression of immune system contributes to impaired development and leads to colony loss/failure"
+    }
+  ],
+  "KE 561": [
+    {
+      "aop_id": "AOP 86",
+      "aop_title": "Decrease Glucose oxidase activity contributes to reduction of antiseptic in food and leads to colony loss/failure"
+    }
+  ],
+  "KE 578": [
+    {
+      "aop_id": "AOP 86",
+      "aop_title": "Decrease Glucose oxidase activity contributes to reduction of antiseptic in food and leads to colony loss/failure"
+    }
+  ],
+  "KE 579": [
+    {
+      "aop_id": "AOP 86",
+      "aop_title": "Decrease Glucose oxidase activity contributes to reduction of antiseptic in food and leads to colony loss/failure"
+    }
+  ],
+  "KE 580": [
+    {
+      "aop_id": "AOP 86",
+      "aop_title": "Decrease Glucose oxidase activity contributes to reduction of antiseptic in food and leads to colony loss/failure"
+    }
+  ],
+  "KE 663": [
+    {
+      "aop_id": "AOP 88",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal foraging and leads to colony loss/failure via abnormal role change within caste"
+    },
+    {
+      "aop_id": "AOP 89",
+      "aop_title": "Nicotinic acetylcholine receptor activation followed by desensitization contributes to abnormal foraging and directly leads to colony loss/failure"
+    },
+    {
+      "aop_id": "AOP 90",
+      "aop_title": "Nicotinic acetylcholine receptor activation contributes to abnormal roll change within the worker bee caste leading to colony loss/failure 2"
+    }
+  ],
+  "KE 585": [
+    {
+      "aop_id": "AOP 91",
+      "aop_title": "Sodium channel inhibition leading to reduced survival"
+    },
+    {
+      "aop_id": "AOP 93",
+      "aop_title": "sodium channel inhibition leading to increased predation"
+    },
+    {
+      "aop_id": "AOP 94",
+      "aop_title": "Sodium channel inhibition leading to congenital malformations"
+    },
+    {
+      "aop_id": "AOP 95",
+      "aop_title": "Ether-a-go-go (ERG) voltage-gated potassium channel inhibition leading to reduced survival"
+    }
+  ],
+  "KE 586": [
+    {
+      "aop_id": "AOP 91",
+      "aop_title": "Sodium channel inhibition leading to reduced survival"
+    },
+    {
+      "aop_id": "AOP 93",
+      "aop_title": "sodium channel inhibition leading to increased predation"
+    },
+    {
+      "aop_id": "AOP 95",
+      "aop_title": "Ether-a-go-go (ERG) voltage-gated potassium channel inhibition leading to reduced survival"
+    }
+  ],
+  "KE 587": [
+    {
+      "aop_id": "AOP 91",
+      "aop_title": "Sodium channel inhibition leading to reduced survival"
+    },
+    {
+      "aop_id": "AOP 95",
+      "aop_title": "Ether-a-go-go (ERG) voltage-gated potassium channel inhibition leading to reduced survival"
+    }
+  ],
+  "KE 588": [
+    {
+      "aop_id": "AOP 91",
+      "aop_title": "Sodium channel inhibition leading to reduced survival"
+    },
+    {
+      "aop_id": "AOP 93",
+      "aop_title": "sodium channel inhibition leading to increased predation"
+    },
+    {
+      "aop_id": "AOP 95",
+      "aop_title": "Ether-a-go-go (ERG) voltage-gated potassium channel inhibition leading to reduced survival"
+    },
+    {
+      "aop_id": "AOP 98",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to decreased shelter seeking and increased predation"
+    },
+    {
+      "aop_id": "AOP 99",
+      "aop_title": "Histamine (H2) receptor antagonism leading to reduced survival"
+    }
+  ],
+  "KE 592": [
+    {
+      "aop_id": "AOP 91",
+      "aop_title": "Sodium channel inhibition leading to reduced survival"
+    },
+    {
+      "aop_id": "AOP 95",
+      "aop_title": "Ether-a-go-go (ERG) voltage-gated potassium channel inhibition leading to reduced survival"
+    }
+  ],
+  "KE 444": [
+    {
+      "aop_id": "AOP 94",
+      "aop_title": "Sodium channel inhibition leading to congenital malformations"
+    }
+  ],
+  "KE 591": [
+    {
+      "aop_id": "AOP 94",
+      "aop_title": "Sodium channel inhibition leading to congenital malformations"
+    }
+  ],
+  "KE 598": [
+    {
+      "aop_id": "AOP 96",
+      "aop_title": "Axonal sodium channel modulation leading to acute mortality"
+    }
+  ],
+  "KE 599": [
+    {
+      "aop_id": "AOP 96",
+      "aop_title": "Axonal sodium channel modulation leading to acute mortality"
+    }
+  ],
+  "KE 600": [
+    {
+      "aop_id": "AOP 96",
+      "aop_title": "Axonal sodium channel modulation leading to acute mortality"
+    }
+  ],
+  "KE 601": [
+    {
+      "aop_id": "AOP 96",
+      "aop_title": "Axonal sodium channel modulation leading to acute mortality"
+    }
+  ],
+  "KE 1139": [
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 1143": [
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 622": [
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 623": [
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 624": [
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 625": [
+    {
+      "aop_id": "AOP 97",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to population decline"
+    }
+  ],
+  "KE 627": [
+    {
+      "aop_id": "AOP 98",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to decreased shelter seeking and increased predation"
+    }
+  ],
+  "KE 629": [
+    {
+      "aop_id": "AOP 98",
+      "aop_title": "5-hydroxytryptamine transporter (5-HTT; SERT) inhibition leading to decreased shelter seeking and increased predation"
+    }
+  ],
+  "KE 633": [
+    {
+      "aop_id": "AOP 99",
+      "aop_title": "Histamine (H2) receptor antagonism leading to reduced survival"
+    }
+  ],
+  "KE 634": [
+    {
+      "aop_id": "AOP 99",
+      "aop_title": "Histamine (H2) receptor antagonism leading to reduced survival"
+    }
+  ],
+  "KE 635": [
+    {
+      "aop_id": "AOP 99",
+      "aop_title": "Histamine (H2) receptor antagonism leading to reduced survival"
+    }
+  ],
+  "KE 638": [
+    {
+      "aop_id": "AOP 99",
+      "aop_title": "Histamine (H2) receptor antagonism leading to reduced survival"
+    }
+  ]
+}

--- a/src/blueprints/v1_api.py
+++ b/src/blueprints/v1_api.py
@@ -674,3 +674,145 @@ def get_reactome_mapping(uuid):
         return jsonify({"error": f"Reactome mapping not found: {uuid}"}), 404
 
     return jsonify({"data": _serialize_reactome_mapping(row)})
+
+
+# ---------------------------------------------------------------------------
+# Routes: AOPs
+# ---------------------------------------------------------------------------
+
+_AOP_CSV_FIELDS = [
+    "aop_id", "aop_title", "ke_count", "mapped_ke_count",
+    "wikipathways_ke_count", "go_ke_count", "reactome_ke_count",
+]
+
+
+def _build_aop_index():
+    """Aggregate the KE->AOP membership snapshot into an AOP-keyed index.
+
+    Inverts ``ke_aop_membership`` (KE label -> [{aop_id, aop_title}]) and
+    cross-references the mapped KE IDs of each resource, so every AOP carries
+    both its total KE count and how many of those KEs the curators have mapped.
+
+    Returns:
+        List of AOP dicts sorted by mapped_ke_count descending, then numeric
+        AOP ID ascending.  Empty list if the membership snapshot is missing.
+    """
+    if not ke_aop_membership:
+        logger.warning("ke_aop_membership is unavailable; /api/v1/aops will be empty")
+        return []
+
+    def _mapped_ids(model, label):
+        # get_mapped_ke_ids() does not filter on approval, matching the
+        # collection endpoints above: the mapping tables only ever receive
+        # approved rows (pending work lives in the *_proposals tables). If that
+        # ever changes, this and /mappings both start counting pending rows.
+        if model is None:
+            return set()
+        try:
+            return set(model.get_mapped_ke_ids())
+        except Exception as exc:
+            logger.warning("Could not read mapped KE IDs for %s: %s", label, exc)
+            return set()
+
+    wp_ids = _mapped_ids(mapping_model, "wikipathways")
+    go_ids = _mapped_ids(go_mapping_model, "go")
+    rx_ids = _mapped_ids(reactome_mapping_model, "reactome")
+    any_ids = wp_ids | go_ids | rx_ids
+
+    # aop_id -> {title, kes, wp, go, rx}
+    index = {}
+    for ke_id, entries in ke_aop_membership.items():
+        for entry in entries or []:
+            aop_id = entry.get("aop_id")
+            if not aop_id:
+                continue
+            agg = index.setdefault(aop_id, {
+                "aop_id": aop_id,
+                "aop_title": entry.get("aop_title") or aop_id,
+                "kes": set(), "wp": set(), "go": set(), "rx": set(),
+            })
+            agg["kes"].add(ke_id)
+            if ke_id in wp_ids:
+                agg["wp"].add(ke_id)
+            if ke_id in go_ids:
+                agg["go"].add(ke_id)
+            if ke_id in rx_ids:
+                agg["rx"].add(ke_id)
+
+    aops = [
+        {
+            "aop_id": agg["aop_id"],
+            "aop_title": agg["aop_title"],
+            "ke_count": len(agg["kes"]),
+            "mapped_ke_count": len(agg["kes"] & any_ids),
+            "wikipathways_ke_count": len(agg["wp"]),
+            "go_ke_count": len(agg["go"]),
+            "reactome_ke_count": len(agg["rx"]),
+        }
+        for agg in index.values()
+    ]
+
+    def _sort_key(aop):
+        try:
+            numeric = int(str(aop["aop_id"]).split()[-1].replace("AOP:", ""))
+        except (ValueError, IndexError):
+            numeric = 10 ** 9
+        return (-aop["mapped_ke_count"], numeric)
+
+    aops.sort(key=_sort_key)
+    return aops
+
+
+@v1_api_bp.route("/aops", methods=["GET"])
+def list_aops():
+    """
+    GET /api/v1/aops
+
+    Lists the Adverse Outcome Pathways this instance knows about, each with its
+    Key Event count and how many of those KEs carry approved mappings, broken
+    down per resource.  Sorted by mapped_ke_count descending.
+
+    Query params (all optional):
+      mapped_only — "true" to return only AOPs with at least one mapped KE
+      q           — case-insensitive substring filter over aop_id and aop_title
+      page        — page number (default 1)
+      per_page    — results per page (default 50, max 200)
+
+    Accept header / ?format=csv behaves as for /mappings.
+
+    AOP membership comes from the precomputed AOP-Wiki snapshot
+    (data/ke_aop_membership.json), the same source behind the ke_aop_context
+    field on mapping records — so it is as current as the last run of
+    scripts/precompute_ke_aop_membership.py, not live SPARQL.
+    """
+    page, per_page = _parse_pagination_params()
+    mapped_only = request.args.get("mapped_only", "").lower() in ("1", "true", "yes")
+    q = (request.args.get("q") or "").strip().lower()
+
+    try:
+        aops = _build_aop_index()
+    except Exception as exc:
+        logger.error("Error in list_aops: %s", exc)
+        return jsonify({"error": "Failed to retrieve AOPs"}), 500
+
+    if mapped_only:
+        aops = [a for a in aops if a["mapped_ke_count"] > 0]
+    if q:
+        aops = [
+            a for a in aops
+            if q in a["aop_id"].lower() or q in a["aop_title"].lower()
+        ]
+
+    total = len(aops)
+    start = (page - 1) * per_page
+    window = aops[start:start + per_page]
+
+    base_url = request.url_root.rstrip("/") + "/api/v1/aops"
+    extra_params = {}
+    if mapped_only:
+        extra_params["mapped_only"] = "true"
+    if q:
+        extra_params["q"] = request.args.get("q")
+    pagination = _make_pagination(page, per_page, total, base_url, extra_params)
+
+    return _respond_collection(window, pagination, _AOP_CSV_FIELDS)

--- a/static/openapi/openapi.yaml
+++ b/static/openapi/openapi.yaml
@@ -345,6 +345,75 @@ paths:
         "429":
           $ref: "#/components/responses/TooManyRequests"
 
+  /aops:
+    get:
+      operationId: listAops
+      summary: List Adverse Outcome Pathways with mapping coverage
+      description: |
+        Returns the AOPs this instance knows about, each with its Key Event
+        count and how many of those KEs carry approved mappings, broken down
+        per resource (WikiPathways / GO / Reactome). Sorted by
+        `mapped_ke_count` descending, so the best-covered AOPs come first.
+
+        AOP membership comes from a precomputed AOP-Wiki snapshot — the same
+        source behind the `ke_aop_context` field on mapping records — so it is
+        as current as the last snapshot refresh, not live SPARQL.
+
+        Set `?format=csv` to download a CSV file instead of JSON.
+      tags:
+        - AOPs
+      parameters:
+        - name: mapped_only
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: "Return only AOPs with at least one mapped Key Event"
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Case-insensitive substring filter over aop_id and aop_title"
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: "Page number (1-based)"
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+          description: "Results per page (max 200)"
+        - name: format
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [csv]
+          description: "Set to 'csv' to receive a CSV download instead of JSON"
+      responses:
+        "200":
+          description: "Paginated list of AOPs"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AopsResponse"
+            text/csv:
+              schema:
+                type: string
+                description: "CSV with one row per AOP"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
 components:
 
   schemas:
@@ -579,6 +648,47 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ReactomeMapping"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+      required:
+        - data
+        - pagination
+
+    Aop:
+      type: object
+      description: "An Adverse Outcome Pathway with its curated mapping coverage"
+      properties:
+        aop_id:
+          type: string
+          description: "AOP-Wiki identifier"
+          example: "AOP 625"
+        aop_title:
+          type: string
+          description: "AOP title from AOP-Wiki"
+        ke_count:
+          type: integer
+          description: "Total Key Events in this AOP"
+        mapped_ke_count:
+          type: integer
+          description: "Key Events with at least one approved mapping on any resource"
+        wikipathways_ke_count:
+          type: integer
+          description: "Key Events with an approved KE-WP mapping"
+        go_ke_count:
+          type: integer
+          description: "Key Events with an approved KE-GO mapping"
+        reactome_ke_count:
+          type: integer
+          description: "Key Events with an approved KE-Reactome mapping"
+
+    AopsResponse:
+      type: object
+      description: "Paginated list of AOPs"
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Aop"
         pagination:
           $ref: "#/components/schemas/Pagination"
       required:

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -494,3 +494,132 @@ class TestAssessmentShape:
         flat = _flatten_for_csv(serialized)
         assert flat["proposed_relationship"] is None
         assert flat["assessment_version"] == "v1"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/aops
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def aop_membership(request):
+    """Install a small KE->AOP membership snapshot for the duration of a test.
+
+    The real snapshot is a 1,500-KE precomputed file; these tests need a
+    handful of KEs with known AOP membership, so the module global is swapped
+    and restored rather than reading from disk.
+    """
+    original = v1_mod.ke_aop_membership
+    v1_mod.ke_aop_membership = {
+        # KE 1 sits in two AOPs; KE 2 only in AOP 10; KE 3 in neither mapped set
+        "KE 1": [
+            {"aop_id": "AOP 10", "aop_title": "Liver steatosis"},
+            {"aop_id": "AOP 20", "aop_title": "Kidney failure"},
+        ],
+        "KE 2": [{"aop_id": "AOP 10", "aop_title": "Liver steatosis"}],
+        "KE 3": [{"aop_id": "AOP 20", "aop_title": "Kidney failure"}],
+    }
+    yield v1_mod.ke_aop_membership
+    v1_mod.ke_aop_membership = original
+
+
+def test_aops_counts_kes_and_mappings_per_aop(v1_client, aop_membership):
+    """Each AOP reports its total KEs and how many carry a mapping."""
+    client, mm, gm = v1_client
+    _seed_mapping(mm, ke_id="KE 1", wp_id="WP1")
+    _seed_go_mapping(gm, ke_id="KE 2", go_id="GO:0000002")
+
+    resp = client.get("/api/v1/aops")
+    assert resp.status_code == 200
+    by_id = {a["aop_id"]: a for a in resp.get_json()["data"]}
+
+    # AOP 10 holds KE 1 (WP-mapped) and KE 2 (GO-mapped) — both mapped
+    assert by_id["AOP 10"]["ke_count"] == 2
+    assert by_id["AOP 10"]["mapped_ke_count"] == 2
+    assert by_id["AOP 10"]["wikipathways_ke_count"] == 1
+    assert by_id["AOP 10"]["go_ke_count"] == 1
+    assert by_id["AOP 10"]["reactome_ke_count"] == 0
+
+    # AOP 20 holds KE 1 (mapped) and KE 3 (unmapped)
+    assert by_id["AOP 20"]["ke_count"] == 2
+    assert by_id["AOP 20"]["mapped_ke_count"] == 1
+    assert by_id["AOP 20"]["aop_title"] == "Kidney failure"
+
+
+def test_aops_sorted_by_mapped_count_descending(v1_client, aop_membership):
+    """Best-covered AOPs come first, which is the order the picker shows."""
+    client, mm, gm = v1_client
+    _seed_mapping(mm, ke_id="KE 1", wp_id="WP1")
+    _seed_mapping(mm, ke_id="KE 2", wp_id="WP2")
+
+    data = client.get("/api/v1/aops").get_json()["data"]
+    assert [a["aop_id"] for a in data] == ["AOP 10", "AOP 20"]
+    assert data[0]["mapped_ke_count"] >= data[1]["mapped_ke_count"]
+
+
+def test_aops_mapped_only_filter(v1_client, aop_membership):
+    """mapped_only drops AOPs no curator has touched."""
+    client, mm, gm = v1_client
+    _seed_mapping(mm, ke_id="KE 2", wp_id="WP2")  # only KE 2 -> only AOP 10
+
+    all_ids = [a["aop_id"] for a in client.get("/api/v1/aops").get_json()["data"]]
+    mapped_ids = [
+        a["aop_id"]
+        for a in client.get("/api/v1/aops?mapped_only=true").get_json()["data"]
+    ]
+    assert "AOP 20" in all_ids
+    assert mapped_ids == ["AOP 10"]
+
+
+def test_aops_query_filter_matches_title_and_id(v1_client, aop_membership):
+    """q searches both the AOP ID and its title."""
+    client, mm, gm = v1_client
+
+    by_title = client.get("/api/v1/aops?q=kidney").get_json()["data"]
+    assert [a["aop_id"] for a in by_title] == ["AOP 20"]
+
+    by_id = client.get("/api/v1/aops?q=aop 10").get_json()["data"]
+    assert [a["aop_id"] for a in by_id] == ["AOP 10"]
+
+
+def test_aops_pagination_envelope(v1_client, aop_membership):
+    """Pagination matches the envelope the other v1 collections return."""
+    client, mm, gm = v1_client
+
+    payload = client.get("/api/v1/aops?per_page=1").get_json()
+    assert len(payload["data"]) == 1
+    assert payload["pagination"]["total"] == 2
+    assert payload["pagination"]["total_pages"] == 2
+    assert payload["pagination"]["next"] is not None
+    assert payload["pagination"]["prev"] is None
+
+
+def test_aops_csv_format(v1_client, aop_membership):
+    """?format=csv returns the flat per-resource columns."""
+    client, mm, gm = v1_client
+    _seed_mapping(mm, ke_id="KE 1", wp_id="WP1")
+
+    resp = client.get("/api/v1/aops?format=csv")
+    assert resp.status_code == 200
+    assert "text/csv" in resp.headers["Content-Type"]
+    body = resp.get_data(as_text=True)
+    assert body.splitlines()[0] == (
+        "aop_id,aop_title,ke_count,mapped_ke_count,"
+        "wikipathways_ke_count,go_ke_count,reactome_ke_count"
+    )
+
+
+def test_aops_empty_when_membership_snapshot_missing(v1_client):
+    """No snapshot means an empty list, not a 500.
+
+    The snapshot is a precomputed file mounted at runtime, so a deployment
+    without it must degrade to "no AOPs known" rather than breaking the API.
+    """
+    client, mm, gm = v1_client
+    original = v1_mod.ke_aop_membership
+    v1_mod.ke_aop_membership = None
+    try:
+        resp = client.get("/api/v1/aops")
+        assert resp.status_code == 200
+        assert resp.get_json()["data"] == []
+    finally:
+        v1_mod.ke_aop_membership = original


### PR DESCRIPTION
Serves the AOP list the Analyser's picker needs, and fixes the stale data behind it. Closes the Builder half of molAOP-analyser#3.

## The gap

Nothing in the public API answers *"which AOPs does this instance have mappings for?"*. A consumer has to page every mapping record, read `ke_aop_context` and invert it — which yields AOP IDs and nothing else: no titles, no total KE counts, no per-resource breakdown. The Analyser does exactly that and falls back to AOP-Wiki SPARQL for the rest, so its AOP dropdown has never actually been Builder-driven.

## `GET /api/v1/aops`

One row per AOP: `aop_id`, `aop_title`, `ke_count`, `mapped_ke_count`, and the split across `wikipathways_ke_count` / `go_ke_count` / `reactome_ke_count`. Sorted by mapped coverage descending.

- `?mapped_only=true` — drop AOPs no curator has touched
- `?q=` — case-insensitive filter over ID and title
- `?page` / `?per_page` / `?format=csv` — same envelope as the other v1 collections

A missing membership snapshot returns an empty list, not a 500 — that file is mounted at runtime rather than shipped in the image, so "not deployed yet" must not break the API.

## The snapshot was four months stale

`data/ke_aop_membership.json` backs `ke_aop_context` on **every** mapping record, not just this endpoint. It was generated on **10 March 2026** and never regenerated. Re-running `scripts/precompute_ke_aop_membership.py`:

| | before | after |
|---|---|---|
| KEs | 1,567 | 1,599 |
| KE-AOP memberships | 3,623 | 3,719 (+125, −0) |
| distinct AOPs | 528 | 539 |

AOP 625: 15 → 18 KEs. AOP 628: 14 → 16. AOP 638: absent → 11 KEs.

It is now **tracked**. Untracked, the API's entire notion of AOP membership lived on whichever machine last ran the script — which is also why nothing surfaced that it had gone stale.

> **Deploy note:** production reads `data/` from the `/app/data` bind mount, which shadows the image. Committing the refreshed snapshot does **not** deploy it; the same copy has to be placed on the mount.

## Verification

609 tests pass (602 before + 7 new). The new tests cover per-AOP KE and mapping counts, per-resource breakdown, sort order, `mapped_only`, `q` over both ID and title, the pagination envelope, CSV columns, and the missing-snapshot degradation. OpenAPI spec updated and re-parsed.