### PR TITLE
Drop the GO size ceiling from both namespaces, and rebuild MF weekly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,32 @@
 .PHONY: help install test lint run docker-build docker-run clean capture-versions backfill-versions go-hierarchy go-corpus mf-corpus wp-corpus wp-annotations ke-corpus ke-corpus-refresh ke-metadata check-releases refresh-stale-corpora
 
-# GO MF has no size ceiling, on purpose.
+# NEITHER GO namespace has a size ceiling, on purpose. Decided 2026-08-04.
 #
-# `go-corpus` ends with subset_go_corpus.py, which cuts go_bp_metadata.json down
-# to the [MIN_GENES, MAX_GENES] = [10, 500] band. `mf-corpus` deliberately omits
-# that step, so go_mf_metadata.json holds the whole namespace (~10.1k terms) and
-# every MF term stays rankable.
+# `subset_go_corpus.py` cuts go_bp_metadata.json down to the
+# [MIN_GENES, MAX_GENES] = [10, 500] band. It is no longer in either target, so
+# both go_bp_metadata.json (~24.5k terms) and go_mf_metadata.json (10,123) hold
+# their whole namespace and every GO term stays rankable.
 #
-# Why the BP reasoning does not carry over: the ceiling exists because
-# go_bp_metadata.json is enumerated as the candidate set by the ranking paths,
-# and BP unfiltered is ~24k terms. MF is less than half that. More importantly
-# `go_mf.hybrid_weights.gene` is 0.0 (scoring_config.yaml), so gene overlap is a
-# display-only chip for MF and does not enter the score — which is what the
-# ceiling was protecting against. An umbrella term like GO:0003824 "catalytic
-# activity" (5,614 genes after closure) can therefore sit in the corpus without
-# distorting ranking, and _filter_redundant_ancestors prunes it whenever a
-# descendant scores comparably.
+# Why the ceiling stopped making sense: it was designed under v1.4, when gene
+# overlap carried real ranking weight (bp 0.45, mf 0.40) and an umbrella term
+# like GO:0003824 "catalytic activity" — 5,614 genes after closure — could
+# dominate gene evidence. v1.5 made ranking pure-semantic: `hybrid_weights.gene`
+# is now 0.0 for BOTH namespaces, so gene overlap is a display-only chip and the
+# blow-up the ceiling existed to prevent cannot reach the score at all.
 #
-# The cost is real but bounded: ~10.1k candidates scored per request instead of
-# a filtered subset, and generic MF terms are reachable. That was the intent.
-# If MF ever moves off gene: 0.0, revisit this.
+# What remains is a candidate-set argument — more terms in the thin score band
+# that #221 documents — and the answer to that is a better encoder, not a filter
+# that also makes valid terms unreachable. The band cut BOTH tails: screening a
+# 196-term curated KE→GO set found 62 (32%) unreachable by any route, including
+# PPAR signaling (9 genes) and hepatocyte proliferation (5).
+#
+# This also makes `make go-corpus` agree with the weekly cron. The cron's
+# gene_ontology rebuild never ran subset_go_corpus.py, so the two paths produced
+# different corpora and a manual rebuild silently re-narrowed what the cron had
+# widened — which is how the discrepancy in #284 arose.
+#
+# subset_go_corpus.py is kept, unreferenced, so the band can be reapplied by
+# hand. If either namespace ever moves off gene: 0.0, revisit this.
 
 help:		## Show this help
 	@echo "Available targets:"
@@ -61,11 +68,12 @@ migrate:	## Run database migration
 go-hierarchy:	## Build GO hierarchy data (IC scores, ancestors, depths) + the full-namespace search index
 	python scripts/precompute_go_hierarchy.py
 
-go-corpus:	## Rebuild the GO BP corpora (hierarchy + search index -> filtered IDs -> subset embeddings/metadata)
+go-corpus:	## Rebuild the GO BP corpus (hierarchy + search index -> embeddings). Not subsetted — see below
 	python scripts/precompute_go_hierarchy.py
-	python scripts/subset_go_corpus.py
+	python scripts/download_go_annotations.py
+	python scripts/precompute_go_embeddings.py
 
-mf-corpus:	## Rebuild the GO MF corpus (annotations -> hierarchy/IC -> embeddings). Deliberately NOT subsetted — see below
+mf-corpus:	## Rebuild the GO MF corpus (annotations -> hierarchy/IC -> embeddings). Not subsetted — see below
 	python scripts/download_go_annotations.py --namespace mf
 	python scripts/precompute_go_hierarchy.py --namespace mf
 	python scripts/precompute_go_embeddings.py --namespace mf

--- a/scripts/check_source_releases.py
+++ b/scripts/check_source_releases.py
@@ -88,15 +88,28 @@ REBUILD = {
         ],
     },
     "gene_ontology": {
+        # Both namespaces. MF was absent from this list until 2026-08-04, so a GO
+        # release rebuilt BP and left MF untouched — which is survivable only while
+        # MF has no corpus at all. It has one now.
+        #
+        # subset_go_corpus.py is deliberately absent: neither namespace is size-
+        # filtered (see the Makefile header). It was never here, which is what made
+        # the cron and `make go-corpus` disagree (#284).
         "commands": [
             ["python", "scripts/precompute_go_hierarchy.py"],
             ["python", "scripts/download_go_annotations.py"],
             ["python", "scripts/precompute_go_embeddings.py"],
+            ["python", "scripts/precompute_go_hierarchy.py", "--namespace", "mf"],
+            ["python", "scripts/download_go_annotations.py", "--namespace", "mf"],
+            ["python", "scripts/precompute_go_embeddings.py", "--namespace", "mf"],
         ],
         "artifacts": [
             "data/go_bp_embeddings.npz",
             "data/go_bp_name_embeddings.npz",
             "data/go_bp_metadata.json",
+            "data/go_mf_embeddings.npz",
+            "data/go_mf_name_embeddings.npz",
+            "data/go_mf_metadata.json",
         ],
     },
     "reactome": {

--- a/src/suggestions/go.py
+++ b/src/suggestions/go.py
@@ -64,16 +64,26 @@ class GoSuggestionService:
         self.go_metadata = {}
         self.go_gene_annotations = {}
 
-        # Full-namespace search index. Distinct from go_metadata ON PURPOSE:
-        # go_metadata is the [MIN_GENES, MAX_GENES] suggestion corpus, and several
-        # ranking paths enumerate it as "the candidate set" (see
-        # _compute_gene_overlap_scores_for), so widening it would silently push
-        # ~24k unranked terms into the Suggested list. Search has no such coupling —
-        # it is a SequenceMatcher over name + definition and touches no embeddings —
-        # so it can safely span the whole namespace, which is what lets a curator
-        # reach a term the gene-count filter excluded.
-        # Falls back to go_metadata when the artifact is absent, preserving the old
-        # (subsetted) search behaviour rather than breaking search outright.
+        # Full-namespace search index. Historically distinct from go_metadata,
+        # which used to be the [MIN_GENES, MAX_GENES] suggestion corpus while this
+        # spanned the whole namespace, so a curator could still reach a term the
+        # gene-count band excluded.
+        #
+        # As of 2026-08-04 the band is not applied to either namespace, so the two
+        # now hold nearly the same term set and this index is close to redundant.
+        # It is kept because the distinction is real in principle — search is a
+        # SequenceMatcher over name + definition and touches no embeddings, so it
+        # can always span more than the ranked corpus — and because reinstating a
+        # band by hand (subset_go_corpus.py still exists) must not silently make
+        # terms unsearchable again.
+        #
+        # Why the band went: it was designed under v1.4, when gene overlap carried
+        # real ranking weight and an umbrella term could dominate gene evidence.
+        # v1.5 made ranking pure-semantic — hybrid_weights.gene is 0.0 for BP and
+        # MF alike — so the blow-up it guarded against cannot reach the score.
+        # What is left is candidate-set dilution in the thin band #221 documents,
+        # against a filter that also cut 32% of a curated KE→GO set out of reach.
+        # Falls back to go_metadata when the artifact is absent.
         self.go_search_metadata = {}
 
         self._load_go_embeddings(go_embeddings_path)


### PR DESCRIPTION
Refs #284, #222, #221. Implements the decision to leave both GO namespaces unfiltered.

## Why the band stopped making sense

The `[MIN_GENES, MAX_GENES] = [10, 500]` band was designed under **v1.4**, when gene overlap carried real ranking weight (`bp 0.45`, `mf 0.40`) and an umbrella term like `GO:0003824` "catalytic activity" — 5,614 genes after closure — could dominate gene evidence.

**v1.5 made ranking pure-semantic.** `hybrid_weights.gene` is `0.0` for *both* namespaces, confirmed at startup:

```
GO BP/MF ranking: pure-semantic v1.5 (embedding=1.00, gene=0.00, bonus=0.00)
```

So the blow-up the band guarded against cannot reach the score at all. What remains is candidate-set dilution in the thin band #221 documents — and the answer to that is a better encoder, not a filter that also makes valid terms unreachable. The band cut **both** tails: screening a 196-term curated KE→GO set found 62 (32%) unreachable by any route, including PPAR signaling (9 genes) and hepatocyte proliferation (5).

## The split this resolves

`subset_go_corpus.py` was in `make go-corpus` but **never in the weekly cron's `gene_ontology` rebuild**. The two paths produced different corpora, and whichever ran last decided how wide the corpus was. That is how the deployment ended up serving an unsubsetted BP corpus after the 2026-08-03 cron rebuild (#284) while the code comments and cluster docs asserted the opposite.

Removing it from `go-corpus` makes the two agree. `go-corpus` also gains the annotation and embedding steps it was missing, so it now actually rebuilds the corpus it names rather than only the hierarchy plus a subset.

## MF now rebuilds weekly

The cron only ever rebuilt BP. Survivable while MF had no corpus; **MF exists as of today**, so a GO release would have rebuilt BP and left MF to drift. Both namespaces are now in `REBUILD["gene_ontology"]`, commands and artifact guard.

## Changes

| File | Change |
|---|---|
| `Makefile` | `go-corpus` drops the subset, gains annotations + embeddings; header comment rewritten to the decision |
| `scripts/check_source_releases.py` | MF added to the GO rebuild commands and artifacts |
| `src/suggestions/go.py` | the comment justifying the band rewritten — it asserted behaviour that is no longer true |

`subset_go_corpus.py` is **kept, unreferenced**, so the band can be reapplied by hand. Every site notes that this needs revisiting if either namespace moves off `gene: 0.0`.

## Verified

`make -n go-corpus` and `make -n mf-corpus` expand correctly; both modules parse; 42 targeted tests pass (`-k "source_release or scoring_config or go_suggest or check_source"`), none fail.

## Note on the deployment

Production is **already** in the state this PR makes canonical — BP unsubsetted since 2026-08-03, MF built unsubsetted today. So no corpus rebuild follows from merging this; it stops the next rebuild from silently re-narrowing BP. #284 can close once this lands.
