### PR TITLE
Replace the never-running in-container cron backup with a Swarm cron job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ RUN pip install --no-cache-dir --prefix=/install \
 FROM python:3.12-slim-bookworm
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 FLASK_APP=app.py FLASK_ENV=production
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends curl sqlite3 cron \
+# sqlite3 is the backup script's engine (Online Backup API). No cron package:
+# the container runs a single gunicorn process as a non-root user, so it cannot
+# start a cron daemon — backups are scheduled on the Swarm instead (issue #215,
+# see "Database backups" in CLAUDE.md).
+RUN apt-get update && apt-get install -y --no-install-recommends curl sqlite3 \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/debconf/*-old /var/lib/dpkg/*-old /var/log/dpkg.log /var/log/apt/*
 
@@ -40,9 +44,6 @@ COPY --from=builder /install /usr/local
 COPY --chown=appuser:appuser . .
 RUN mkdir -p /app/static/css /app/static/js /app/data /app/logs /app/data/backups \
     && chown appuser:appuser /app/static/css /app/static/js /app/data /app/logs /app/data/backups
-# Install backup crontab
-COPY scripts/ke-wp-backup /etc/cron.d/ke-wp-backup
-RUN chmod 0644 /etc/cron.d/ke-wp-backup
 # Make scripts executable
 RUN chmod +x /app/scripts/backup_db.sh /app/scripts/docker-entrypoint.sh
 USER appuser

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -315,6 +315,59 @@ docker-compose down
 docker-compose down -v
 ```
 
+### Database Backups
+
+`ke_wp_mapping.db` is the upstream source the Molecular AOP Analyser consumes,
+so losing it loses the curation both tools rest on. On the Swarm deployment the
+database lives on GlusterFS, which is replica 2 — that is **not** a backup, since
+it replicates deletions and corruption faithfully.
+
+Backups run as a **Swarm cron job**, not as a cron daemon inside the container.
+The container runs a single gunicorn process as a non-root user and cannot start
+cron: the `/etc/cron.d/ke-wp-backup` file and the entrypoint's
+`service cron start` that used to ship here ran after `USER appuser`, failed as
+non-root, and were swallowed by `|| true`. The mechanism looked deployed for
+months while never producing a single backup (issue #215).
+
+| Property | Value |
+|----------|-------|
+| Job | `cronjobs_molaop-builder-backup` (swarm-cronjob) |
+| Schedule | Daily 02:00 UTC |
+| Defined in | `/mnt/gluster/docker/cronjobs/stack.yml` on tgx1; canonical source `TGX-UM/cronjobs` |
+| Payload | `scripts/backup_db.sh`, run in a one-shot container off this repo's image |
+| Output | `/mnt/gluster/docker/molaop-builder/data/backups/ke_wp_mapping_<ts>.db` |
+| Retention | 7 days (`RETENTION_DAYS`) |
+
+The job reads the database file directly on the shared mount rather than
+`docker exec`-ing into the running app, so it is node-independent: it works
+wherever the scheduler places it and does not pin either service to a node.
+
+`backup_db.sh` uses `sqlite3 .backup` (the [Online Backup API](https://sqlite.org/backup.html)),
+which is safe while the application is writing, then runs `PRAGMA integrity_check`
+and deletes the backup if it fails. Never copy the `.db` file without its `-wal`
+and `-shm` companions — that yields a torn snapshot.
+
+```bash
+# Run off-schedule
+ssh tgx1 "docker service scale cronjobs_molaop-builder-backup=1"
+ssh tgx1 "docker service logs cronjobs_molaop-builder-backup"
+
+# Or against the running container, after significant curation
+ssh tgx1 'docker exec $(docker ps -qf name=molaop-builder) /app/scripts/backup_db.sh'
+
+# Restore: stop the service, replace the file, start it again
+ssh tgx1 "docker service scale molaop-builder=0"
+ssh tgx1 "cp /mnt/gluster/docker/molaop-builder/data/backups/<snapshot>.db \
+             /mnt/gluster/docker/molaop-builder/data/ke_wp_mapping.db"
+ssh tgx1 "docker service scale molaop-builder=1"
+```
+
+> **Known limitation:** backups land beside the live database on the same mount,
+> so they survive node loss but not an accidental `rm -rf` of the data directory.
+> Copying them off-cluster belongs to the cluster-wide tier-1/tier-2 backup plan
+> (`operations/backup-strategy.md` in the cluster docs), which is not yet
+> implemented and is the cluster admin's call.
+
 ### Monitoring and Health Checks
 
 The application includes built-in health checks:

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 # /app/scripts/backup_db.sh
 # SQLite backup using Online Backup API (safe during active writes).
-# Schedule: daily at 02:00 container time. Retention: 7 days.
 # Source: https://sqlite.org/backup.html
+#
+# Scheduled daily at 02:00 UTC as a Swarm cron job, NOT by a cron daemon inside
+# this container — see "Database backups" in CLAUDE.md. The job runs this same
+# script in a one-shot container off the same image, with the data directory
+# bind-mounted, so it works on whichever node the scheduler picks.
+#
+# Run it by hand after significant curation:
+#   ssh tgx1 "docker exec \$(docker ps -qf name=molaop-builder) /app/scripts/backup_db.sh"
 set -euo pipefail
 
-DB_PATH="/app/data/ke_wp_mapping.db"
-BACKUP_DIR="/app/data/backups"
+# Overridable so the Swarm job (and local testing) can point at other paths
+# without editing the script.
+DB_PATH="${DB_PATH:-/app/data/ke_wp_mapping.db}"
+BACKUP_DIR="${BACKUP_DIR:-/app/data/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 BACKUP_FILE="${BACKUP_DIR}/ke_wp_mapping_${TIMESTAMP}.db"
-RETENTION_DAYS=7
 
 mkdir -p "${BACKUP_DIR}"
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # /app/scripts/docker-entrypoint.sh
-# Start cron for scheduled backups, then exec the main process (gunicorn).
-# Using exec ensures gunicorn receives Docker stop signals correctly.
+# Exec the main process (gunicorn). Using exec ensures gunicorn receives Docker
+# stop signals correctly.
+#
+# This used to run `service cron start || true` to schedule backup_db.sh. That
+# never worked: the line runs after `USER appuser` in the Dockerfile, so
+# starting the daemon needs root and always failed — silently, because of the
+# `|| true`. The result was a backup mechanism that looked deployed for months
+# without ever producing a single backup (issue #215). Backups are now a Swarm
+# cron job; see "Database backups" in CLAUDE.md.
 set -e
-
-# Start cron daemon in background for backup scheduling
-service cron start || true
 
 # Hand off to gunicorn (or whatever CMD is passed)
 exec "$@"

--- a/scripts/ke-wp-backup
+++ b/scripts/ke-wp-backup
@@ -1,2 +1,0 @@
-# KE-WP Mapping database backup — daily at 02:00
-0 2 * * * appuser /app/scripts/backup_db.sh >> /app/logs/backup.log 2>&1


### PR DESCRIPTION
Refs #215. Repo-side half; the cluster-side job still needs to be deployed (below).

## Sharper root cause than the issue states

The issue says the crontab file "is not installed" in the deployed container. It **is**:

```
$ ls /etc/cron.d/
.placeholder  e2scrub_all  ke-wp-backup      <- Dockerfile:44 installs it
```

The issue's evidence for "no cron daemon" was also inconclusive — `ps` does not exist in this image, so `ps aux | grep -c '[c]ron'` returns 0 whether or not cron is running. Checking `/proc` directly instead:

```
$ for p in /proc/[0-9]*/comm; do cat $p; done | sort | uniq -c
      4 gunicorn
      2 sh
```

The conclusion holds — no daemon, `/app/logs/` empty, the backup has never run — but the cause is the entrypoint's `service cron start`. It sits after `USER appuser` in the Dockerfile, so starting the daemon needs root, fails every time, and the `|| true` swallows it. A mechanism that looked deployed for months and produced nothing.

## Changes

- Remove the cron package, the `/etc/cron.d` file, `scripts/ke-wp-backup`, and the dead entrypoint line. The issue asks whether the inert crontab should stay; leaving a mechanism that looks deployed but cannot work is what caused this, so it goes.
- Make `backup_db.sh` accept `DB_PATH` / `BACKUP_DIR` / `RETENTION_DAYS` from the environment (defaults unchanged) so the Swarm job needs no edits to the script.
- Document the mechanism, an off-schedule run, a restore procedure, and the remaining off-cluster gap in `docs/DEPLOYMENT.md`.

## Why a Swarm cron job, not host cron

The issue suggests host cron on both nodes with a `docker exec` and a CID guard. The cluster docs rule that out — `operations/scheduling-cronjobs.md` says application and data jobs go on the Swarm, and specifically: *"Do not use `docker exec` and do not assume a node."* A `docker exec` job would also re-pin the service to a node.

The cluster already has the right mechanism, which the issue missed: `cronjobs_scheduler` (swarm-cronjob) is running, and `cronjobs_aopwiki-snorql-reload` last completed successfully on Sunday. The Builder just was not registered with it.

The job runs this repo's own image and calls the script that already ships in it, so backup logic stays versioned with the app that owns the schema, and it reads the DB file on GlusterFS instead of exec'ing into the app — node-independent either way.

## Verification

Ran the exact job design as a one-shot container against the live database:

```
$ docker run --rm --entrypoint /app/scripts/backup_db.sh \
    --mount type=bind,source=/mnt/gluster/docker/molaop-builder/data,target=/app/data \
    ghcr.io/marvinm2/molaop-builder:main-9d7e24a
[BACKUP OK] /app/data/backups/ke_wp_mapping_20260722_200610.db

$ sqlite3 <that file> "PRAGMA integrity_check; ..."
ok
126 mappings, 123 proposals      <- matches live
```

Image builds; container boots to `/health` 200 with the cron machinery gone. Full suite: 668 passed.

## Not done — needs a decision

The job block is written and validated against `/mnt/gluster/docker/cronjobs/stack.yml`, but **not deployed**: `docker stack deploy` on that stack touches shared infrastructure owned by the cluster admin. Worth a word with @slaenen first, since it is the first per-service DB backup to actually run on the cluster.

Also still open, and explicitly the admin's call: backups land beside the live DB on the same mount, so they do not survive an `rm -rf` of the data dir. Off-cluster copies are tier-1/tier-2 in `operations/backup-strategy.md`, marked NOT YET IMPLEMENTED cluster-wide.