### PR TITLE
Stop the privacy notice claiming name and affiliation are published

### DIFF
--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -37,14 +37,22 @@
             <p>When you authenticate via OAuth and submit a proposal, the application stores:</p>
             <ul>
                 <li><strong>Your provider-prefixed username</strong> (e.g. <code>github:alice</code>,
-                    <code>orcid:0000-0003-2230-0840</code>) — the stable identifier for your contributions.</li>
-                <li><strong>The name you entered</strong> on the proposal form — used for attribution on
-                    approved mappings.</li>
+                    <code>orcid:0000-0003-2230-0840</code>) — the stable identifier for your contributions.
+                    <em>This is the only one of these fields that is published.</em> It appears on the
+                    approved mapping, in the public REST API, and in the exported datasets.</li>
+                <li><strong>The name you entered</strong> on the proposal form — held on the proposal
+                    record so a reviewer can recognise who submitted it. Not published.</li>
                 <li><strong>Your email address</strong> — used so an administrator can contact you about an
-                    ambiguous or rejected proposal.</li>
-                <li><strong>Your institutional affiliation</strong> (optional) — surfaced on the public
-                    provenance record of an approved mapping.</li>
+                    ambiguous or rejected proposal. Not published.</li>
+                <li><strong>Your institutional affiliation</strong> — held on the proposal record as
+                    internal context for review. Not published.</li>
             </ul>
+            <p>
+                &ldquo;Not published&rdquo; means the field is stored in the application database and is
+                visible to administrators reviewing proposals, but is not served by the public API, does not
+                appear in any CSV, GMT, Parquet or RDF export, and is not included in the Zenodo deposit.
+                Public attribution of a mapping rests entirely on the provider-prefixed username above.
+            </p>
             <p>
                 The legal basis under the General Data Protection Regulation (GDPR) is
                 <strong>performance of a contract</strong>: you choose to authenticate, submit a proposal,


### PR DESCRIPTION
Closes #279.

## The problem

`templates/privacy.html` told curators two things that are not true:

- the name entered on the proposal form is *"used for attribution on approved mappings"*
- institutional affiliation is *"surfaced on the public provenance record of an approved mapping"*

Neither field is published anywhere:

```
$ grep -rn "user_affiliation\|user_name" src/blueprints/v1_api.py src/exporters/ templates/mapping_detail.html
$
```

Both are collected on the proposal form, stored on the `proposals` row, and never reach the public REST API, any exporter, or the mapping detail page. Public attribution rests entirely on `provider_username`.

This matters more than a docs nit because it is a false statement in the document that establishes the **lawful basis for processing**, and it errs in the direction of claiming *more* publication than occurs. A curator reading it is told their affiliation will appear on a public record; it will not.

## The fix

Correct the notice rather than start publishing the fields. Publishing affiliation would push it into the Zenodo deposit and the Turtle exports, where an erasure request cannot reach it — that is a decision belonging with the retention questions in #163, not a fix for an inaccuracy.

The corrected section now states positively which field **is** published, and defines "not published" so the difference between stored-and-admin-visible and publicly-served is explicit:

> "Not published" means the field is stored in the application database and is visible to administrators reviewing proposals, but is not served by the public API, does not appear in any CSV, GMT, Parquet or RDF export, and is not included in the Zenodo deposit. Public attribution of a mapping rests entirely on the provider-prefixed username above.

## Verified

`/privacy` renders 200 via the Flask test client; the two false phrases are absent from the rendered output and the three new ones are present. The retention table lower down was already accurate — it names `proposed_by` / `approved_by_curator`, which genuinely are the public provenance — and is unchanged.

## Noticed while here, not fixed

The notice describes affiliation as **"(optional)"**, but `templates/explore.html:200` marks the field `required`. That is a third mismatch between the notice and the application, and it belongs to #271, which is already open on making those three contact fields less burdensome for a logged-in curator. Whatever #271 decides should settle the wording; changing "(optional)" here in isolation would just move the inconsistency.
