### PR TITLE
Show GO assessment answers in the admin review panel

### DIFF
--- a/static/js/admin_proposals.js
+++ b/static/js/admin_proposals.js
@@ -44,6 +44,27 @@ var AdminProposals = (function () {
         step4: { complete: 'Complete mechanism', keysteps: 'Key steps only', minor: 'Minor aspects' }
     };
 
+    // Issue #213: GO proposals carry a different assessment schema. The WP and
+    // Reactome queues store four categorical answers (proposed_relationship /
+    // _basis / _specificity / _coverage on `proposals`), while the GO mapper
+    // asks three High/Medium/Low questions stored as 3/2/1 integers
+    // (proposed_connection_score / _specificity_score / _evidence_score on
+    // `ke_go_proposals`). The panel used to test only the WP columns, so every
+    // GO proposal — including freshly submitted ones — rendered as
+    // "No assessment submitted (legacy proposal)" even though the answers were
+    // stored correctly. Question wording matches the submitter's form in
+    // static/js/main.js:4420-4460 so reviewer and submitter see the same labels.
+    var goDimensionLabels = { 3: 'High', 2: 'Medium', 1: 'Low' };
+    var goDimensions = [
+        { key: 'proposed_connection_score', label: 'Connection (biological relevance)' },
+        { key: 'proposed_specificity_score', label: 'Specificity (term precision)' },
+        { key: 'proposed_evidence_score', label: 'Evidence (literature support)' }
+    ];
+
+    function _hasValue(v) {
+        return v !== null && v !== undefined && v !== '';
+    }
+
     // -------------------------------------------------------------------------
     // DataTable init
     // -------------------------------------------------------------------------
@@ -211,6 +232,12 @@ var AdminProposals = (function () {
             proposed_basis: $row.data('proposed-basis') || null,
             proposed_specificity: $row.data('proposed-specificity') || null,
             proposed_coverage: $row.data('proposed-coverage') || null,
+            // Issue #213: GO's three-dimension assessment. Absent on the WP and
+            // Reactome queues, where these stay null and the four-answer block
+            // above is rendered instead.
+            proposed_connection_score: $row.data('proposed-connection-score') || null,
+            proposed_specificity_score: $row.data('proposed-specificity-score') || null,
+            proposed_evidence_score: $row.data('proposed-evidence-score') || null,
             suggestion_score: $row.data('suggestion-score') || null,
             user_name: $row.data('user-name') || '',
             submitted_by: $row.data('submitted-by') || '',
@@ -290,12 +317,22 @@ var AdminProposals = (function () {
         // Assessment block (verbatim from admin_proposals.html:280-296)
         var assessmentHtml = (function () {
             var p = proposal;
-            var hasAssessment = p.proposed_relationship != null && p.proposed_relationship !== ''
-                || p.proposed_basis != null && p.proposed_basis !== ''
-                || p.proposed_specificity != null && p.proposed_specificity !== ''
-                || p.proposed_coverage != null && p.proposed_coverage !== '';
+            var hasAssessment = _hasValue(p.proposed_relationship)
+                || _hasValue(p.proposed_basis)
+                || _hasValue(p.proposed_specificity)
+                || _hasValue(p.proposed_coverage);
+            // Issue #213: GO's three-dimension schema (see goDimensions above).
+            var hasGoAssessment = goDimensions.some(function (d) {
+                return _hasValue(p[d.key]);
+            });
             var body;
-            if (hasAssessment) {
+            if (hasGoAssessment) {
+                body = goDimensions.map(function (d) {
+                    var raw = p[d.key];
+                    var label = _hasValue(raw) ? (goDimensionLabels[raw] || raw) : '—';
+                    return '<div><strong>' + escapeHtml(d.label) + ':</strong> ' + escapeHtml(label) + '</div>';
+                }).join('');
+            } else if (hasAssessment) {
                 body = '<div><strong>Relationship:</strong> ' + escapeHtml(stepLabels.step1[p.proposed_relationship] || p.proposed_relationship || '—') + '</div>' +
                        '<div><strong>Basis:</strong> ' + escapeHtml(stepLabels.step2[p.proposed_basis] || p.proposed_basis || '—') + '</div>' +
                        '<div><strong>Specificity:</strong> ' + escapeHtml(stepLabels.step3[p.proposed_specificity] || p.proposed_specificity || '—') + '</div>' +

--- a/templates/admin_go_proposals.html
+++ b/templates/admin_go_proposals.html
@@ -85,10 +85,15 @@
                                 data-pathway-title="{{ (proposal.go_name or proposal.mapping_go_name)|e }}"
                                 data-confidence="{{ (proposal.new_pair_confidence_level or proposal.proposed_confidence)|e }}"
                                 data-connection-type="{{ (proposal.new_pair_connection_type or proposal.proposed_connection_type)|e }}"
-                                data-proposed-relationship="{{ proposal.proposed_relationship|e if proposal.proposed_relationship else '' }}"
-                                data-proposed-basis="{{ proposal.proposed_basis|e if proposal.proposed_basis else '' }}"
-                                data-proposed-specificity="{{ proposal.proposed_specificity|e if proposal.proposed_specificity else '' }}"
-                                data-proposed-coverage="{{ proposal.proposed_coverage|e if proposal.proposed_coverage else '' }}"
+                                {# Issue #213: GO proposals use the three-dimension assessment schema
+                                   (ke_go_proposals), not the WP four-answer one. The WP-shaped
+                                   data-proposed-relationship/basis/specificity/coverage attributes
+                                   that used to sit here referenced columns this table does not have,
+                                   so they were always empty and the review panel reported every GO
+                                   proposal as "No assessment submitted (legacy proposal)". #}
+                                data-proposed-connection-score="{{ proposal.proposed_connection_score if proposal.proposed_connection_score is not none else '' }}"
+                                data-proposed-specificity-score="{{ proposal.proposed_specificity_score if proposal.proposed_specificity_score is not none else '' }}"
+                                data-proposed-evidence-score="{{ proposal.proposed_evidence_score if proposal.proposed_evidence_score is not none else '' }}"
                                 data-suggestion-score="{{ proposal.suggestion_score|e if proposal.suggestion_score else '' }}"
                                 data-submitted-by="{{ (proposal.github_username or proposal.user_name)|e }}"
                                 data-created-at="{{ (proposal.created_at_formatted or proposal.created_at)|e }}">

--- a/tests/test_admin_proposals_js.py
+++ b/tests/test_admin_proposals_js.py
@@ -194,3 +194,74 @@ class TestAdminProposalsJs:
             assert "grid-template-columns" in content, (
                 f"{tpl_name}: missing grid-template-columns two-column layout"
             )
+
+    def test_go_assessment_rendered_in_panel(self):
+        """Issue #213: the shared review panel must render GO's three-dimension
+        assessment, not just the WP four-answer one.
+
+        The panel used to test only proposed_relationship/_basis/_specificity/
+        _coverage — columns that exist on `proposals` but not on
+        `ke_go_proposals` — so every GO proposal fell through to the
+        "legacy proposal" branch even when its three answers were stored.
+        """
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        js_path = os.path.join(project_root, "static", "js", "admin_proposals.js")
+        content = open(js_path, encoding="utf-8").read()
+
+        for field in [
+            "proposed_connection_score",
+            "proposed_specificity_score",
+            "proposed_evidence_score",
+        ]:
+            assert field in content, (
+                f"admin_proposals.js: GO assessment field {field} never read — "
+                "GO proposals will render as 'No assessment submitted'"
+            )
+
+        # The GO branch must be evaluated before the legacy fallback.
+        assert "hasGoAssessment" in content, (
+            "admin_proposals.js: no GO-specific assessment branch"
+        )
+        # Anchor on the branch statement and the fallback's rendered markup so
+        # the explanatory comments above them do not satisfy the assertion.
+        go_branch = content.index("if (hasGoAssessment)")
+        legacy = content.index("No assessment submitted (legacy proposal)</div>")
+        assert go_branch < legacy, (
+            "admin_proposals.js: GO assessment branch must precede the "
+            "legacy-proposal fallback"
+        )
+
+    def test_go_template_emits_go_assessment_attrs(self):
+        """Issue #213: the GO queue's rows must carry GO's assessment columns.
+
+        The row attributes feed _rowToProposal, which backs the panel's fast
+        path. admin_go_proposals.html previously copied the WP four-answer
+        attributes verbatim; those reference columns ke_go_proposals does not
+        have, so they rendered as empty strings on every row.
+        """
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(tests_dir)
+        path = os.path.join(project_root, "templates", "admin_go_proposals.html")
+        content = open(path, encoding="utf-8").read()
+
+        # Match on `attr=` so prose in comments cannot satisfy the assertion.
+        for attr in [
+            "data-proposed-connection-score=",
+            "data-proposed-specificity-score=",
+            "data-proposed-evidence-score=",
+        ]:
+            assert attr in content, (
+                f"admin_go_proposals.html: missing {attr}"
+            )
+
+        # The WP-shaped attributes are structurally always empty here.
+        for attr in [
+            "data-proposed-relationship=",
+            "data-proposed-basis=",
+            "data-proposed-coverage=",
+        ]:
+            assert attr not in content, (
+                f"admin_go_proposals.html: {attr} references a column "
+                "ke_go_proposals does not have"
+            )

--- a/tests/test_assessment_roundtrip_go.py
+++ b/tests/test_assessment_roundtrip_go.py
@@ -1,0 +1,157 @@
+"""Issue #213 — KE-GO HTTP end-to-end assessment round-trip.
+
+HTTP path: POST /submit_go_mapping (with connection_score / specificity_score /
+evidence_score) -> GET /admin/go-proposals/<id>. Asserts the three GO dimension
+answers survive the form -> DB -> review-panel handoff.
+
+GO uses a DIFFERENT assessment schema from WP and Reactome: three High/Medium/Low
+questions stored as 3/2/1 integers in ke_go_proposals.proposed_connection_score /
+_specificity_score / _evidence_score, versus the four categorical proposed_*
+columns on `proposals`. The two roundtrip tests that existed (WP, Reactome) both
+covered the four-column schema, so nothing checked that GO's three answers reach
+the reviewer — and they did not: the shared review panel tested only the WP
+columns and reported every GO proposal as "No assessment submitted (legacy
+proposal)" (issue #213). The storage path was correct throughout; only the read
+side was broken. These tests pin the read side.
+
+Fixture pattern mirrors tests/test_assessment_roundtrip_wp.py::wp_admin_client.
+"""
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def go_admin_client():
+    """Test client with both api + admin blueprints wired to a shared temp-file
+    GO DB, authenticated as a github:testadmin user (in ADMIN_USERS)."""
+    # Set ADMIN_USERS BEFORE importing app so admin_required honors the override.
+    os.environ["ADMIN_USERS"] = "github:testadmin"
+
+    from app import app as flask_app
+    import src.blueprints.admin as admin_mod
+    import src.blueprints.api as api_mod
+    from src.core.models import Database, GoMappingModel, GoProposalModel
+
+    fd, db_path = tempfile.mkstemp()
+    db = Database(db_path)
+    gmm = GoMappingModel(db)
+    gpm = GoProposalModel(db)
+
+    orig_api_gpm = api_mod.go_proposal_model
+    orig_api_gmm = api_mod.go_mapping_model
+    orig_admin_gpm = admin_mod.go_proposal_model
+    orig_admin_gmm = admin_mod.go_mapping_model
+
+    # Both blueprints hold their own module globals — wiring only api would
+    # leave the admin detail route reading the production DB.
+    api_mod.go_proposal_model = gpm
+    api_mod.go_mapping_model = gmm
+    admin_mod.go_proposal_model = gpm
+    admin_mod.go_mapping_model = gmm
+
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+
+    with flask_app.test_client() as test_client:
+        with flask_app.app_context():
+            with test_client.session_transaction() as sess:
+                sess["user"] = {
+                    "username": "github:testadmin",
+                    "email": "admin@example.com",
+                }
+            yield test_client, gpm, gmm, db
+
+    api_mod.go_proposal_model = orig_api_gpm
+    api_mod.go_mapping_model = orig_api_gmm
+    admin_mod.go_proposal_model = orig_admin_gpm
+    admin_mod.go_mapping_model = orig_admin_gmm
+
+    os.close(fd)
+    os.unlink(db_path)
+
+
+def _submit(client, **overrides):
+    """POST a new-pair GO mapping, returning the created proposal id."""
+    data = {
+        "ke_id": "KE 149",
+        "ke_title": "Test KE 149",
+        "go_id": "GO:0006954",
+        "go_name": "inflammatory response",
+        "connection_type": "describes",
+        "confidence_level": "high",
+        "go_namespace": "biological_process",
+        "connection_score": "3",
+        "specificity_score": "3",
+        "evidence_score": "3",
+        "suggestion_score": "3.0",
+    }
+    data.update(overrides)
+    resp = client.post("/submit_go_mapping", data=data)
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    return resp.get_json()["proposal_id"]
+
+
+def test_assessment_roundtrip_go(go_admin_client):
+    """Happy path: submit with all three dimension answers, assert they are
+    stored AND exposed by the detail endpoint the review panel reads."""
+    client, gpm, gmm, db = go_admin_client
+
+    proposal_id = _submit(client)
+
+    # 1. Stored on the proposal row.
+    row = gpm.get_go_proposal_by_id(proposal_id)
+    assert row["proposed_connection_score"] == 3
+    assert row["proposed_specificity_score"] == 3
+    assert row["proposed_evidence_score"] == 3
+
+    # 2. Reaching the reviewer. This is the assertion that fails for #213 —
+    #    the panel renders from this payload, so a missing key here is what
+    #    produced "No assessment submitted (legacy proposal)".
+    resp = client.get(f"/admin/go-proposals/{proposal_id}")
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    payload = resp.get_json()
+    assert payload["proposed_connection_score"] == 3
+    assert payload["proposed_specificity_score"] == 3
+    assert payload["proposed_evidence_score"] == 3
+
+
+def test_assessment_mixed_scores_go(go_admin_client):
+    """Distinct per-dimension values survive — guards against a fix that
+    renders one score three times, or collapses them into the derived
+    confidence level."""
+    client, gpm, gmm, db = go_admin_client
+
+    proposal_id = _submit(
+        client,
+        connection_score="3",
+        specificity_score="2",
+        evidence_score="1",
+        confidence_level="medium",
+        suggestion_score="2.0",
+    )
+
+    payload = client.get(f"/admin/go-proposals/{proposal_id}").get_json()
+    assert payload["proposed_connection_score"] == 3
+    assert payload["proposed_specificity_score"] == 2
+    assert payload["proposed_evidence_score"] == 1
+
+
+def test_assessment_legacy_go(go_admin_client):
+    """Backward-compat: a submission with no dimension answers leaves the three
+    columns NULL, so the panel's genuine "legacy proposal" branch still applies
+    to the pre-dimension GO proposals already in the database."""
+    client, gpm, gmm, db = go_admin_client
+
+    proposal_id = _submit(
+        client,
+        connection_score="",
+        specificity_score="",
+        evidence_score="",
+    )
+
+    payload = client.get(f"/admin/go-proposals/{proposal_id}").get_json()
+    assert payload["proposed_connection_score"] is None
+    assert payload["proposed_specificity_score"] is None
+    assert payload["proposed_evidence_score"] is None


### PR DESCRIPTION
Fixes #213.

## Correction to the issue

The issue reports the guided assessment answers are "discarded". They are not — they are stored correctly. Live DB, the exact proposal from the issue:

```
{'id': 13, 'ke_id': 'KE 149', 'go_id': 'GO:0006954', 'status': 'approved',
 'proposed_connection_score': 3, 'proposed_specificity_score': 3, 'proposed_evidence_score': 3}
```

3/3/3 — exactly what was selected. Proposals 8–11, 14 and 15 likewise. **No data was lost and no recovery is needed.** The defect is entirely on the read side.

## Root cause

Two parallel assessment schemas exist:

| table | assessment columns |
|---|---|
| `proposals` (WP, Reactome) | `proposed_relationship`, `proposed_basis`, `proposed_specificity`, `proposed_coverage` |
| `ke_go_proposals` (GO) | `proposed_connection_score`, `proposed_specificity_score`, `proposed_evidence_score` |

The shared review panel (`static/js/admin_proposals.js`) tested only the four WP columns. `ke_go_proposals` has none of them, so `hasAssessment` was always false for GO and every GO proposal fell through to the "No assessment submitted (legacy proposal)" branch.

`templates/admin_go_proposals.html` had the same problem: it copied the WP `data-proposed-*` row attributes verbatim, referencing columns this table lacks, so they rendered as empty strings — which is the HTML dump in the issue.

The data was already reaching the browser: `get_go_proposal_by_id` explicitly selects the three score columns and the detail route jsonifies the whole row. The panel received them and discarded them.

## Changes

- Render GO's three dimensions in the panel, evaluated ahead of the legacy fallback. Labels ("Connection (biological relevance)" etc., High/Medium/Low for 3/2/1) match the submitter's form so reviewer and submitter see the same wording.
- Emit the GO assessment columns as row data attributes, replacing the WP-shaped ones.
- Add `tests/test_assessment_roundtrip_go.py`. There were round-trip tests for WP and Reactome, both covering the four-column schema; nothing exercised GO's, which is how this shipped.
- Extend `test_admin_proposals_js.py` with two assertions on the panel and template. Both were confirmed to fail against the unfixed code.

Full suite: 673 passed.

## Follow-up, not in this PR

`grep` finds no consumers of the three GO score columns outside `models.py` — approval does not carry them onto `ke_go_mappings` the way the WP path carries its four onto `mappings`. So the answers are visible to the reviewer now, but still absent from the exported mapping's provenance. Worth a separate issue, since it needs a schema change.