### PR TITLE
Add an mf-corpus target, deliberately without the size ceiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,25 @@
-.PHONY: help install test lint run docker-build docker-run clean capture-versions backfill-versions go-hierarchy go-corpus wp-corpus wp-annotations ke-corpus ke-corpus-refresh ke-metadata check-releases refresh-stale-corpora
+.PHONY: help install test lint run docker-build docker-run clean capture-versions backfill-versions go-hierarchy go-corpus mf-corpus wp-corpus wp-annotations ke-corpus ke-corpus-refresh ke-metadata check-releases refresh-stale-corpora
+
+# GO MF has no size ceiling, on purpose.
+#
+# `go-corpus` ends with subset_go_corpus.py, which cuts go_bp_metadata.json down
+# to the [MIN_GENES, MAX_GENES] = [10, 500] band. `mf-corpus` deliberately omits
+# that step, so go_mf_metadata.json holds the whole namespace (~10.1k terms) and
+# every MF term stays rankable.
+#
+# Why the BP reasoning does not carry over: the ceiling exists because
+# go_bp_metadata.json is enumerated as the candidate set by the ranking paths,
+# and BP unfiltered is ~24k terms. MF is less than half that. More importantly
+# `go_mf.hybrid_weights.gene` is 0.0 (scoring_config.yaml), so gene overlap is a
+# display-only chip for MF and does not enter the score — which is what the
+# ceiling was protecting against. An umbrella term like GO:0003824 "catalytic
+# activity" (5,614 genes after closure) can therefore sit in the corpus without
+# distorting ranking, and _filter_redundant_ancestors prunes it whenever a
+# descendant scores comparably.
+#
+# The cost is real but bounded: ~10.1k candidates scored per request instead of
+# a filtered subset, and generic MF terms are reachable. That was the intent.
+# If MF ever moves off gene: 0.0, revisit this.
 
 help:		## Show this help
 	@echo "Available targets:"
@@ -43,6 +64,11 @@ go-hierarchy:	## Build GO hierarchy data (IC scores, ancestors, depths) + the fu
 go-corpus:	## Rebuild the GO BP corpora (hierarchy + search index -> filtered IDs -> subset embeddings/metadata)
 	python scripts/precompute_go_hierarchy.py
 	python scripts/subset_go_corpus.py
+
+mf-corpus:	## Rebuild the GO MF corpus (annotations -> hierarchy/IC -> embeddings). Deliberately NOT subsetted — see below
+	python scripts/download_go_annotations.py --namespace mf
+	python scripts/precompute_go_hierarchy.py --namespace mf
+	python scripts/precompute_go_embeddings.py --namespace mf
 
 wp-corpus:	## Rebuild the WikiPathways corpus (annotations -> title embeddings -> combined embeddings). Metadata holds every pathway; the size filter marks which are rankable
 	python scripts/download_wikipathways_annotations.py


### PR DESCRIPTION
Refs #222, #152. Part of re-including GO Molecular Function.

## Why

GO MF is wired end to end — `go_namespace` on the mapping and proposal tables, an `aspect_filter=all|bp|mf` control in the UI and API, `VOCAB.goNamespace` in RDF, `go_namespace` in JSON and CSV — but **no `go_mf_*` artifact has ever existed on the deployment**. `_load_mf_data` takes its absent-files branch, and the merge is guarded by `if self.go_mf_metadata:` with no user-facing signal, so:

- "MF only" returns an empty list
- "All GO" silently returns BP only

All 348 approved GO mappings are `biological_process` because that is the only outcome the tool permits, not because curators chose it.

There was also no documented way to build the corpus. All three scripts already take `--namespace mf`; nothing said so, which is the same discoverability gap #225 is open on.

## The deliberate omission

`go-corpus` ends with `subset_go_corpus.py`, which cuts `go_bp_metadata.json` to the `[MIN_GENES, MAX_GENES] = [10, 500]` band. **`mf-corpus` omits that step**, so `go_mf_metadata.json` holds the whole namespace (10,123 terms) and every MF term stays rankable.

The BP reasoning does not carry over:

| | BP | MF |
|---|---|---|
| `hybrid_weights.gene` | contributes | **0.0 — display-only chip** |
| unfiltered namespace | ~24k terms | 10.1k terms |
| filtered corpus | 4,281 terms | n/a |

The ceiling exists to stop umbrella terms dominating **gene evidence**. For MF there is no gene signal to dominate — `go_mf.hybrid_weights.gene` is `0.0` in `scoring_config.yaml`, so `GO:0003824` "catalytic activity" (5,614 genes after closure) cannot distort ranking. And `_filter_redundant_ancestors` already prunes an ancestor whenever a descendant scores comparably, which is the case the gene-count ceiling was a blunt proxy for.

The cost is real but bounded and intended: ~10.1k candidates scored per request, and generic MF terms become reachable. Reachability is the point — the cluster docs record that the BP band made 62 of 196 curated KE→GO terms (32%) unreachable by *any* route, which is what drove the full-namespace search index.

I put the rationale in a Makefile comment rather than only in this PR, because **the omission of a step is invisible at the call site** and reads as an oversight to the next person. If MF ever moves off `gene: 0.0`, this needs revisiting, and the comment says so.

## Verified

`make help` lists the target; `make -n mf-corpus` expands to the three commands in dependency order (annotations → hierarchy, which reads them for IC and the propagated closure → embeddings).

The corpus is being built on the deployment with exactly this sequence as I write; the service restart and `aspect_filter=mf` verification follow separately, since they are operations rather than repo changes.

## Not in this PR

`reactome-corpus` is still missing (#225), and the UI should arguably hide the MF toggle whenever the corpus is absent rather than returning an empty list silently — that is #152's remaining scope.
